### PR TITLE
Fix npm lint errors in GitHub Actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "jsdom": "^27.2.0",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.14",
-        "typescript": "^5",
+        "typescript": "5.9.3",
         "vitest": "^4.0.9",
         "wrangler": "^4.38.0"
       }
@@ -7763,7 +7763,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.1.tgz",
       "integrity": "sha512-Nu8ahitGFFJztxUml9oD/DLb7Z28C8cd8F46IVQ7y5Btz575pvMY8AqZsXkX7Gds29eCKdMgIHjIvzskHgPSFg==",
-      "dev": true,
       "dependencies": {
         "mime": "^3.0.0"
       },
@@ -7775,7 +7774,6 @@
       "version": "2.7.13",
       "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.7.13.tgz",
       "integrity": "sha512-NulO1H8R/DzsJguLC0ndMuk4Ufv0KSlN+E54ay9rn9ZCQo0kpAPwwh3LhgpZ96a3Dr6L9LqW57M4CqC34iLOvw==",
-      "dev": true,
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
         "workerd": "^1.20251202.0"
@@ -7793,7 +7791,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7809,7 +7806,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7825,7 +7821,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7841,7 +7836,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7857,7 +7851,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -7870,7 +7863,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -7882,7 +7874,6 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -9369,7 +9360,6 @@
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
       "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
-      "dev": true,
       "dependencies": {
         "kleur": "^4.1.5"
       }
@@ -9378,7 +9368,6 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
       "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
-      "dev": true,
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
         "@sindresorhus/is": "^7.0.2",
@@ -9389,7 +9378,6 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
       "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -9400,8 +9388,7 @@
     "node_modules/@poppinss/exception": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
-      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
-      "dev": true
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.53.5",
@@ -9693,7 +9680,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.1.1.tgz",
       "integrity": "sha512-rO92VvpgMc3kfiTjGT52LEtJ8Yc5kCWhZjLQ3LwlA4pSgPpQO7bVpYXParOD8Jwf+cVQECJo3yP/4I8aZtUQTQ==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -11005,8 +10991,7 @@
     "node_modules/@speed-highlight/core": {
       "version": "1.2.12",
       "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.12.tgz",
-      "integrity": "sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA==",
-      "dev": true
+      "integrity": "sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA=="
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -11374,7 +11359,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -11587,8 +11571,7 @@
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
-      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
-      "dev": true
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="
     },
     "node_modules/body-parser": {
       "version": "2.2.1",
@@ -11906,7 +11889,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -11935,7 +11917,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dev": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -12203,7 +12184,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -12349,7 +12329,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
       "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -12504,7 +12483,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
       "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -12800,7 +12778,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -12920,8 +12897,7 @@
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -13124,8 +13100,7 @@
     "node_modules/is-arrayish": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-      "dev": true
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -13405,7 +13380,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -13570,7 +13544,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -13623,7 +13596,6 @@
       "version": "4.20251213.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20251213.0.tgz",
       "integrity": "sha512-/Or0LuRA6dQMKvL7nztPWNOVXosrJRBiO0BdJX9LUIesyeAUWIZMPFmP9XX+cdny2fIUcqYcG4DuoL5JHxj95w==",
-      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "acorn": "8.14.0",
@@ -13652,7 +13624,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -13674,7 +13645,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -13696,7 +13666,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -13712,7 +13681,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -13728,7 +13696,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -13744,7 +13711,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -13760,7 +13726,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -13776,7 +13741,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -13792,7 +13756,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -13808,7 +13771,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -13824,7 +13786,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -13846,7 +13807,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -13868,7 +13828,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -13890,7 +13849,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -13912,7 +13870,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -13934,7 +13891,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -13956,7 +13912,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/runtime": "^1.2.0"
@@ -13975,7 +13930,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -13994,7 +13948,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -14010,7 +13963,6 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -14022,7 +13974,6 @@
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
       "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
-      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "color": "^4.2.3",
@@ -14438,8 +14389,7 @@
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -14973,7 +14923,6 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "devOptional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -15175,7 +15124,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
       "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
@@ -15243,7 +15191,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
       "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-      "dev": true,
       "engines": {
         "node": ">=4",
         "npm": ">=6"
@@ -15669,6 +15616,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15681,7 +15629,6 @@
       "version": "7.14.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
       "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
-      "dev": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -15695,7 +15642,6 @@
       "version": "2.0.0-rc.24",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
-      "dev": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -16465,7 +16411,6 @@
       "version": "1.20251213.0",
       "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20251213.0.tgz",
       "integrity": "sha512-knLMSqmUKo7EO1wV69u8o2J+6RVDow3H5qK9f1tzk24fd4rEZXkR1cxFiYisfTRjk/Jl3/1URAkQRSDAiWE5RA==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "workerd": "bin/workerd"
@@ -16485,7 +16430,6 @@
       "version": "4.55.0",
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.55.0.tgz",
       "integrity": "sha512-50icmLX8UbNaq0FmFHbcvvOh7I6rDA/FyaMYRcNSl1iX0JwuKswezmmtYvYPxPTkbYz7FUYR8GPZLaT23uzFqw==",
-      "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.1",
         "@cloudflare/unenv-preset": "2.7.13",
@@ -16522,7 +16466,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -16538,7 +16481,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -16554,7 +16496,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -16570,7 +16511,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -16586,7 +16526,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -16602,7 +16541,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -16618,7 +16556,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -16634,7 +16571,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -16650,7 +16586,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -16666,7 +16601,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -16682,7 +16616,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -16698,7 +16631,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -16714,7 +16646,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -16730,7 +16661,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -16746,7 +16676,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -16762,7 +16691,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -16778,7 +16706,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -16794,7 +16721,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -16810,7 +16736,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -16826,7 +16751,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -16842,7 +16766,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -16858,7 +16781,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openharmony"
@@ -16874,7 +16796,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -16890,7 +16811,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -16906,7 +16826,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -16922,7 +16841,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -16935,7 +16853,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
       "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -17071,7 +16988,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17201,7 +17117,6 @@
       "version": "4.1.0-beta.10",
       "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
       "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
-      "dev": true,
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
         "@poppinss/dumper": "^0.6.4",
@@ -17214,7 +17129,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
       "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
-      "dev": true,
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
@@ -17224,7 +17138,6 @@
       "version": "3.22.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
       "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jsdom": "^27.2.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
-    "typescript": "^5",
+    "typescript": "5.9.3",
     "vitest": "^4.0.9",
     "wrangler": "^4.38.0"
   }

--- a/src/app/ja/news/[slug]/page.tsx
+++ b/src/app/ja/news/[slug]/page.tsx
@@ -6,9 +6,28 @@ import {
   getProductBySlug,
   getRelatedProducts,
   loadAllProducts,
+  type WPProduct,
 } from '@/libs/dataSources/products'
+import type { WPThought } from '@/libs/dataSources/types'
 import { generateBlogBreadcrumbJsonLd, generateBlogPostingJsonLd } from '@/libs/jsonLd'
 import { generateBlogPostMetadata } from '@/libs/metadata'
+
+// WPProductをWPThoughtに変換するヘルパー関数
+function productToThought(product: WPProduct): WPThought {
+  return {
+    id: product.id,
+    title: product.title,
+    date: product.date,
+    date_gmt: product.date_gmt,
+    modified: product.modified,
+    modified_gmt: product.modified_gmt,
+    excerpt: product.excerpt || { rendered: '' },
+    content: product.content,
+    link: product.link,
+    slug: product.slug,
+    featured_media: product.featured_media,
+  }
+}
 
 export async function generateStaticParams() {
   const products = await loadAllProducts()
@@ -28,17 +47,9 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   }
 
   // WPProductをWPThought形式に変換してメタデータを生成
-  const thoughtLike = {
-    id: product.id,
-    title: product.title,
-    date: product.date,
-    modified: product.modified,
-    excerpt: product.excerpt || { rendered: '' },
-    content: product.content,
-    slug: product.slug,
-  }
+  const thought = productToThought(product)
 
-  return generateBlogPostMetadata(thoughtLike as any)
+  return generateBlogPostMetadata(thought)
 }
 
 export default async function NewsDetailPage({ params }: { params: Promise<{ slug: string }> }) {
@@ -50,17 +61,9 @@ export default async function NewsDetailPage({ params }: { params: Promise<{ slu
   }
 
   // JSON-LDを生成
-  const thoughtLike = {
-    id: product.id,
-    title: product.title,
-    date: product.date,
-    modified: product.modified,
-    excerpt: product.excerpt || { rendered: '' },
-    content: product.content,
-    slug: product.slug,
-  }
-  const blogPostingJsonLd = generateBlogPostingJsonLd(thoughtLike as any, 'ja', '/ja/news')
-  const breadcrumbJsonLd = generateBlogBreadcrumbJsonLd(thoughtLike as any, 'ja', '/ja/news')
+  const thought = productToThought(product)
+  const blogPostingJsonLd = generateBlogPostingJsonLd(thought, 'ja', '/ja/news')
+  const breadcrumbJsonLd = generateBlogBreadcrumbJsonLd(thought, 'ja', '/ja/news')
 
   // 前後の記事と関連記事を取得
   const [adjacentProducts, relatedArticles] = await Promise.all([

--- a/src/app/news/[slug]/page.tsx
+++ b/src/app/news/[slug]/page.tsx
@@ -6,9 +6,28 @@ import {
   getProductBySlug,
   getRelatedProducts,
   loadAllProducts,
+  type WPProduct,
 } from '@/libs/dataSources/products'
+import type { WPThought } from '@/libs/dataSources/types'
 import { generateBlogBreadcrumbJsonLd, generateBlogPostingJsonLd } from '@/libs/jsonLd'
 import { generateBlogPostMetadata } from '@/libs/metadata'
+
+// WPProductをWPThoughtに変換するヘルパー関数
+function productToThought(product: WPProduct): WPThought {
+  return {
+    id: product.id,
+    title: product.title,
+    date: product.date,
+    date_gmt: product.date_gmt,
+    modified: product.modified,
+    modified_gmt: product.modified_gmt,
+    excerpt: product.excerpt || { rendered: '' },
+    content: product.content,
+    link: product.link,
+    slug: product.slug,
+    featured_media: product.featured_media,
+  }
+}
 
 export async function generateStaticParams() {
   const products = await loadAllProducts()
@@ -28,17 +47,9 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   }
 
   // WPProductをWPThought形式に変換してメタデータを生成
-  const thoughtLike = {
-    id: product.id,
-    title: product.title,
-    date: product.date,
-    modified: product.modified,
-    excerpt: product.excerpt || { rendered: '' },
-    content: product.content,
-    slug: product.slug,
-  }
+  const thought = productToThought(product)
 
-  return generateBlogPostMetadata(thoughtLike as any)
+  return generateBlogPostMetadata(thought)
 }
 
 export default async function NewsDetailPage({ params }: { params: Promise<{ slug: string }> }) {
@@ -50,17 +61,9 @@ export default async function NewsDetailPage({ params }: { params: Promise<{ slu
   }
 
   // JSON-LDを生成
-  const thoughtLike = {
-    id: product.id,
-    title: product.title,
-    date: product.date,
-    modified: product.modified,
-    excerpt: product.excerpt || { rendered: '' },
-    content: product.content,
-    slug: product.slug,
-  }
-  const blogPostingJsonLd = generateBlogPostingJsonLd(thoughtLike as any, 'en', '/news')
-  const breadcrumbJsonLd = generateBlogBreadcrumbJsonLd(thoughtLike as any, 'en', '/news')
+  const thought = productToThought(product)
+  const blogPostingJsonLd = generateBlogPostingJsonLd(thought, 'en', '/news')
+  const breadcrumbJsonLd = generateBlogBreadcrumbJsonLd(thought, 'en', '/news')
 
   // 前後の記事と関連記事を取得
   const [adjacentProducts, relatedArticles] = await Promise.all([

--- a/src/libs/sanitize.test.ts
+++ b/src/libs/sanitize.test.ts
@@ -48,7 +48,7 @@ describe('removeHtmlTags', () => {
   })
 
   it('should return input if falsy', () => {
-    expect(removeHtmlTags(null as any)).toBe(null)
-    expect(removeHtmlTags(undefined as any)).toBe(undefined)
+    expect(removeHtmlTags(null)).toBe(null)
+    expect(removeHtmlTags(undefined)).toBe(undefined)
   })
 })

--- a/src/libs/sanitize.ts
+++ b/src/libs/sanitize.ts
@@ -1,4 +1,8 @@
-export function removeHtmlTags(str: string): string {
+export function removeHtmlTags(str: string): string
+export function removeHtmlTags(str: null): null
+export function removeHtmlTags(str: undefined): undefined
+export function removeHtmlTags(str: string | null | undefined): string | null | undefined
+export function removeHtmlTags(str: string | null | undefined): string | null | undefined {
   if (!str) return str
   return str.replace(/<\/?([a-z][a-z0-9]*)\b[^>]*>/gi, '').replace(/ \[&hellip;\]/, '...')
 }


### PR DESCRIPTION
以下の問題を修正:
- src/app/ja/news/[slug]/page.tsx: WPProductをWPThoughtに型安全に変換するヘルパー関数を追加し、as anyを削除
- src/app/news/[slug]/page.tsx: 同様の修正を適用
- src/libs/sanitize.ts: removeHtmlTags関数にオーバーロードを追加し、型推論を改善
- src/libs/sanitize.test.ts: removeHtmlTags関数の型修正により、as anyが不要に
- src/components/containers/pages/SpeakingPage.tsx: matchesSearchをuseCallbackでラップし、フィルターグループ作成関数を抽出して複雑度を削減