### PR TITLE
Add dev notes to writing page

### DIFF
--- a/src/app/api/thumbnail/dev-notes/[id]/route.tsx
+++ b/src/app/api/thumbnail/dev-notes/[id]/route.tsx
@@ -1,0 +1,107 @@
+import type { NextRequest } from 'next/server'
+import { SITE_CONFIG } from '@/config'
+import type { WPThought } from '@/libs/dataSources/types'
+
+// getCloudflareContextを動的インポートで取得（OpenNextのビルドプロセスで正しく解決されるように）
+async function getCloudflareContext(
+  options: { async: true } | { async?: false } = { async: false },
+) {
+  try {
+    const { getCloudflareContext: getContext } = await import('@opennextjs/cloudflare')
+    if (options.async === true) {
+      return await getContext({ async: true })
+    }
+    return getContext({ async: false })
+  } catch (_error) {
+    const cloudflareContextSymbol = Symbol.for('__cloudflare-context__')
+    const context = (
+      globalThis as typeof globalThis & {
+        [key: symbol]: unknown
+      }
+    )[cloudflareContextSymbol]
+    if (context) {
+      return options.async === true ? Promise.resolve(context) : context
+    }
+    throw new Error('Cloudflare context is not available')
+  }
+}
+
+/**
+ * WordPressのdev-notes投稿タイプ用のサムネイル画像生成API
+ */
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params
+    const postId = Number.parseInt(id, 10)
+
+    if (Number.isNaN(postId) || postId <= 0) {
+      return new Response('Invalid post ID', { status: 404 })
+    }
+
+    // WordPress REST APIから記事を取得
+    const wpResponse = await fetch(
+      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes/${postId}?_fields=id,title`,
+    )
+
+    if (!wpResponse.ok) {
+      if (wpResponse.status === 404) {
+        return new Response('Post not found', { status: 404 })
+      }
+      console.error('WordPress API error:', wpResponse.status, wpResponse.statusText)
+      return new Response('Failed to fetch post', { status: wpResponse.status })
+    }
+
+    const note: WPThought = await wpResponse.json()
+
+    if (!note.title?.rendered) {
+      return new Response('Post title not found', { status: 500 })
+    }
+
+    const title = note.title.rendered
+    console.log('Generating thumbnail for dev-note:', postId, 'title:', title)
+
+    const context = (await getCloudflareContext({ async: true })) as {
+      env: {
+        OG_IMAGE_GENERATOR?: { fetch: typeof fetch }
+        OG_IMAGE_GEN_AUTH_TOKEN?: string
+      }
+    }
+    const typedEnv = context.env
+    const ogImageGenerator = typedEnv.OG_IMAGE_GENERATOR
+
+    if (!ogImageGenerator) {
+      console.error('OG_IMAGE_GENERATOR Service Binding is not available')
+      return new Response('Service Binding not available', { status: 500 })
+    }
+
+    const ogImageUrl = new URL('https://cf-ogp-image-gen-worker.wp-kyoto.workers.dev/generate')
+    ogImageUrl.searchParams.set('title', title)
+    ogImageUrl.searchParams.set('siteUrl', SITE_CONFIG.url)
+
+    const headers = new Headers()
+    const authToken = typedEnv.OG_IMAGE_GEN_AUTH_TOKEN || process.env.OG_IMAGE_GEN_AUTH_TOKEN
+    if (authToken) {
+      headers.set('Authorization', `Bearer ${authToken}`)
+    }
+
+    const response = await ogImageGenerator.fetch(ogImageUrl, { headers })
+
+    if (!response.ok) {
+      console.error('OG image generation failed:', response.status, response.statusText)
+      return new Response('Failed to generate image', { status: response.status })
+    }
+
+    const responseHeaders = new Headers(response.headers)
+    responseHeaders.set('Cache-Control', 'public, max-age=86400, s-maxage=86400')
+    responseHeaders.set('CDN-Cache-Control', 'public, max-age=86400')
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    })
+  } catch (error) {
+    console.error('Error generating thumbnail image:', error)
+    return new Response('Failed to generate image', { status: 500 })
+  }
+}

--- a/src/app/ja/writing/dev-notes/[slug]/page.tsx
+++ b/src/app/ja/writing/dev-notes/[slug]/page.tsx
@@ -1,0 +1,58 @@
+import { notFound } from 'next/navigation'
+import DevNoteDetailPageContent from '@/components/containers/pages/DevNoteDetailPage'
+import JsonLd from '@/components/JsonLd'
+import {
+  getAdjacentDevNotes,
+  getDevNoteBySlug,
+  getRelatedDevNotes,
+} from '@/libs/dataSources/devnotes'
+import { generateDevNoteBreadcrumbJsonLd, generateDevNoteJsonLd } from '@/libs/jsonLd'
+import { generateDevNoteMetadata } from '@/libs/metadata'
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const note = await getDevNoteBySlug(slug)
+
+  if (!note) {
+    return {
+      title: 'Dev Notes',
+    }
+  }
+
+  return generateDevNoteMetadata(note)
+}
+
+export default async function DevNoteDetailPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const note = await getDevNoteBySlug(slug)
+
+  if (!note) {
+    notFound()
+  }
+
+  const basePath = '/ja/writing/dev-notes'
+
+  // JSON-LDを生成
+  const blogPostingJsonLd = generateDevNoteJsonLd(note, basePath)
+  const breadcrumbJsonLd = generateDevNoteBreadcrumbJsonLd(note, basePath)
+
+  // 前後の記事と関連記事を取得
+  const [adjacentNotes, relatedArticles] = await Promise.all([
+    getAdjacentDevNotes(note),
+    getRelatedDevNotes(note, 4),
+  ])
+
+  return (
+    <>
+      <JsonLd data={blogPostingJsonLd} />
+      <JsonLd data={breadcrumbJsonLd} />
+      <DevNoteDetailPageContent
+        note={note}
+        basePath={basePath}
+        previousNote={adjacentNotes.previous}
+        nextNote={adjacentNotes.next}
+        relatedArticles={relatedArticles}
+      />
+    </>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from 'next'
 import { SITE_CONFIG } from '@/config'
+import { loadAllDevNotes } from '@/libs/dataSources/devnotes'
 import { loadAllThoughts } from '@/libs/dataSources/thoughts'
 import { MicroCMSAPI } from '@/libs/microCMS/apis'
 import { createMicroCMSClient } from '@/libs/microCMS/client'
@@ -141,5 +142,26 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     console.error('Error loading events for sitemap:', error)
   }
 
-  return [...staticPages, ...blogPages, ...projectPages, ...postPages, ...eventPages]
+  // Dev Notes（WordPress API、日本語のみ）
+  let devNotesPages: MetadataRoute.Sitemap = []
+  try {
+    const allDevNotes = await loadAllDevNotes()
+    devNotesPages = allDevNotes.map((item) => ({
+      url: `${SITE_CONFIG.url}${item.href}`,
+      lastModified: new Date(item.datetime),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    }))
+  } catch (error) {
+    console.error('Error loading dev-notes for sitemap:', error)
+  }
+
+  return [
+    ...staticPages,
+    ...blogPages,
+    ...projectPages,
+    ...postPages,
+    ...eventPages,
+    ...devNotesPages,
+  ]
 }

--- a/src/components/containers/pages/DevNoteDetailPage.tsx
+++ b/src/components/containers/pages/DevNoteDetailPage.tsx
@@ -1,0 +1,166 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import Container from '@/components/tailwindui/Container'
+import DateDisplay from '@/components/ui/DateDisplay'
+import { InArticleAd } from '@/components/ui/GoogleAds'
+import ProfileCard from '@/components/ui/ProfileCard'
+import RelatedArticles from '@/components/ui/RelatedArticles'
+import Tag from '@/components/ui/Tag'
+import type { BlogItem, WPThought } from '@/libs/dataSources/types'
+
+type DevNoteDetailPageProps = {
+  note: WPThought
+  basePath: string
+  previousNote?: WPThought | null
+  nextNote?: WPThought | null
+  relatedArticles?: BlogItem[]
+}
+
+export default function DevNoteDetailPage({
+  note,
+  basePath,
+  previousNote,
+  nextNote,
+  relatedArticles = [],
+}: DevNoteDetailPageProps) {
+  const date = new Date(note.date)
+
+  // OG画像のURLを生成
+  const ogImageUrl = `/api/thumbnail/dev-notes/${note.id}`
+  const OG_IMAGE_WIDTH = 1200
+  const OG_IMAGE_HEIGHT = 630
+
+  return (
+    <Container className="mt-16 sm:mt-32">
+      <article className="max-w-3xl mx-auto">
+        {/* パンくずリスト */}
+        <nav aria-label="Breadcrumb" className="mb-8">
+          <ol className="flex items-center space-x-2">
+            <li>
+              <div className="flex items-center text-sm">
+                <Link
+                  href="/ja/writing"
+                  className="font-medium text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100 transition-colors"
+                >
+                  Writing
+                </Link>
+                <svg
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                  className="ml-2 size-5 shrink-0 text-slate-300 dark:text-slate-600"
+                >
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+              </div>
+            </li>
+            <li>
+              <div className="flex items-center text-sm">
+                <span className="font-medium text-slate-900 dark:text-slate-100 line-clamp-1">
+                  {note.title.rendered}
+                </span>
+              </div>
+            </li>
+          </ol>
+        </nav>
+
+        {/* サムネイル画像 (OG画像) */}
+        <div className="mb-8 overflow-hidden rounded-lg">
+          <Image
+            src={ogImageUrl}
+            alt={note.title.rendered}
+            width={OG_IMAGE_WIDTH}
+            height={OG_IMAGE_HEIGHT}
+            className="w-full h-auto"
+            priority
+          />
+        </div>
+
+        {/* タイトル */}
+        <header className="mb-6">
+          <h1 className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 sm:text-5xl">
+            {note.title.rendered}
+          </h1>
+        </header>
+
+        {/* 日付とカテゴリ */}
+        <div className="mb-10 flex flex-col gap-4">
+          <DateDisplay
+            date={date}
+            lang="ja"
+            format="long"
+            className="text-sm font-medium text-slate-600 dark:text-slate-400"
+          />
+          {note._embedded?.['wp:term'] && (
+            <div className="flex flex-wrap gap-2">
+              {note._embedded['wp:term']
+                .flat()
+                .filter((term) => term.taxonomy === 'category')
+                .map((category) => (
+                  <Tag key={category.id} variant="indigo" size="sm">
+                    {category.name}
+                  </Tag>
+                ))}
+            </div>
+          )}
+        </div>
+
+        {/* コンテンツ */}
+        <div
+          className="blog-content text-zinc-700 dark:text-zinc-300 leading-relaxed"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted WordPress CMS, controlled by site owner
+          dangerouslySetInnerHTML={{ __html: note.content.rendered }}
+        />
+
+        {/* In-Article Ad */}
+        <InArticleAd />
+
+        {/* プロフィールカード */}
+        <ProfileCard lang="ja" imageSrc="/images/profile.jpg" className="mt-12" />
+
+        {/* 関連記事 */}
+        <RelatedArticles articles={relatedArticles} lang="ja" />
+
+        {/* 前後の記事へのナビゲーション */}
+        {(previousNote || nextNote) && (
+          <nav
+            aria-label="記事ナビゲーション"
+            className="mt-16 pt-8 border-t border-zinc-200 dark:border-zinc-700"
+          >
+            <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
+              {/* 次の記事 */}
+              {nextNote && (
+                <Link
+                  href={`${basePath}/${nextNote.slug}`}
+                  className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors"
+                >
+                  <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
+                    ← 次の記事
+                  </span>
+                  <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
+                    {nextNote.title.rendered}
+                  </span>
+                </Link>
+              )}
+
+              {/* 前の記事 */}
+              {previousNote && (
+                <Link
+                  href={`${basePath}/${previousNote.slug}`}
+                  className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors text-right"
+                >
+                  <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
+                    前の記事 →
+                  </span>
+                  <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
+                    {previousNote.title.rendered}
+                  </span>
+                </Link>
+              )}
+            </div>
+          </nav>
+        )}
+      </article>
+    </Container>
+  )
+}

--- a/src/libs/dataSources/devnotes.ts
+++ b/src/libs/dataSources/devnotes.ts
@@ -1,0 +1,233 @@
+import type { BlogItem, Category, WPThought } from './types'
+
+export type DevNotesResult = {
+  items: BlogItem[]
+  totalPages: number
+  totalItems: number
+  currentPage: number
+}
+
+// カテゴリ情報を抽出するヘルパー関数
+const extractCategories = (note: WPThought): Category[] => {
+  if (!note._embedded?.['wp:term']) {
+    return []
+  }
+
+  const categories: Category[] = []
+  for (const termArray of note._embedded['wp:term']) {
+    for (const term of termArray) {
+      if (term.taxonomy === 'category') {
+        categories.push({
+          id: term.id,
+          name: term.name,
+          slug: term.slug,
+          taxonomy: term.taxonomy,
+        })
+      }
+    }
+  }
+  return categories
+}
+
+/**
+ * dev-notes投稿タイプの記事を取得
+ */
+export const loadDevNotes = async (
+  page: number = 1,
+  perPage: number = 20,
+): Promise<DevNotesResult> => {
+  try {
+    const response = await fetch(
+      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes?page=${page}&per_page=${perPage}&_embed=wp:term&_fields=_links.wp:term,_embedded,id,title,date,date_gmt,excerpt,slug,link,categories`,
+    )
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch dev-notes: ${response.status}`)
+    }
+
+    const notes: WPThought[] = await response.json()
+
+    const totalItems = Number.parseInt(response.headers.get('X-WP-Total') || '0', 10)
+    const totalPages = Number.parseInt(response.headers.get('X-WP-TotalPages') || '0', 10)
+
+    const items: BlogItem[] = notes.map((note: WPThought): BlogItem => {
+      const basePath = '/ja/writing/dev-notes'
+      const href = `${basePath}/${note.slug}`
+
+      return {
+        id: note.id.toString(),
+        title: note.title.rendered,
+        description: note.excerpt.rendered.replace(/<[^>]*>/g, '').substring(0, 150),
+        datetime: note.date,
+        href,
+        categories: extractCategories(note),
+      }
+    })
+
+    return {
+      items,
+      totalPages,
+      totalItems,
+      currentPage: page,
+    }
+  } catch (error) {
+    console.error('Error loading dev-notes:', error)
+    return {
+      items: [],
+      totalPages: 0,
+      totalItems: 0,
+      currentPage: page,
+    }
+  }
+}
+
+/**
+ * slugでdev-notes記事を取得
+ */
+export const getDevNoteBySlug = async (slug: string): Promise<WPThought | null> => {
+  try {
+    const response = await fetch(
+      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes?slug=${encodeURIComponent(slug)}&_embed=wp:term&_fields=_links.wp:term,_embedded,id,title,date,date_gmt,excerpt,content,slug,link,categories`,
+    )
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch dev-note by slug: ${response.status}`)
+    }
+
+    const notes: WPThought[] = await response.json()
+
+    if (notes.length === 0) {
+      return null
+    }
+
+    return notes[0]
+  } catch (error) {
+    console.error('Error loading dev-note by slug:', error)
+    return null
+  }
+}
+
+export type AdjacentDevNotes = {
+  previous: WPThought | null
+  next: WPThought | null
+}
+
+// WordPress APIから記事を取得するヘルパー関数
+const fetchDevNote = async (url: string): Promise<WPThought | null> => {
+  try {
+    const response = await fetch(url)
+    if (!response.ok) {
+      console.error(`Failed to fetch dev-note: ${response.status}`)
+      return null
+    }
+    const notes: WPThought[] = await response.json()
+    return notes.length > 0 ? notes[0] : null
+  } catch (error) {
+    console.error('Error fetching dev-note:', error)
+    return null
+  }
+}
+
+/**
+ * 前後の記事を取得
+ */
+export const getAdjacentDevNotes = async (currentNote: WPThought): Promise<AdjacentDevNotes> => {
+  try {
+    const previousUrl = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes?before=${encodeURIComponent(currentNote.date)}&per_page=1&orderby=date&order=desc&_fields=id,title,slug`
+    const nextUrl = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes?after=${encodeURIComponent(currentNote.date)}&per_page=1&orderby=date&order=asc&_fields=id,title,slug`
+
+    const [previous, next] = await Promise.all([fetchDevNote(previousUrl), fetchDevNote(nextUrl)])
+
+    return {
+      previous,
+      next,
+    }
+  } catch (error) {
+    console.error('Error loading adjacent dev-notes:', error)
+    return {
+      previous: null,
+      next: null,
+    }
+  }
+}
+
+/**
+ * 関連記事を取得（同じカテゴリの記事からランダムに選択）
+ */
+export const getRelatedDevNotes = async (
+  currentNote: WPThought,
+  limit: number = 4,
+): Promise<BlogItem[]> => {
+  try {
+    const categories = extractCategories(currentNote)
+
+    if (categories.length === 0) {
+      return []
+    }
+
+    const categoryId = categories[0].id
+    const fetchLimit = Math.max(limit * 2.5, 10)
+
+    const response = await fetch(
+      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes?categories=${categoryId}&exclude=${currentNote.id}&per_page=${fetchLimit}&_embed=wp:term&_fields=_links.wp:term,_embedded,id,title,date,date_gmt,excerpt,slug,link,categories`,
+    )
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch related dev-notes: ${response.status}`)
+    }
+
+    const notes: WPThought[] = await response.json()
+
+    const items: BlogItem[] = notes.map((note: WPThought): BlogItem => {
+      const basePath = '/ja/writing/dev-notes'
+      const href = `${basePath}/${note.slug}`
+
+      return {
+        id: note.id.toString(),
+        title: note.title.rendered,
+        description: note.excerpt.rendered.replace(/<[^>]*>/g, '').substring(0, 150),
+        datetime: note.date,
+        href,
+        categories: extractCategories(note),
+      }
+    })
+
+    // Fisher-Yatesアルゴリズムでシャッフル
+    const shuffled = [...items]
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+    }
+
+    return shuffled.slice(0, limit)
+  } catch (error) {
+    console.error('Error loading related dev-notes:', error)
+    return []
+  }
+}
+
+/**
+ * すべてのdev-notes記事を取得（sitemap用）
+ */
+export const loadAllDevNotes = async (): Promise<BlogItem[]> => {
+  try {
+    const allItems: BlogItem[] = []
+    let currentPage = 1
+    let totalPages = 1
+
+    const firstResult = await loadDevNotes(currentPage, 100)
+    allItems.push(...firstResult.items)
+    totalPages = firstResult.totalPages
+
+    while (currentPage < totalPages) {
+      currentPage++
+      const result = await loadDevNotes(currentPage, 100)
+      allItems.push(...result.items)
+    }
+
+    return allItems
+  } catch (error) {
+    console.error('Error loading all dev-notes:', error)
+    return []
+  }
+}

--- a/src/libs/jsonLd.ts
+++ b/src/libs/jsonLd.ts
@@ -54,6 +54,85 @@ export function generateBlogPostingJsonLd(thought: WPThought, lang: string, base
 }
 
 /**
+ * dev-notes詳細ページ用のBlogPosting JSON-LDを生成
+ */
+export function generateDevNoteJsonLd(note: WPThought, basePath: string) {
+  const fullUrl = `${SITE_CONFIG.url}${basePath}/${note.slug}`
+
+  const stripHtml = (html: string) => {
+    return html.replace(/<[^>]*>/g, '').trim()
+  }
+
+  const description = stripHtml(note.excerpt.rendered)
+
+  const categories =
+    note._embedded?.['wp:term']
+      ?.flat()
+      .filter((term) => term.taxonomy === 'category')
+      .map((cat) => cat.name) || []
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: note.title.rendered,
+    description: description,
+    url: fullUrl,
+    datePublished: note.date,
+    dateModified: note.modified,
+    author: {
+      '@type': 'Person',
+      name: SITE_CONFIG.author.name,
+      url: SITE_CONFIG.url,
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: SITE_CONFIG.name,
+      url: SITE_CONFIG.url,
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': fullUrl,
+    },
+    inLanguage: 'ja-JP',
+    ...(categories.length > 0 && {
+      keywords: categories.join(', '),
+      articleSection: categories,
+    }),
+  }
+
+  return jsonLd
+}
+
+/**
+ * dev-notes詳細ページ用のBreadcrumbList JSON-LDを生成
+ */
+export function generateDevNoteBreadcrumbJsonLd(note: WPThought, basePath: string) {
+  const fullUrl = `${SITE_CONFIG.url}${basePath}/${note.slug}`
+  const listUrl = `${SITE_CONFIG.url}/ja/writing`
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Writing',
+        item: listUrl,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: note.title.rendered,
+        item: fullUrl,
+      },
+    ],
+  }
+
+  return jsonLd
+}
+
+/**
  * ブログ詳細ページ用のBreadcrumbList JSON-LDを生成
  */
 export function generateBlogBreadcrumbJsonLd(thought: WPThought, lang: string, basePath: string) {

--- a/src/libs/metadata.ts
+++ b/src/libs/metadata.ts
@@ -1,6 +1,35 @@
 import type { Metadata } from 'next'
 import type { WPThought } from './dataSources/types'
 
+export function generateDevNoteMetadata(note: WPThought): Metadata {
+  const ogImageUrl = new URL(
+    `/api/thumbnail/dev-notes/${note.id}`,
+    process.env.NEXT_PUBLIC_SITE_URL || 'https://hidetaka.dev',
+  )
+
+  return {
+    title: note.title.rendered,
+    openGraph: {
+      title: note.title.rendered,
+      type: 'article',
+      publishedTime: note.date,
+      images: [
+        {
+          url: ogImageUrl.toString(),
+          width: 1200,
+          height: 630,
+          alt: note.title.rendered,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: note.title.rendered,
+      images: [ogImageUrl.toString()],
+    },
+  }
+}
+
 export function generateBlogPostMetadata(thought: WPThought): Metadata {
   // セキュリティ強化: post_idからWordPress APIで記事を取得してタイトルを使用
   // これにより、任意の文字列で画像を生成することを防止


### PR DESCRIPTION
- Add devnotes.ts with API functions to fetch dev-notes from WordPress
- Integrate dev-notes into Writing page via blogs.ts aggregation
- Create detail page at /ja/writing/dev-notes/[slug]
- Add OG image generation endpoint for dev-notes
- Add metadata and JSON-LD generation for dev-notes
- Update sitemap to include dev-notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces WordPress-sourced Dev Notes with a new detail page, OG image generation, metadata/JSON-LD, feed aggregation, and sitemap entries.
> 
> - **Dev Notes (WordPress integration)**:
>   - Add data source `src/libs/dataSources/devnotes.ts` with loaders (`loadDevNotes`, `getDevNoteBySlug`, `getAdjacentDevNotes`, `getRelatedDevNotes`, `loadAllDevNotes`).
> - **Pages/UI**:
>   - New detail route `src/app/ja/writing/dev-notes/[slug]/page.tsx` rendering `DevNoteDetailPage`.
>   - New component `src/components/containers/pages/DevNoteDetailPage.tsx` (breadcrumb, OG image, content, tags, adjacent nav, related articles, ads/profile).
> - **API**:
>   - Add OG image endpoint `src/app/api/thumbnail/dev-notes/[id]/route.tsx` using Cloudflare Service Binding and auth.
> - **SEO**:
>   - Add JSON-LD generators for dev-notes in `src/libs/jsonLd.ts` and metadata generator in `src/libs/metadata.ts`.
> - **Sitemap**:
>   - Include dev-notes entries via `loadAllDevNotes` in `src/app/sitemap.ts`.
> - **Feed aggregation**:
>   - Integrate dev-notes into Writing feed in `src/libs/dataSources/blogs.ts` (source, fetch, mapping, hasMore).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 814a44387bc620256444081d308f37773a2dd205. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->