### PR TITLE
feat: GitHub ActionsのCIワークフローを並列実行可能に改善

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI
 
 on:
   push:
@@ -7,7 +7,28 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint:check
+
   test:
+    name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -27,9 +48,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # - name: Run linter
-      #   run: npm run lint
-
       - name: Run unit tests
         run: npm run test
 
@@ -43,10 +61,44 @@ jobs:
           name: coverage-report
           path: coverage/
 
+  build:
+    name: Next.js Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Build Next.js
         run: npm run build
         env:
           MICROCMS_API_MODE: mock
+
+  cf-build:
+    name: OpenNext Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build for Cloudflare
         run: npm run cf:build


### PR DESCRIPTION
- lint、test、build、cf-buildの4つのジョブを並列実行するように変更
- 各ジョブを独立したジョブとして分離し、実行速度を向上
- lintジョブを追加（npm run lint:check）
- testジョブはNode.js 20.x/22.xのマトリックス戦略を維持
- build/cf-buildジョブはNode.js 20.xで実行
- ワークフロー名をTestからCIに変更