### PR TITLE
Add category display to writing pages

### DIFF
--- a/src/components/containers/pages/DevNoteDetailPage.tsx
+++ b/src/components/containers/pages/DevNoteDetailPage.tsx
@@ -99,15 +99,12 @@ export default function DevNoteDetailPage({
                 .filter((term) => term.taxonomy === 'category')
                 .map((category) => {
                   // category.slugが既にエンコードされている可能性があるので、一度デコードしてからエンコード
-                  // malformed percent-encodingの場合はそのまま使用
+                  // malformed percent-encodingの場合は初期値をそのまま使用
                   let normalizedSlug = category.slug
-                  if (category.slug.includes('%')) {
-                    try {
-                      normalizedSlug = decodeURIComponent(category.slug)
-                    } catch {
-                      // malformed percent-encoding (e.g., 'foo%bar') の場合はそのまま使用
-                      normalizedSlug = category.slug
-                    }
+                  try {
+                    normalizedSlug = decodeURIComponent(category.slug)
+                  } catch {
+                    // decodeURIComponentが失敗した場合は初期値(category.slug)を使用
                   }
                   const categoryUrl = `/ja/writing/category/${encodeURIComponent(normalizedSlug)}`
                   return (


### PR DESCRIPTION
- Add Link component wrapping for category tags in DevNoteDetailPage
- Categories now link to /ja/writing/category/{slug} format
- Add hover effects (hover:bg-indigo-100, dark:hover:bg-indigo-900/30)
- Normalize category slugs with proper URL encoding
- Consistent with blog post category display implementation

This improves navigation by allowing users to browse articles by category.