### PR TITLE
Add category display to writing page

### DIFF
--- a/src/app/ja/writing/category/[name]/page.tsx
+++ b/src/app/ja/writing/category/[name]/page.tsx
@@ -1,0 +1,47 @@
+import { notFound } from 'next/navigation'
+import WritingPageContent from '@/components/containers/pages/WritingPage'
+import { loadBlogPosts } from '@/libs/dataSources/blogs'
+import { MicroCMSAPI } from '@/libs/microCMS/apis'
+import { createMicroCMSClient } from '@/libs/microCMS/client'
+
+export const metadata = {
+  title: 'Writing カテゴリ',
+}
+
+// ISR: 1時間ごとにページを再検証（複数ソースの集約）
+export const revalidate = 3600
+
+export default async function WritingCategoryPage({
+  params,
+}: {
+  params: Promise<{ name: string }>
+}) {
+  const { name } = await params
+  // Next.jsのApp Routerでは、URLパラメータは自動的にデコードされる
+  // ただし、URLエンコードされた文字列がそのまま渡される場合もあるので、両方試す
+  const decodedName = name.includes('%') ? decodeURIComponent(name) : name
+
+  const microCMS = new MicroCMSAPI(createMicroCMSClient())
+
+  // カテゴリ(タグ)でフィルタリングされたニュース記事を取得
+  const newsArticles = await microCMS.listPostsByTag(decodedName, { lang: 'japanese' })
+
+  // 外部記事は全て取得してクライアント側でフィルタリング
+  // (外部記事にはタグ情報がないため、すべて取得する必要がある)
+  const { items: externalArticles, hasMoreBySource } = await loadBlogPosts('ja')
+
+  // ニュース記事が存在しない場合は404
+  if (newsArticles.length === 0) {
+    notFound()
+  }
+
+  return (
+    <WritingPageContent
+      lang="ja"
+      externalArticles={externalArticles}
+      hasMoreBySource={hasMoreBySource}
+      newsArticles={newsArticles}
+      categoryName={decodedName}
+    />
+  )
+}

--- a/src/app/writing/category/[name]/page.tsx
+++ b/src/app/writing/category/[name]/page.tsx
@@ -1,0 +1,47 @@
+import { notFound } from 'next/navigation'
+import WritingPageContent from '@/components/containers/pages/WritingPage'
+import { loadBlogPosts } from '@/libs/dataSources/blogs'
+import { MicroCMSAPI } from '@/libs/microCMS/apis'
+import { createMicroCMSClient } from '@/libs/microCMS/client'
+
+export const metadata = {
+  title: 'Writing Category',
+}
+
+// ISR: 1時間ごとにページを再検証（複数ソースの集約）
+export const revalidate = 3600
+
+export default async function WritingCategoryPage({
+  params,
+}: {
+  params: Promise<{ name: string }>
+}) {
+  const { name } = await params
+  // Next.jsのApp Routerでは、URLパラメータは自動的にデコードされる
+  // ただし、URLエンコードされた文字列がそのまま渡される場合もあるので、両方試す
+  const decodedName = name.includes('%') ? decodeURIComponent(name) : name
+
+  const microCMS = new MicroCMSAPI(createMicroCMSClient())
+
+  // カテゴリ(タグ)でフィルタリングされたニュース記事を取得
+  const newsArticles = await microCMS.listPostsByTag(decodedName, { lang: 'english' })
+
+  // 外部記事は全て取得してクライアント側でフィルタリング
+  // (外部記事にはタグ情報がないため、すべて取得する必要がある)
+  const { items: externalArticles, hasMoreBySource } = await loadBlogPosts('en')
+
+  // ニュース記事が存在しない場合は404
+  if (newsArticles.length === 0) {
+    notFound()
+  }
+
+  return (
+    <WritingPageContent
+      lang="en"
+      externalArticles={externalArticles}
+      hasMoreBySource={hasMoreBySource}
+      newsArticles={newsArticles}
+      categoryName={decodedName}
+    />
+  )
+}

--- a/src/components/containers/pages/WritingPage.tsx
+++ b/src/components/containers/pages/WritingPage.tsx
@@ -225,30 +225,51 @@ function Sidebar({
         </nav>
       </div>
 
-      {/* タグフィルター */}
+      {/* カテゴリフィルター（タグベース） */}
       {availableTags.length > 0 && (
         <div>
           <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-slate-900 dark:text-white">
             {tagTitle}
           </h3>
           <nav className="space-y-1">
-            <FilterItem
-              active={filterTag === null}
-              onClick={() => onFilterTagChange(null)}
-              count={counts.all}
+            <Link
+              href={lang === 'ja' ? '/ja/writing' : '/writing'}
+              className={`w-full flex items-center justify-between rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors ${
+                filterTag === null
+                  ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-400'
+                  : 'text-slate-700 hover:bg-zinc-50 dark:text-slate-300 dark:hover:bg-zinc-800'
+              }`}
             >
-              {allText}
-            </FilterItem>
-            {availableTags.map((tag) => (
-              <FilterItem
-                key={tag}
-                active={filterTag === tag}
-                onClick={() => onFilterTagChange(tag)}
-                count={counts.byTag[tag] || 0}
-              >
-                {tag}
-              </FilterItem>
-            ))}
+              <span>{allText}</span>
+            </Link>
+            {availableTags.map((tag) => {
+              const categoryUrl =
+                lang === 'ja'
+                  ? `/ja/writing/category/${encodeURIComponent(tag)}`
+                  : `/writing/category/${encodeURIComponent(tag)}`
+              return (
+                <Link
+                  key={tag}
+                  href={categoryUrl}
+                  className={`w-full flex items-center justify-between rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors ${
+                    filterTag === tag
+                      ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-400'
+                      : 'text-slate-700 hover:bg-zinc-50 dark:text-slate-300 dark:hover:bg-zinc-800'
+                  }`}
+                >
+                  <span>{tag}</span>
+                  <span
+                    className={`ml-2 rounded-full px-2 py-0.5 text-xs ${
+                      filterTag === tag
+                        ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
+                        : 'bg-zinc-100 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-400'
+                    }`}
+                  >
+                    {counts.byTag[tag] || 0}
+                  </span>
+                </Link>
+              )
+            })}
           </nav>
         </div>
       )}
@@ -316,15 +337,17 @@ export default function WritingPageContent({
   externalArticles,
   hasMoreBySource = {},
   newsArticles,
+  categoryName,
 }: {
   lang: string
   externalArticles: FeedItem[]
   hasMoreBySource?: Record<string, boolean>
   newsArticles: MicroCMSPostsRecord[]
+  categoryName?: string
 }) {
   const [searchQuery, setSearchQuery] = useState('')
-  const [filterType, setFilterType] = useState<FilterType>('all')
-  const [filterTag, setFilterTag] = useState<FilterTag>(null)
+  const [filterType, setFilterType] = useState<FilterType>(categoryName ? 'news' : 'all')
+  const [filterTag, setFilterTag] = useState<FilterTag>(categoryName || null)
   const [filterDataSource, setFilterDataSource] = useState<FilterDataSource>(null)
   const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false)
 
@@ -449,9 +472,18 @@ export default function WritingPageContent({
   ])
 
   // テキスト
-  const title = lang === 'ja' ? 'Writing' : 'Writing'
-  const description =
-    lang === 'ja'
+  const title = categoryName
+    ? lang === 'ja'
+      ? `カテゴリ: ${categoryName}`
+      : `Category: ${categoryName}`
+    : lang === 'ja'
+      ? 'Writing'
+      : 'Writing'
+  const description = categoryName
+    ? lang === 'ja'
+      ? `「${categoryName}」カテゴリの記事一覧です。`
+      : `Articles in the "${categoryName}" category.`
+    : lang === 'ja'
       ? '技術記事、ブログ投稿、ニュースなどの執筆活動を紹介しています。'
       : "A collection of technical articles, blog posts, news, and other writing I've published."
   const filterButtonText = lang === 'ja' ? 'フィルター' : 'Filter'

--- a/src/libs/microCMS/apis.ts
+++ b/src/libs/microCMS/apis.ts
@@ -221,4 +221,35 @@ export class MicroCMSAPI {
     })
     return events
   }
+
+  /**
+   * タグで投稿記事をフィルタリング（writing category用）
+   */
+  public async listPostsByTag(
+    tag: string,
+    query?: { lang?: 'japanese' | 'english' },
+  ): Promise<MicroCMSPostsRecord[]> {
+    if (!this.client) {
+      if (process.env.MICROCMS_API_MODE === 'mock') {
+        return MICROCMS_MOCK_POSTs.filter((post) => post.tags.includes(tag))
+      }
+      return []
+    }
+    const lang = query?.lang ?? null
+    const filters = [`tags[contains]${tag}`, lang ? `lang[contains]${query?.lang}` : undefined]
+      .filter(Boolean)
+      .join('[and]')
+
+    const { contents: posts } = await this.client.get<{
+      contents: MicroCMSPostsRecord[]
+    }>({
+      endpoint: 'posts',
+      queries: {
+        orders: '-publishedAt',
+        filters,
+        limit: 50,
+      },
+    })
+    return posts
+  }
 }


### PR DESCRIPTION
- MicroCMSAPI に listPostsByTag メソッドを追加
- /ja/writing/category/[name] と /writing/category/[name] ページを作成
- WritingPage コンポーネントにカテゴリサイドバーを追加（タグをカテゴリとして扱う）
- ブログページの実装を参考に、再利用可能な形で実装