### PR TITLE
Fix responsive images in blog posts

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,7 +82,7 @@
 }
 
 .blog-content img {
-  @apply rounded-lg my-6 max-w-full h-auto;
+  @apply block rounded-lg my-6 max-w-full h-auto w-auto;
 }
 
 .blog-content hr {


### PR DESCRIPTION
Add w-auto and block display to ensure images are responsive

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make blog post images responsive by adding `block` and `w-auto` to `.blog-content img` in `src/app/globals.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6d9b1b83ddca3801b18ed15aed835eaa61b2719. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->