### PR TITLE
Dev notes link redirection

### DIFF
--- a/src/libs/middleware/redirectRules.test.ts
+++ b/src/libs/middleware/redirectRules.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DevNotesExclusionRedirectRule,
+  LegacyPathRedirectRule,
+  type RedirectRule,
+  RedirectRuleEngine,
+} from './redirectRules'
+
+describe('RedirectRuleEngine', () => {
+  describe('shouldRedirect', () => {
+    it('パスがルールにマッチする場合はtrueを返す', () => {
+      const rule: RedirectRule = {
+        shouldRedirect: (pathname) => pathname === '/old-path',
+        getRedirectPath: (_pathname, _baseUrl) => '/new-path',
+      }
+      const engine = new RedirectRuleEngine([rule])
+      const result = engine.shouldRedirect('/old-path', 'https://example.com')
+      expect(result).toBe(true)
+    })
+
+    it('パスがルールにマッチしない場合はfalseを返す', () => {
+      const rule: RedirectRule = {
+        shouldRedirect: (pathname) => pathname === '/old-path',
+        getRedirectPath: (_pathname, _baseUrl) => '/new-path',
+      }
+      const engine = new RedirectRuleEngine([rule])
+      const result = engine.shouldRedirect('/other-path', 'https://example.com')
+      expect(result).toBe(false)
+    })
+
+    it('複数のルールがある場合、最初にマッチしたルールを使用する', () => {
+      const rule1: RedirectRule = {
+        shouldRedirect: (pathname) => pathname.startsWith('/a'),
+        getRedirectPath: (_pathname, _baseUrl) => '/a-redirect',
+      }
+      const rule2: RedirectRule = {
+        shouldRedirect: (pathname) => pathname.startsWith('/ab'),
+        getRedirectPath: (_pathname, _baseUrl) => '/ab-redirect',
+      }
+      const engine = new RedirectRuleEngine([rule1, rule2])
+      const result = engine.shouldRedirect('/abc', 'https://example.com')
+      expect(result).toBe(true)
+    })
+
+    it('リダイレクト先のパスを正しく取得できる', () => {
+      const rule: RedirectRule = {
+        shouldRedirect: (pathname) => pathname === '/old-path',
+        getRedirectPath: (_pathname, baseUrl) => `${baseUrl}/new-path`,
+      }
+      const engine = new RedirectRuleEngine([rule])
+      const result = engine.getRedirectPath('/old-path', 'https://example.com')
+      expect(result).toBe('https://example.com/new-path')
+    })
+  })
+})
+
+describe('LegacyPathRedirectRule', () => {
+  describe('shouldRedirect', () => {
+    it('/projects を /work にリダイレクトする', () => {
+      const rule = new LegacyPathRedirectRule('/projects', '/work')
+      expect(rule.shouldRedirect('/projects')).toBe(true)
+      expect(rule.shouldRedirect('/projects/')).toBe(true)
+      expect(rule.shouldRedirect('/projects/something')).toBe(true)
+    })
+
+    it('/ja/projects を /ja/work にリダイレクトする', () => {
+      const rule = new LegacyPathRedirectRule('/ja/projects', '/ja/work')
+      expect(rule.shouldRedirect('/ja/projects')).toBe(true)
+      expect(rule.shouldRedirect('/ja/projects/')).toBe(true)
+      expect(rule.shouldRedirect('/ja/projects/something')).toBe(true)
+    })
+
+    it('/oss を /work にリダイレクトする', () => {
+      const rule = new LegacyPathRedirectRule('/oss', '/work')
+      expect(rule.shouldRedirect('/oss')).toBe(true)
+      expect(rule.shouldRedirect('/oss/')).toBe(true)
+    })
+
+    it('/articles を /writing にリダイレクトする', () => {
+      const rule = new LegacyPathRedirectRule('/articles', '/writing')
+      expect(rule.shouldRedirect('/articles')).toBe(true)
+      expect(rule.shouldRedirect('/articles/')).toBe(true)
+    })
+
+    it('マッチしないパスはfalseを返す', () => {
+      const rule = new LegacyPathRedirectRule('/projects', '/work')
+      expect(rule.shouldRedirect('/other')).toBe(false)
+      expect(rule.shouldRedirect('/project')).toBe(false)
+    })
+
+    it('getRedirectPathが正しいパスを返す', () => {
+      const rule = new LegacyPathRedirectRule('/projects', '/work')
+      expect(rule.getRedirectPath('/projects', 'https://example.com')).toBe(
+        'https://example.com/work',
+      )
+      expect(rule.getRedirectPath('/projects/something', 'https://example.com')).toBe(
+        'https://example.com/work/something',
+      )
+    })
+  })
+})
+
+describe('DevNotesExclusionRedirectRule', () => {
+  describe('shouldRedirect', () => {
+    it('/writing/[id] を /news にリダイレクトする', () => {
+      const rule = new DevNotesExclusionRedirectRule('/writing/', '/news/')
+      expect(rule.shouldRedirect('/writing/old-post')).toBe(true)
+      expect(rule.shouldRedirect('/writing/something')).toBe(true)
+    })
+
+    it('/writing/ 自体はリダイレクトしない', () => {
+      const rule = new DevNotesExclusionRedirectRule('/writing/', '/news/')
+      expect(rule.shouldRedirect('/writing/')).toBe(false)
+    })
+
+    it('/writing/dev-notes/ で始まるパスはリダイレクトしない', () => {
+      const rule = new DevNotesExclusionRedirectRule('/writing/', '/news/')
+      expect(rule.shouldRedirect('/writing/dev-notes/')).toBe(false)
+      expect(rule.shouldRedirect('/writing/dev-notes/some-slug')).toBe(false)
+    })
+
+    it('/ja/writing/[id] を /ja/news/ にリダイレクトする', () => {
+      const rule = new DevNotesExclusionRedirectRule('/ja/writing/', '/ja/news/')
+      expect(rule.shouldRedirect('/ja/writing/old-post')).toBe(true)
+      expect(rule.shouldRedirect('/ja/writing/something')).toBe(true)
+    })
+
+    it('/ja/writing/ 自体はリダイレクトしない', () => {
+      const rule = new DevNotesExclusionRedirectRule('/ja/writing/', '/ja/news/')
+      expect(rule.shouldRedirect('/ja/writing/')).toBe(false)
+    })
+
+    it('/ja/writing/dev-notes/ で始まるパスはリダイレクトしない', () => {
+      const rule = new DevNotesExclusionRedirectRule('/ja/writing/', '/ja/news/')
+      expect(rule.shouldRedirect('/ja/writing/dev-notes/')).toBe(false)
+      expect(rule.shouldRedirect('/ja/writing/dev-notes/some-slug')).toBe(false)
+    })
+
+    it('getRedirectPathが正しいパスを返す', () => {
+      const rule = new DevNotesExclusionRedirectRule('/writing/', '/news/')
+      expect(rule.getRedirectPath('/writing/old-post', 'https://example.com')).toBe(
+        'https://example.com/news/',
+      )
+    })
+  })
+})
+
+describe('統合テスト: 実際のmiddlewareのルール', () => {
+  it('dev-notesのパスはリダイレクトされない', () => {
+    const rules: RedirectRule[] = [
+      new LegacyPathRedirectRule('/projects', '/work'),
+      new LegacyPathRedirectRule('/ja/projects', '/ja/work'),
+      new LegacyPathRedirectRule('/oss', '/work'),
+      new LegacyPathRedirectRule('/ja/oss', '/ja/work'),
+      new LegacyPathRedirectRule('/articles', '/writing'),
+      new LegacyPathRedirectRule('/ja/articles', '/ja/writing'),
+      new DevNotesExclusionRedirectRule('/writing/', '/news/'),
+      new DevNotesExclusionRedirectRule('/ja/writing/', '/ja/news/'),
+    ]
+
+    const engine = new RedirectRuleEngine(rules)
+
+    // dev-notesはリダイレクトされない
+    expect(engine.shouldRedirect('/ja/writing/dev-notes/some-slug', 'https://hidetaka.dev')).toBe(
+      false,
+    )
+    expect(engine.shouldRedirect('/ja/writing/dev-notes/', 'https://hidetaka.dev')).toBe(false)
+    expect(engine.shouldRedirect('/writing/dev-notes/some-slug', 'https://hidetaka.dev')).toBe(
+      false,
+    )
+
+    // 他のwritingパスはリダイレクトされる
+    expect(engine.shouldRedirect('/ja/writing/old-post', 'https://hidetaka.dev')).toBe(true)
+    expect(engine.shouldRedirect('/writing/old-post', 'https://hidetaka.dev')).toBe(true)
+
+    // 他のルールも動作する
+    expect(engine.shouldRedirect('/projects', 'https://hidetaka.dev')).toBe(true)
+    expect(engine.shouldRedirect('/ja/projects', 'https://hidetaka.dev')).toBe(true)
+  })
+})

--- a/src/libs/middleware/redirectRules.ts
+++ b/src/libs/middleware/redirectRules.ts
@@ -1,0 +1,124 @@
+/**
+ * リダイレクトルールのインターフェース
+ * 純粋関数として実装され、テスト可能な設計
+ */
+export interface RedirectRule {
+  /**
+   * 指定されたパスがリダイレクト対象かどうかを判定する
+   * @param pathname チェックするパス
+   * @returns リダイレクトが必要な場合true
+   */
+  shouldRedirect(pathname: string): boolean
+
+  /**
+   * リダイレクト先のURLを取得する
+   * @param pathname 元のパス
+   * @param baseUrl ベースURL（例: https://hidetaka.dev）
+   * @returns リダイレクト先の完全なURL
+   */
+  getRedirectPath(pathname: string, baseUrl: string): string
+}
+
+/**
+ * レガシーパスを新しいパスにリダイレクトするルール
+ * 例: /projects → /work
+ */
+export class LegacyPathRedirectRule implements RedirectRule {
+  constructor(
+    private readonly oldPath: string,
+    private readonly newPath: string,
+  ) {}
+
+  shouldRedirect(pathname: string): boolean {
+    return pathname === this.oldPath || pathname.startsWith(`${this.oldPath}/`)
+  }
+
+  getRedirectPath(pathname: string, baseUrl: string): string {
+    const newPathname = pathname.replace(this.oldPath, this.newPath)
+    return `${baseUrl}${newPathname}`
+  }
+}
+
+/**
+ * dev-notesパスを除外したリダイレクトルール
+ * /writing/[id] → /news/ のリダイレクトで、dev-notesは除外する
+ */
+export class DevNotesExclusionRedirectRule implements RedirectRule {
+  constructor(
+    private readonly sourcePath: string,
+    private readonly targetPath: string,
+  ) {}
+
+  shouldRedirect(pathname: string): boolean {
+    // ソースパス自体はリダイレクトしない
+    if (pathname === this.sourcePath) {
+      return false
+    }
+
+    // dev-notesパスはリダイレクトしない
+    const devNotesPath = `${this.sourcePath}dev-notes/`
+    if (pathname.startsWith(devNotesPath)) {
+      return false
+    }
+
+    // それ以外のソースパス配下はリダイレクトする
+    return pathname.startsWith(this.sourcePath)
+  }
+
+  getRedirectPath(_pathname: string, baseUrl: string): string {
+    return `${baseUrl}${this.targetPath}`
+  }
+}
+
+/**
+ * リダイレクトルールエンジン
+ * 複数のルールを管理し、リダイレクトが必要かどうかを判定する
+ */
+export class RedirectRuleEngine {
+  constructor(private readonly rules: RedirectRule[]) {}
+
+  /**
+   * 指定されたパスがリダイレクト対象かどうかを判定する
+   * @param pathname チェックするパス
+   * @param baseUrl ベースURL
+   * @returns リダイレクトが必要な場合true
+   */
+  shouldRedirect(pathname: string, _baseUrl: string): boolean {
+    return this.rules.some((rule) => rule.shouldRedirect(pathname))
+  }
+
+  /**
+   * リダイレクト先のURLを取得する
+   * 最初にマッチしたルールのリダイレクト先を返す
+   * @param pathname 元のパス
+   * @param baseUrl ベースURL
+   * @returns リダイレクト先の完全なURL
+   */
+  getRedirectPath(pathname: string, baseUrl: string): string {
+    const matchingRule = this.rules.find((rule) => rule.shouldRedirect(pathname))
+    if (!matchingRule) {
+      throw new Error(`No matching rule found for pathname: ${pathname}`)
+    }
+    return matchingRule.getRedirectPath(pathname, baseUrl)
+  }
+}
+
+/**
+ * アプリケーションで使用するリダイレクトルールのファクトリー関数
+ * すべてのリダイレクトルールを設定して返す
+ */
+export function createRedirectRules(): RedirectRule[] {
+  return [
+    // レガシーパスのリダイレクト
+    new LegacyPathRedirectRule('/projects', '/work'),
+    new LegacyPathRedirectRule('/ja/projects', '/ja/work'),
+    new LegacyPathRedirectRule('/oss', '/work'),
+    new LegacyPathRedirectRule('/ja/oss', '/ja/work'),
+    new LegacyPathRedirectRule('/articles', '/writing'),
+    new LegacyPathRedirectRule('/ja/articles', '/ja/writing'),
+
+    // microCMS posts API廃止に伴う移行（dev-notesは除外）
+    new DevNotesExclusionRedirectRule('/writing/', '/news/'),
+    new DevNotesExclusionRedirectRule('/ja/writing/', '/ja/news/'),
+  ]
+}


### PR DESCRIPTION
Exclude `/writing/dev-notes/` paths from redirection to fix incorrect navigation to `/news/`.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd305c11-39b8-4e03-b932-a2e4ac3b46ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bd305c11-39b8-4e03-b932-a2e4ac3b46ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

