### PR TITLE
Optimize GitHub Actions CI with conditional jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
       test: ${{ steps.filter.outputs.test }}
       build: ${{ steps.filter.outputs.build }}
       cf-build: ${{ steps.filter.outputs.cf-build }}
+      workflow: ${{ steps.filter.outputs.workflow }}
     steps:
       - uses: actions/checkout@v4
 
@@ -58,13 +59,15 @@ jobs:
               - 'wrangler.jsonc'
               - 'package.json'
               - 'package-lock.json'
+            workflow:
+              - '.github/workflows/test.yml'
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: changes
-    if: needs.changes.outputs.lint == 'true'
+    if: needs.changes.outputs.lint == 'true' || needs.changes.outputs.workflow == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -86,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [changes, lint]
-    if: needs.changes.outputs.test == 'true'
+    if: needs.changes.outputs.workflow == 'true' || (needs.changes.outputs.test == 'true' && needs.lint.conclusion != 'failure')
 
     steps:
       - uses: actions/checkout@v4
@@ -117,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [changes, lint]
-    if: needs.changes.outputs.build == 'true'
+    if: needs.changes.outputs.workflow == 'true' || (needs.changes.outputs.build == 'true' && needs.lint.conclusion != 'failure')
 
     steps:
       - uses: actions/checkout@v4
@@ -141,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [changes, lint]
-    if: needs.changes.outputs.cf-build == 'true'
+    if: needs.changes.outputs.workflow == 'true' || (needs.changes.outputs.cf-build == 'true' && needs.lint.conclusion != 'failure')
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Make test, build, and cf-build jobs depend on successful lint execution. This prevents unnecessary CI runs when linting fails, improving overall CI efficiency.

- test job now requires lint to pass
- build job now requires lint to pass
- cf-build job now requires lint to pass