### PR TITLE
Set up ads.txt file if missing

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-6091198629319043, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Google AdSenseの広告配信のためにads.txtファイルを追加。
パブリッシャーID (pub-6091198629319043) を使用して、
Googleの推奨形式に従って設定。