### PR TITLE
feat: イベントレポートページに前後の記事ナビゲーションリンクを追加

### DIFF
--- a/src/app/event-reports/[slug]/page.tsx
+++ b/src/app/event-reports/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import SpeakingDetailPageContent from '@/components/containers/pages/SpeakingDetailPage'
-import { getWPEventBySlug } from '@/libs/dataSources/events'
+import { getWPEventBySlug, getAdjacentEvents } from '@/libs/dataSources/events'
 import { notFound } from 'next/navigation'
 
 export async function generateMetadata({
@@ -34,11 +34,16 @@ export default async function SpeakingDetailPage({
     notFound()
   }
 
+  // 前後の記事を取得
+  const { previous, next } = await getAdjacentEvents(event)
+
   return (
     <SpeakingDetailPageContent
       event={event}
       lang="en"
       basePath="/event-reports"
+      previousEvent={previous}
+      nextEvent={next}
     />
   )
 }

--- a/src/app/ja/event-reports/[slug]/page.tsx
+++ b/src/app/ja/event-reports/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import SpeakingDetailPageContent from '@/components/containers/pages/SpeakingDetailPage'
-import { getWPEventBySlug } from '@/libs/dataSources/events'
+import { getWPEventBySlug, getAdjacentEvents } from '@/libs/dataSources/events'
 import { notFound } from 'next/navigation'
 
 export async function generateMetadata({
@@ -34,11 +34,16 @@ export default async function SpeakingDetailPage({
     notFound()
   }
 
+  // 前後の記事を取得
+  const { previous, next } = await getAdjacentEvents(event)
+
   return (
     <SpeakingDetailPageContent
       event={event}
       lang="ja"
       basePath="/ja/event-reports"
+      previousEvent={previous}
+      nextEvent={next}
     />
   )
 }

--- a/src/components/containers/pages/SpeakingDetailPage.tsx
+++ b/src/components/containers/pages/SpeakingDetailPage.tsx
@@ -10,16 +10,22 @@ type SpeakingDetailPageProps = {
   event: WPEvent
   lang: string
   basePath: string
+  previousEvent?: WPEvent | null
+  nextEvent?: WPEvent | null
 }
 
 export default function SpeakingDetailPage({
   event,
   lang,
   basePath,
+  previousEvent,
+  nextEvent,
 }: SpeakingDetailPageProps) {
   const date = new Date(event.date)
   const speakingLabel = lang === 'ja' ? '登壇・講演' : 'Speaking'
   const reportLabel = lang === 'ja' ? 'レポート' : 'Report'
+  const previousLabel = lang === 'ja' ? '前の記事' : 'Previous'
+  const nextLabel = lang === 'ja' ? '次の記事' : 'Next'
 
   // OG画像のURLを生成
   const ogImageUrl = `/api/thumbnail/events/${event.id}`
@@ -102,6 +108,46 @@ export default function SpeakingDetailPage({
 
         {/* プロフィールカード */}
         <ProfileCard lang={lang} imageSrc="/images/profile.jpg" className="mt-12" />
+
+        {/* 前後の記事へのナビゲーション */}
+        {(previousEvent || nextEvent) && (
+          <nav
+            aria-label="記事ナビゲーション"
+            className="mt-16 pt-8 border-t border-zinc-200 dark:border-zinc-700"
+          >
+            <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
+              {/* 次の記事 */}
+              {nextEvent && (
+                <Link
+                  href={`${basePath}/${nextEvent.slug}`}
+                  className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors"
+                >
+                  <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
+                    ← {nextLabel}
+                  </span>
+                  <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
+                    {nextEvent.title.rendered}
+                  </span>
+                </Link>
+              )}
+
+              {/* 前の記事 */}
+              {previousEvent && (
+                <Link
+                  href={`${basePath}/${previousEvent.slug}`}
+                  className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors text-right"
+                >
+                  <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
+                    {previousLabel} →
+                  </span>
+                  <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
+                    {previousEvent.title.rendered}
+                  </span>
+                </Link>
+              )}
+            </div>
+          </nav>
+        )}
       </article>
     </Container>
   )

--- a/src/libs/dataSources/events.ts
+++ b/src/libs/dataSources/events.ts
@@ -41,3 +41,59 @@ export const getWPEventBySlug = async (slug: string): Promise<WPEvent | null> =>
   }
 }
 
+export type AdjacentEvents = {
+  previous: WPEvent | null
+  next: WPEvent | null
+}
+
+// WordPress APIから記事を取得するヘルパー関数
+const fetchEvent = async (url: string): Promise<WPEvent | null> => {
+  try {
+    const response = await fetch(url)
+
+    if (!response.ok) {
+      return null
+    }
+
+    const events: WPEvent[] = await response.json()
+
+    if (events.length === 0) {
+      return null
+    }
+
+    return events[0]
+  } catch (error) {
+    console.error('Error fetching event:', error)
+    return null
+  }
+}
+
+export const getAdjacentEvents = async (
+  currentEvent: WPEvent
+): Promise<AdjacentEvents> => {
+  try {
+    // 前の記事を取得（現在の記事より前の日付で最も新しいもの）
+    const previousUrl = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/events?before=${encodeURIComponent(currentEvent.date)}&per_page=1&orderby=date&order=desc&_fields=id,title,slug`
+
+    // 次の記事を取得（現在の記事より後の日付で最も古いもの）
+    const nextUrl = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/events?after=${encodeURIComponent(currentEvent.date)}&per_page=1&orderby=date&order=asc&_fields=id,title,slug`
+
+    // 並列で実行
+    const [previous, next] = await Promise.all([
+      fetchEvent(previousUrl),
+      fetchEvent(nextUrl),
+    ])
+
+    return {
+      previous,
+      next,
+    }
+  } catch (error) {
+    console.error('Error loading adjacent events:', error)
+    return {
+      previous: null,
+      next: null,
+    }
+  }
+}
+


### PR DESCRIPTION
- events.tsにgetAdjacentEvents関数を追加して前後の記事を取得
- SpeakingDetailPageコンポーネントにナビゲーションUIを追加
- 日本語版と英語版の両方のページで前後の記事を取得して表示
- BlogDetailPageと同じデザインパターンを使用