### PR TITLE
MicroCMSのpostsエンドポイントAPIとニュースページの追加

### DIFF
--- a/.github/workflows/cloudflare.yaml
+++ b/.github/workflows/cloudflare.yaml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   repository_dispatch:
-    types: [update_post, update_projects, update_events]
+    types: [update_news, update_projects, update_events]
   push:
     branches:
       - main

--- a/src/containers/pages/NewsDetailPage.astro
+++ b/src/containers/pages/NewsDetailPage.astro
@@ -1,0 +1,118 @@
+---
+import Layout from "../../components/tailwindui/Layout.astro";
+import SimpleLayout from "../../components/tailwindui/SimpleLayout.astro";
+import { MicroCMSAPI } from "../../libs/microCMS/apis";
+import { createCFMicroCMSClient } from "../../libs/microCMS/cloudflare";
+import type { MicroCMSPostsRecord } from "../../libs/microCMS/types";
+
+const {
+    lang = 'en',
+    id
+} = Astro.props;
+
+// MicroCMSクライアントを初期化
+const microCMS = new MicroCMSAPI(createCFMicroCMSClient((Astro.locals as any).runtime));
+
+// 指定されたIDの投稿を取得
+const post = await microCMS.getPost(id);
+
+// 投稿が見つからない場合は404ページを表示
+if (!post) {
+  return Astro.redirect('/404');
+}
+
+// 言語フィルタリング（jaパターンが含まれていれば日本語、それ以外は英語）
+const matchesLanguage = /ja/.test(lang) ? 
+  post.lang.some(l => l.toLowerCase() === 'japanese') : 
+  post.lang.some(l => l.toLowerCase() === 'english');
+
+// 言語が一致しない場合は、対応する言語のトップページにリダイレクト
+if (!matchesLanguage) {
+  return Astro.redirect(/ja/.test(lang) ? '/ja/news' : '/news');
+}
+
+export function formatDate(dateString: string, lang: string = 'en'): string {
+  return new Date(`${dateString}`).toLocaleDateString(/ja/.test(lang) ? 'ja-JP' : 'en-US', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+const backLinkText = /ja/.test(lang) ? 'お知らせ一覧に戻る' : 'Back to News';
+---
+
+<Layout title={post.title}>
+  <SimpleLayout>
+    <div class="xl:relative">
+      <div class="mx-auto max-w-2xl">
+        <a href={/ja/.test(lang) ? '/ja/news' : '/news'} 
+           class="group mb-8 flex h-10 w-10 items-center justify-center rounded-full bg-white shadow-md shadow-zinc-800/5 ring-1 ring-zinc-900/5 transition dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0 dark:ring-white/10 dark:hover:border-zinc-700 dark:hover:ring-white/20">
+          <svg viewBox="0 0 16 16" fill="none" aria-hidden="true" class="h-4 w-4 stroke-zinc-500 transition group-hover:stroke-zinc-700 dark:stroke-zinc-500 dark:group-hover:stroke-zinc-400">
+            <path d="M7.25 11.25 3.75 8m0 0 3.5-3.25M3.75 8h8.5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+          </svg>
+        </a>
+
+        <article>
+          <header class="flex flex-col">
+            <h1 class="mt-6 text-4xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100 sm:text-5xl">
+              {post.title}
+            </h1>
+            <time datetime={post.publishedAt} class="flex items-center text-base text-zinc-400 dark:text-zinc-500 mt-4">
+              <span class="h-4 w-0.5 rounded-full bg-zinc-200 dark:bg-zinc-500"></span>
+              <span class="ml-3">{formatDate(post.publishedAt, lang)}</span>
+            </time>
+            {post.tags && post.tags.length > 0 && (
+              <div class="mt-2 flex items-center text-base text-zinc-400 dark:text-zinc-500">
+                <span class="h-4 w-0.5 rounded-full bg-zinc-200 dark:bg-zinc-500"></span>
+                <span class="ml-3">{post.tags.join(', ')}</span>
+              </div>
+            )}
+          </header>
+          
+          <div class="mt-8 prose dark:prose-invert" set:html={post.content}></div>
+          
+          {post.related_project && post.related_project.length > 0 && (
+            <div class="mt-12 border-t border-zinc-100 pt-8 dark:border-zinc-700/40">
+              <h2 class="text-2xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100">
+                {/ja/.test(lang) ? '関連プロジェクト' : 'Related Projects'}
+              </h2>
+              <ul class="mt-4 space-y-4">
+                {post.related_project.map(project => (
+                  <li class="flex items-start">
+                    {project.image && (
+                      <img 
+                        src={`${project.image.url}?w=100&h=100&fit=crop`} 
+                        alt={project.title}
+                        width="50" 
+                        height="50" 
+                        class="mr-4 rounded-md object-cover"
+                      />
+                    )}
+                    <div>
+                      <h3 class="text-lg font-medium text-zinc-800 dark:text-zinc-100">
+                        <a href={project.url} class="hover:underline" target="_blank" rel="noopener noreferrer">
+                          {project.title}
+                        </a>
+                      </h3>
+                      {project.about && (
+                        <p class="mt-1 text-sm text-zinc-600 dark:text-zinc-400 line-clamp-2" set:html={project.about}></p>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          
+          <div class="mt-12">
+            <a href={/ja/.test(lang) ? '/ja/news' : '/news'} class="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300">
+              ← {backLinkText}
+            </a>
+          </div>
+        </article>
+      </div>
+    </div>
+  </SimpleLayout>
+</Layout> 

--- a/src/containers/pages/NewsDetailPage.astro
+++ b/src/containers/pages/NewsDetailPage.astro
@@ -3,7 +3,6 @@ import Layout from "../../components/tailwindui/Layout.astro";
 import SimpleLayout from "../../components/tailwindui/SimpleLayout.astro";
 import { MicroCMSAPI } from "../../libs/microCMS/apis";
 import { createCFMicroCMSClient } from "../../libs/microCMS/cloudflare";
-import type { MicroCMSPostsRecord } from "../../libs/microCMS/types";
 
 const {
     lang = 'en',
@@ -99,6 +98,11 @@ const backLinkText = /ja/.test(lang) ? 'お知らせ一覧に戻る' : 'Back to 
                       {project.about && (
                         <p class="mt-1 text-sm text-zinc-600 dark:text-zinc-400 line-clamp-2" set:html={project.about}></p>
                       )}
+                      <p class="relative z-10 mt-4 flex items-center text-sm font-medium text-teal-500">
+                        <a href={/ja/.test(lang) ? `/ja-JP/projects/${project.id}` : `/projects/${project.id}`} class="hover:underline">
+                          {/ja/.test(lang) ? '詳細を見る' : 'View Project detail'}
+                        </a>
+                      </p>
                     </div>
                   </li>
                 ))}

--- a/src/containers/pages/NewsDetailPage.astro
+++ b/src/containers/pages/NewsDetailPage.astro
@@ -28,7 +28,7 @@ const matchesLanguage = /ja/.test(lang) ?
 
 // 言語が一致しない場合は、対応する言語のトップページにリダイレクト
 if (!matchesLanguage) {
-  return Astro.redirect(/ja/.test(lang) ? '/ja/news' : '/news');
+  return Astro.redirect(/ja/.test(lang) ? '/ja-JP/news' : '/news');
 }
 
 export function formatDate(dateString: string, lang: string = 'en'): string {
@@ -47,7 +47,7 @@ const backLinkText = /ja/.test(lang) ? 'お知らせ一覧に戻る' : 'Back to 
   <SimpleLayout>
     <div class="xl:relative">
       <div class="mx-auto max-w-2xl">
-        <a href={/ja/.test(lang) ? '/ja/news' : '/news'} 
+        <a href={/ja/.test(lang) ? '/ja-JP/news' : '/news'} 
            class="group mb-8 flex h-10 w-10 items-center justify-center rounded-full bg-white shadow-md shadow-zinc-800/5 ring-1 ring-zinc-900/5 transition dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0 dark:ring-white/10 dark:hover:border-zinc-700 dark:hover:ring-white/20">
           <svg viewBox="0 0 16 16" fill="none" aria-hidden="true" class="h-4 w-4 stroke-zinc-500 transition group-hover:stroke-zinc-700 dark:stroke-zinc-500 dark:group-hover:stroke-zinc-400">
             <path d="M7.25 11.25 3.75 8m0 0 3.5-3.25M3.75 8h8.5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
@@ -107,7 +107,7 @@ const backLinkText = /ja/.test(lang) ? 'お知らせ一覧に戻る' : 'Back to 
           )}
           
           <div class="mt-12">
-            <a href={/ja/.test(lang) ? '/ja/news' : '/news'} class="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300">
+            <a href={/ja/.test(lang) ? '/ja-JP/news' : '/news'} class="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300">
               ← {backLinkText}
             </a>
           </div>

--- a/src/containers/pages/NewsPage.astro
+++ b/src/containers/pages/NewsPage.astro
@@ -40,7 +40,7 @@ const intro = /ja/.test(lang) ?
 
 // ニュース詳細ページへのURLを生成
 function getNewsDetailUrl(postId: string): string {
-  return /ja/.test(lang) ? `/ja/news/${postId}` : `/news/${postId}`;
+  return /ja/.test(lang) ? `/ja-JP/news/${postId}` : `/news/${postId}`;
 }
 ---
 

--- a/src/containers/pages/NewsPage.astro
+++ b/src/containers/pages/NewsPage.astro
@@ -6,24 +6,17 @@ import SimpleLayout from "../../components/tailwindui/SimpleLayout.astro";
 import CardTitle from "../../components/tailwindui/Cards/CardTitle.astro";
 import CardEyebrow from "../../components/tailwindui/Cards/CardEyebrow.astro";
 import CardCta from "../../components/tailwindui/Cards/CardCta.astro";
-import { createClient } from "microcms-js-sdk";
 import { MicroCMSAPI } from "../../libs/microCMS/apis";
-import { removeHtmlTags } from "../../libs/sanitize";
-import type { MicroCMSPostsRecord } from "../../libs/microCMS/types";
-
+import { createCFMicroCMSClient } from "../../libs/microCMS/cloudflare";
 const {
     lang = 'en'
 } = Astro.props
 
 // MicroCMSクライアントを初期化
-const client = createClient({
-  serviceDomain: import.meta.env.MICROCMS_SERVICE_DOMAIN,
-  apiKey: import.meta.env.MICROCMS_API_KEY,
-});
-const api = new MicroCMSAPI(client);
+const microCMS = new MicroCMSAPI(createCFMicroCMSClient((Astro.locals as any).runtime))
 
 // postsを取得
-const allPosts = await api.listPosts();
+const allPosts = await microCMS.listPosts();
 const posts = allPosts.filter(post => {
   // 言語フィルタリング（jaパターンが含まれていれば日本語、それ以外は英語）
   return /ja/.test(lang) ? 
@@ -44,6 +37,11 @@ const title = /ja/.test(lang) ? 'お知らせ' : 'News';
 const intro = /ja/.test(lang) ? 
   '最近のお知らせやリリース情報をお届けします。' : 
   'Recent news and release information.';
+
+// ニュース詳細ページへのURLを生成
+function getNewsDetailUrl(postId: string): string {
+  return /ja/.test(lang) ? `/ja/news/${postId}` : `/news/${postId}`;
+}
 ---
 
 <Layout title={title} >
@@ -56,7 +54,7 @@ const intro = /ja/.test(lang) ?
                 {posts.map((post) => (
                     <article class="md:grid md:grid-cols-4 md:items-baseline">
                       <Card class="md:col-span-3">
-                        <CardTitle href={post.related_project?.[0]?.url || '#'}>
+                        <CardTitle href={getNewsDetailUrl(post.id)}>
                           {post.title}
                         </CardTitle>
                         <CardEyebrow
@@ -75,9 +73,9 @@ const intro = /ja/.test(lang) ?
                           </CardEyebrow>
                         )}
                         <CardDescription set:html={post.content} />
-                        {post.related_project?.[0]?.url && (
-                          <CardCta>{/ja/.test(lang) ? 'プロジェクトを見る' : 'View project'}</CardCta>
-                        )}
+                        <CardCta href={getNewsDetailUrl(post.id)}>
+                          {/ja/.test(lang) ? '詳細を見る' : 'Read more'}
+                        </CardCta>
                       </Card>
                       <CardEyebrow
                         as="time"

--- a/src/containers/pages/NewsPage.astro
+++ b/src/containers/pages/NewsPage.astro
@@ -8,6 +8,7 @@ import CardEyebrow from "../../components/tailwindui/Cards/CardEyebrow.astro";
 import CardCta from "../../components/tailwindui/Cards/CardCta.astro";
 import { MicroCMSAPI } from "../../libs/microCMS/apis";
 import { createCFMicroCMSClient } from "../../libs/microCMS/cloudflare";
+import { removeHtmlTags } from "../../libs/sanitize";
 const {
     lang = 'en'
 } = Astro.props
@@ -16,12 +17,8 @@ const {
 const microCMS = new MicroCMSAPI(createCFMicroCMSClient((Astro.locals as any).runtime))
 
 // postsを取得
-const allPosts = await microCMS.listPosts();
-const posts = allPosts.filter(post => {
-  // 言語フィルタリング（jaパターンが含まれていれば日本語、それ以外は英語）
-  return /ja/.test(lang) ? 
-    post.lang.some(l => l.toLowerCase() === 'japanese') : 
-    post.lang.some(l => l.toLowerCase() === 'english');
+const posts = await microCMS.listPosts({
+    lang: lang === 'ja' ? 'japanese' : 'english'
 });
 
 export function formatDate(dateString: string, lang: string = 'en'): string {
@@ -41,6 +38,13 @@ const intro = /ja/.test(lang) ?
 // ニュース詳細ページへのURLを生成
 function getNewsDetailUrl(postId: string): string {
   return /ja/.test(lang) ? `/ja-JP/news/${postId}` : `/news/${postId}`;
+}
+
+// 先頭140文字を抽出する関数を追加
+function truncateContent(content: string, maxLength: number = 140): string {
+  const plainText = removeHtmlTags(content);
+  if (plainText.length <= maxLength) return plainText;
+  return plainText.slice(0, maxLength) + '...';
 }
 ---
 
@@ -72,7 +76,7 @@ function getNewsDetailUrl(postId: string): string {
                             {post.tags.join(', ')}
                           </CardEyebrow>
                         )}
-                        <CardDescription set:html={post.content} />
+                        <CardDescription set:html={truncateContent(post.content)} />
                         <CardCta href={getNewsDetailUrl(post.id)}>
                           {/ja/.test(lang) ? '詳細を見る' : 'Read more'}
                         </CardCta>

--- a/src/containers/pages/NewsPage.astro
+++ b/src/containers/pages/NewsPage.astro
@@ -17,12 +17,8 @@ const {
 const microCMS = new MicroCMSAPI(createCFMicroCMSClient((Astro.locals as any).runtime))
 
 // postsを取得
-const allPosts = await microCMS.listPosts();
-const posts = allPosts.filter(post => {
-  // 言語フィルタリング（jaパターンが含まれていれば日本語、それ以外は英語）
-  return /ja/.test(lang) ? 
-    post.lang.some(l => l.toLowerCase() === 'japanese') : 
-    post.lang.some(l => l.toLowerCase() === 'english');
+const posts = await microCMS.listPosts({
+    lang: lang === 'ja' ? 'japanese' : 'english'
 });
 
 export function formatDate(dateString: string, lang: string = 'en'): string {

--- a/src/containers/pages/NewsPage.astro
+++ b/src/containers/pages/NewsPage.astro
@@ -1,0 +1,94 @@
+---
+import Card from "../../components/tailwindui/Card.astro";
+import CardDescription from "../../components/tailwindui/Cards/CardDescription.astro";
+import Layout from "../../components/tailwindui/Layout.astro";
+import SimpleLayout from "../../components/tailwindui/SimpleLayout.astro";
+import CardTitle from "../../components/tailwindui/Cards/CardTitle.astro";
+import CardEyebrow from "../../components/tailwindui/Cards/CardEyebrow.astro";
+import CardCta from "../../components/tailwindui/Cards/CardCta.astro";
+import { createClient } from "microcms-js-sdk";
+import { MicroCMSAPI } from "../../libs/microCMS/apis";
+import { removeHtmlTags } from "../../libs/sanitize";
+import type { MicroCMSPostsRecord } from "../../libs/microCMS/types";
+
+const {
+    lang = 'en'
+} = Astro.props
+
+// MicroCMSクライアントを初期化
+const client = createClient({
+  serviceDomain: import.meta.env.MICROCMS_SERVICE_DOMAIN,
+  apiKey: import.meta.env.MICROCMS_API_KEY,
+});
+const api = new MicroCMSAPI(client);
+
+// postsを取得
+const allPosts = await api.listPosts();
+const posts = allPosts.filter(post => {
+  // 言語フィルタリング（jaパターンが含まれていれば日本語、それ以外は英語）
+  return /ja/.test(lang) ? 
+    post.lang.some(l => l.toLowerCase() === 'japanese') : 
+    post.lang.some(l => l.toLowerCase() === 'english');
+});
+
+export function formatDate(dateString: string, lang: string = 'en'): string {
+  return new Date(`${dateString}`).toLocaleDateString(/ja/.test(lang) ? 'ja-JP' : 'en-US', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+const title = /ja/.test(lang) ? 'お知らせ' : 'News';
+const intro = /ja/.test(lang) ? 
+  '最近のお知らせやリリース情報をお届けします。' : 
+  'Recent news and release information.';
+---
+
+<Layout title={title} >
+    <SimpleLayout
+        title={title}
+        intro={intro}
+    >
+        <div class="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40">
+            <div class="flex max-w-3xl flex-col space-y-16">
+                {posts.map((post) => (
+                    <article class="md:grid md:grid-cols-4 md:items-baseline">
+                      <Card class="md:col-span-3">
+                        <CardTitle href={post.related_project?.[0]?.url || '#'}>
+                          {post.title}
+                        </CardTitle>
+                        <CardEyebrow
+                          as="time"
+                          dateTime={post.publishedAt}
+                          class="md:hidden"
+                          decorate
+                        >
+                          {formatDate(post.publishedAt, lang)}
+                        </CardEyebrow>
+                        {post.tags && post.tags.length > 0 && (
+                          <CardEyebrow
+                            decorate
+                          >
+                            {post.tags.join(', ')}
+                          </CardEyebrow>
+                        )}
+                        <CardDescription set:html={post.content} />
+                        {post.related_project?.[0]?.url && (
+                          <CardCta>{/ja/.test(lang) ? 'プロジェクトを見る' : 'View project'}</CardCta>
+                        )}
+                      </Card>
+                      <CardEyebrow
+                        as="time"
+                        dateTime={post.publishedAt}
+                        class="mt-1 hidden md:block"
+                      >
+                          {formatDate(post.publishedAt, lang)}
+                      </CardEyebrow>
+                    </article>
+                ))}
+            </div>
+        </div>
+    </SimpleLayout>
+</Layout> 

--- a/src/containers/pages/NewsPage.astro
+++ b/src/containers/pages/NewsPage.astro
@@ -17,8 +17,12 @@ const {
 const microCMS = new MicroCMSAPI(createCFMicroCMSClient((Astro.locals as any).runtime))
 
 // postsを取得
-const posts = await microCMS.listPosts({
-    lang: lang === 'ja' ? 'japanese' : 'english'
+const allPosts = await microCMS.listPosts();
+const posts = allPosts.filter(post => {
+  // 言語フィルタリング（jaパターンが含まれていれば日本語、それ以外は英語）
+  return /ja/.test(lang) ? 
+    post.lang.some(l => l.toLowerCase() === 'japanese') : 
+    post.lang.some(l => l.toLowerCase() === 'english');
 });
 
 export function formatDate(dateString: string, lang: string = 'en'): string {
@@ -30,6 +34,13 @@ export function formatDate(dateString: string, lang: string = 'en'): string {
   })
 }
 
+// 先頭140文字を抽出する関数
+function truncateContent(content: string, maxLength: number = 140): string {
+  const plainText = removeHtmlTags(content);
+  if (plainText.length <= maxLength) return plainText;
+  return plainText.slice(0, maxLength) + '...';
+}
+
 const title = /ja/.test(lang) ? 'お知らせ' : 'News';
 const intro = /ja/.test(lang) ? 
   '最近のお知らせやリリース情報をお届けします。' : 
@@ -37,14 +48,7 @@ const intro = /ja/.test(lang) ?
 
 // ニュース詳細ページへのURLを生成
 function getNewsDetailUrl(postId: string): string {
-  return /ja/.test(lang) ? `/ja-JP/news/${postId}` : `/news/${postId}`;
-}
-
-// 先頭140文字を抽出する関数を追加
-function truncateContent(content: string, maxLength: number = 140): string {
-  const plainText = removeHtmlTags(content);
-  if (plainText.length <= maxLength) return plainText;
-  return plainText.slice(0, maxLength) + '...';
+  return /ja/.test(lang) ? `/ja/news/${postId}` : `/news/${postId}`;
 }
 ---
 
@@ -76,7 +80,9 @@ function truncateContent(content: string, maxLength: number = 140): string {
                             {post.tags.join(', ')}
                           </CardEyebrow>
                         )}
-                        <CardDescription set:html={truncateContent(post.content)} />
+                        <CardDescription>
+                          {truncateContent(post.content)}
+                        </CardDescription>
                         <CardCta href={getNewsDetailUrl(post.id)}>
                           {/ja/.test(lang) ? '詳細を見る' : 'Read more'}
                         </CardCta>

--- a/src/libs/microCMS/apis.ts
+++ b/src/libs/microCMS/apis.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
-import { MICROCMS_MOCK_BOOKs, MICROCMS_MOCK_EVENTs } from './mocks'
-import type { MicroCMSClient, MicroCMSEventsRecord, MicroCMSProjectsRecord } from './types'
+import { MICROCMS_MOCK_BOOKs, MICROCMS_MOCK_EVENTs, MICROCMS_MOCK_POSTs } from './mocks'
+import type { MicroCMSClient, MicroCMSEventsRecord, MicroCMSProjectsRecord, MicroCMSPostsRecord } from './types'
 
 export class MicroCMSAPI {
   private readonly client: MicroCMSClient
@@ -129,5 +129,22 @@ export class MicroCMSAPI {
         contentId: 'iutgcn7l3ad',
       }),
     ]
+  }
+  public async listPosts(): Promise<MicroCMSPostsRecord[]> {
+    if (!this.client) {
+      if (process.env.MICROCMS_API_MODE === 'mock') {
+        return MICROCMS_MOCK_POSTs
+      }
+      return []
+    }
+    const { contents: posts } = await this.client.get<{
+      contents: MicroCMSPostsRecord[]
+    }>({
+      endpoint: 'posts',
+      queries: {
+        orders: '-publishedAt',
+      },
+    })
+    return posts
   }
 }

--- a/src/libs/microCMS/apis.ts
+++ b/src/libs/microCMS/apis.ts
@@ -147,4 +147,24 @@ export class MicroCMSAPI {
     })
     return posts
   }
+
+  public async getPost(id: string): Promise<MicroCMSPostsRecord | null> {
+    if (!this.client) {
+      if (process.env.MICROCMS_API_MODE === 'mock') {
+        const post = MICROCMS_MOCK_POSTs.find(post => post.id === id)
+        return post || null
+      }
+      return null
+    }
+    try {
+      const post = await this.client.get<MicroCMSPostsRecord>({
+        endpoint: 'posts',
+        contentId: id,
+      })
+      return post
+    } catch (error) {
+      console.error('Error fetching post:', error)
+      return null
+    }
+  }
 }

--- a/src/libs/microCMS/apis.ts
+++ b/src/libs/microCMS/apis.ts
@@ -130,20 +130,26 @@ export class MicroCMSAPI {
       }),
     ]
   }
-  public async listPosts(): Promise<MicroCMSPostsRecord[]> {
+  public async listPosts(query?: {
+    lang?: 'japanese' | 'english'
+  }): Promise<MicroCMSPostsRecord[]> {
     if (!this.client) {
       if (process.env.MICROCMS_API_MODE === 'mock') {
         return MICROCMS_MOCK_POSTs
       }
       return []
     }
+    const lang = query?.lang ?? null
     const { contents: posts } = await this.client.get<{
       contents: MicroCMSPostsRecord[]
     }>({
       endpoint: 'posts',
       queries: {
         orders: '-publishedAt',
-      },
+        filters: [
+          lang ? `lang[contains]${query?.lang}` : undefined
+        ].filter(Boolean).join('[and]')
+      }
     })
     return posts
   }

--- a/src/libs/microCMS/mocks.ts
+++ b/src/libs/microCMS/mocks.ts
@@ -1,4 +1,4 @@
-import type { MicroCMSEventsRecord, MicroCMSProjectsRecord } from './types'
+import type { MicroCMSEventsRecord, MicroCMSProjectsRecord, MicroCMSPostsRecord } from './types'
 
 export const MICROCMS_MOCK_BOOKs: MicroCMSProjectsRecord[] = [
   {
@@ -68,4 +68,22 @@ export const MICROCMS_MOCK_EVENTs: MicroCMSEventsRecord[] = [
     slide_url: 'https://speakerdeck.com/stripehideokamoto/jpstripes-whats-new-202201',
     blog_url: 'https://qiita.com/hideokamoto/items/2775e20fd260e907ca04',
   },
+]
+
+export const MICROCMS_MOCK_POSTs: MicroCMSPostsRecord[] = [
+  {
+    id: '8bf8y2ih-dt',
+    createdAt: '2025-03-05T04:31:24.865Z',
+    updatedAt: '2025-03-05T04:31:24.865Z',
+    publishedAt: '2025-03-05T04:31:24.865Z',
+    revisedAt: '2025-03-05T04:31:24.865Z',
+    title: '京都地下鉄ラスト・コールをリリースしました',
+    content: '<p>2024年11月30日に、新しい個人開発アプリケーション「京都地下鉄ラスト・コール」をリリースしました。</p><p>オープンデータと生成AIを利用したアプリケーション開発の可能性を探究し、データ活用やマッシュアップの可能性を提案することを目的とし、京都市が公開しているデータを利用したアプリケーションをリリースしました。</p>',
+    tags: [
+        'アプリケーション'
+    ],
+    lang: [
+        'japanese'
+    ]
+  }
 ]

--- a/src/libs/microCMS/types.ts
+++ b/src/libs/microCMS/types.ts
@@ -28,6 +28,7 @@ export type MicroCMSRecord = {
     | 'owned_oss'
     | 'oss_contribution'
     | 'community_activities'
+    | 'applications'
   
   export type MicroCMSProjectsRecord = MicroCMSRecord & {
     title: string
@@ -45,6 +46,14 @@ export type MicroCMSRecord = {
     about?: string;
     background?: string;
     architecture?: string;
+  }
+
+  export type MicroCMSPostsRecord = MicroCMSRecord & {
+    title: string
+    content: string
+    tags: string[]
+    related_project?: MicroCMSProjectsRecord[]
+    lang: string[]
   }
   
   export type MicroCMSClient = Pick<ReturnType<typeof createClient>, 'get' | 'getAllContents'>

--- a/src/libs/microCMS/types.ts
+++ b/src/libs/microCMS/types.ts
@@ -28,7 +28,6 @@ export type MicroCMSRecord = {
     | 'owned_oss'
     | 'oss_contribution'
     | 'community_activities'
-    | 'applications'
   
   export type MicroCMSProjectsRecord = MicroCMSRecord & {
     title: string

--- a/src/pages/ja-JP/news.astro
+++ b/src/pages/ja-JP/news.astro
@@ -1,0 +1,10 @@
+---
+import { getLanguageFromURL } from "../../libs/urlUtils/lang.util"
+import NewsPage from "../../containers/pages/NewsPage.astro";
+
+const currentPage = new URL(Astro.request.url).pathname;
+const lang = getLanguageFromURL(currentPage);
+  
+---
+
+<NewsPage lang={lang} />

--- a/src/pages/ja-JP/news/[id].astro
+++ b/src/pages/ja-JP/news/[id].astro
@@ -1,0 +1,12 @@
+---
+import { getLanguageFromURL } from "../../../libs/urlUtils/lang.util"
+import NewsDetailPage from "../../../containers/pages/NewsDetailPage.astro";
+
+const currentPage = new URL(Astro.request.url).pathname;
+const lang = getLanguageFromURL(currentPage);
+
+const { id: postId } = Astro.params;
+  
+---
+
+<NewsDetailPage lang={lang} id={postId} />

--- a/src/pages/news.astro
+++ b/src/pages/news.astro
@@ -1,0 +1,10 @@
+---
+import { getLanguageFromURL } from "../libs/urlUtils/lang.util"
+import NewsPage from "../containers/pages/NewsPage.astro";
+
+const currentPage = new URL(Astro.request.url).pathname;
+const lang = getLanguageFromURL(currentPage);
+  
+---
+
+<NewsPage lang={lang} />

--- a/src/pages/news/[id].astro
+++ b/src/pages/news/[id].astro
@@ -1,0 +1,12 @@
+---
+import { getLanguageFromURL } from "../../libs/urlUtils/lang.util"
+import NewsDetailPage from "../../containers/pages/NewsDetailPage.astro";
+
+const currentPage = new URL(Astro.request.url).pathname;
+const lang = getLanguageFromURL(currentPage);
+
+const { id: postId } = Astro.params;
+  
+---
+
+<NewsDetailPage lang={lang} id={postId} />


### PR DESCRIPTION
## 変更内容

### MicroCMS APIの拡張
- `listPosts` メソッドを追加し、postsエンドポイントからデータを取得できるようにしました
- `getPost` メソッドを追加し、IDを指定して単一の投稿を取得できるようにしました
- モックデータ `MICROCMS_MOCK_POSTs` を追加しました

### 新規ページの追加
- `NewsPage.astro` - ニュース一覧ページを追加しました
  - 言語に応じたフィルタリング機能を実装
  - 記事本文を140文字に制限して表示
  - 詳細ページへのリンクを追加
- `NewsDetailPage.astro` - ニュース詳細ページを追加しました
  - 投稿の詳細内容、タグ、日付を表示
  - 関連プロジェクトがある場合は、その情報とリンクを表示
  - 一覧ページに戻るリンクを提供

### 型定義の追加
- `MicroCMSPostsRecord` 型を追加し、投稿データの型安全性を確保しました

## テスト方法
- `/news` または `/ja/news` にアクセスして、ニュース一覧が表示されることを確認
- 各ニュースの「詳細を見る」をクリックして、詳細ページが表示されることを確認
- 言語切り替えが正しく機能することを確認