### PR TITLE
Fix embedded presentation overflow issues

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,6 +85,13 @@
   @apply rounded-lg my-6 max-w-full h-auto;
 }
 
+.blog-content iframe,
+.blog-content embed,
+.blog-content object,
+.blog-content video {
+  @apply my-6 max-w-full h-auto;
+}
+
 .blog-content hr {
   @apply my-8 border-zinc-200 dark:border-zinc-700;
 }


### PR DESCRIPTION
iframe、embed、object、videoにmax-w-fullを適用し、
プレゼン資料等の埋め込みコンテンツがコンテナからはみ出さないようにしました。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Apply responsive sizing to `iframe`, `embed`, `object`, and `video` within `.blog-content` to prevent overflow.
> 
> - **Styles (blog content)**:
>   - Add responsive rules for `iframe`, `embed`, `object`, and `video` in `src/app/globals.css` under `.blog-content`:
>     - Apply `my-6 max-w-full h-auto` to keep embedded media within container and spaced consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06a17d6688c719d292659d8b040949753077f1ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->