### PR TITLE
feat: 登壇依頼フォームページとCTAの実装

### DIFF
--- a/src/app/ja/speaking-request/page.tsx
+++ b/src/app/ja/speaking-request/page.tsx
@@ -1,0 +1,30 @@
+import Container from '@/components/tailwindui/Container'
+import HubSpotForm from '@/components/ui/HubSpotForm'
+import PageHeader from '@/components/ui/PageHeader'
+
+export const metadata = {
+  title: '登壇依頼',
+  description: 'イベントやカンファレンスへの登壇依頼はこちらからお願いします。',
+}
+
+export default function SpeakingRequestPage() {
+  return (
+    <section className="pt-12 sm:pt-16 pb-8 sm:pb-12 bg-white dark:bg-zinc-900">
+      <Container>
+        <PageHeader
+          title="登壇依頼"
+          description="イベントやカンファレンスへの登壇をご依頼いただける場合は、以下のフォームにイベントの詳細をご記入ください。できるだけ早くご返信いたします。"
+        />
+
+        <div className="max-w-2xl mx-auto mt-8">
+          <HubSpotForm
+            formId={process.env.NEXT_PUBLIC_HUBSPOT_SPEAKING_FORM_ID || ''}
+            portalId={process.env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID}
+            className="bg-white dark:bg-zinc-900 rounded-lg p-6"
+          />
+        </div>
+      </Container>
+    </section>
+  )
+}
+

--- a/src/app/ja/speaking-request/page.tsx
+++ b/src/app/ja/speaking-request/page.tsx
@@ -7,6 +7,13 @@ export const metadata = {
   description: 'イベントやカンファレンスへの登壇依頼はこちらからお願いします。',
 }
 
+/**
+ * Renders the Japanese speaking request page with a header and an embedded HubSpot form.
+ *
+ * The HubSpot form's `formId` is taken from NEXT_PUBLIC_HUBSPOT_SPEAKING_FORM_ID (falls back to an empty string if undefined) and `portalId` from NEXT_PUBLIC_HUBSPOT_PORTAL_ID.
+ *
+ * @returns The page's JSX element.
+ */
 export default function SpeakingRequestPage() {
   return (
     <section className="pt-12 sm:pt-16 pb-8 sm:pb-12 bg-white dark:bg-zinc-900">
@@ -27,4 +34,3 @@ export default function SpeakingRequestPage() {
     </section>
   )
 }
-

--- a/src/app/speaking-request/page.tsx
+++ b/src/app/speaking-request/page.tsx
@@ -1,0 +1,30 @@
+import Container from '@/components/tailwindui/Container'
+import HubSpotForm from '@/components/ui/HubSpotForm'
+import PageHeader from '@/components/ui/PageHeader'
+
+export const metadata = {
+  title: 'Speaking Request',
+  description: 'Request Hidetaka Okamoto to speak at your event or conference.',
+}
+
+export default function SpeakingRequestPage() {
+  return (
+    <section className="pt-12 sm:pt-16 pb-8 sm:pb-12 bg-white dark:bg-zinc-900">
+      <Container>
+        <PageHeader
+          title="Speaking Request"
+          description="Interested in having me speak at your event or conference? Please fill out the form below with details about your event, and I'll get back to you as soon as possible."
+        />
+
+        <div className="max-w-2xl mx-auto mt-8">
+          <HubSpotForm
+            formId={process.env.NEXT_PUBLIC_HUBSPOT_SPEAKING_FORM_ID || ''}
+            portalId={process.env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID}
+            className="bg-white dark:bg-zinc-900 rounded-lg p-6"
+          />
+        </div>
+      </Container>
+    </section>
+  )
+}
+

--- a/src/app/speaking-request/page.tsx
+++ b/src/app/speaking-request/page.tsx
@@ -7,6 +7,16 @@ export const metadata = {
   description: 'Request Hidetaka Okamoto to speak at your event or conference.',
 }
 
+/**
+ * Renders the Speaking Request page with a header and embedded HubSpot form.
+ *
+ * Displays a PageHeader prompting users to request a speaking engagement and
+ * a centered HubSpot form. The form is configured using the
+ * NEXT_PUBLIC_HUBSPOT_SPEAKING_FORM_ID and NEXT_PUBLIC_HUBSPOT_PORTAL_ID
+ * environment variables.
+ *
+ * @returns The React element for the Speaking Request page.
+ */
 export default function SpeakingRequestPage() {
   return (
     <section className="pt-12 sm:pt-16 pb-8 sm:pb-12 bg-white dark:bg-zinc-900">
@@ -27,4 +37,3 @@ export default function SpeakingRequestPage() {
     </section>
   )
 }
-

--- a/src/components/containers/pages/SpeakingDetailPage.tsx
+++ b/src/components/containers/pages/SpeakingDetailPage.tsx
@@ -19,6 +19,17 @@ type SpeakingDetailPageProps = {
   relatedEvents?: BlogItem[]
 }
 
+/**
+ * Renders the speaking event detail page with metadata, full content, social sharing, a speaking-request CTA, profile, related events, and previous/next navigation.
+ *
+ * @param event - WordPress event object containing at least `id`, `date`, `slug`, `title.rendered`, and `content.rendered`
+ * @param lang - Language code used for localized labels (e.g., `'ja'` for Japanese)
+ * @param basePath - Base path for the speaking list used to build breadcrumb and navigation links
+ * @param previousEvent - Optional previous event used for navigation
+ * @param nextEvent - Optional next event used for navigation
+ * @param relatedEvents - Optional list of related blog/event items shown under "Other Recent Events"
+ * @returns The React element for the speaking event detail page
+ */
 export default function SpeakingDetailPage({
   event,
   lang,

--- a/src/components/containers/pages/SpeakingDetailPage.tsx
+++ b/src/components/containers/pages/SpeakingDetailPage.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import Container from '@/components/tailwindui/Container'
+import CTAButton from '@/components/ui/CTAButton'
 import DateDisplay from '@/components/ui/DateDisplay'
 import ProfileCard from '@/components/ui/ProfileCard'
 import RelatedArticles from '@/components/ui/RelatedArticles'
@@ -120,6 +121,23 @@ export default function SpeakingDetailPage({
           lang={lang}
           className="mt-12 pt-8 border-t border-zinc-200 dark:border-zinc-700"
         />
+
+        {/* 登壇依頼CTA */}
+        <div className="mt-12 pt-8 border-t border-zinc-200 dark:border-zinc-700">
+          <div className="bg-gradient-to-r from-indigo-50 to-purple-50 dark:from-indigo-950/30 dark:to-purple-950/30 rounded-xl p-8 text-center">
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-3">
+              {lang === 'ja' ? '登壇依頼をお待ちしています' : 'Interested in Having Me Speak?'}
+            </h2>
+            <p className="text-slate-600 dark:text-slate-400 mb-6 max-w-2xl mx-auto">
+              {lang === 'ja'
+                ? 'イベントやカンファレンスへの登壇をご依頼いただける場合は、お気軽にお問い合わせください。'
+                : 'If you would like me to speak at your event or conference, please feel free to reach out.'}
+            </p>
+            <CTAButton href={lang === 'ja' ? '/ja/speaking-request' : '/speaking-request'}>
+              {lang === 'ja' ? '登壇依頼はこちら' : 'Request Speaking Engagement'}
+            </CTAButton>
+          </div>
+        </div>
 
         {/* プロフィールカード */}
         <ProfileCard lang={lang} imageSrc="/images/profile.jpg" className="mt-12" />

--- a/src/components/containers/pages/SpeakingPage.tsx
+++ b/src/components/containers/pages/SpeakingPage.tsx
@@ -463,6 +463,18 @@ function createYearFilterGroup(
   }
 }
 
+/**
+ * Render the Speaking page content with searchable, filterable, and paginated-ready event listings.
+ *
+ * Renders a hero with localized title/description and a CTA, a responsive search and filter UI (desktop sidebar + mobile drawer),
+ * and a list of unified event cards merged from microCMS and WordPress sources. Filters include type, place, and year; search
+ * matches title, description, session title, and place. Events are shown newest-first and links are resolved per event source.
+ *
+ * @param lang - Locale code used for text content and local routing (e.g., 'ja' for Japanese)
+ * @param events - Array of unified event objects (announcements and reports) to display and filter
+ * @param basePath - Base path used to build internal links for report events
+ * @returns The page's React element tree containing the hero, filter controls, and filtered event grid (or an empty-state message)
+ */
 export default function SpeakingPageContent({
   lang,
   events,

--- a/src/components/containers/pages/SpeakingPage.tsx
+++ b/src/components/containers/pages/SpeakingPage.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useCallback, useMemo, useState } from 'react'
 import Container from '@/components/tailwindui/Container'
+import CTAButton from '@/components/ui/CTAButton'
 import DateDisplay from '@/components/ui/DateDisplay'
 import FilterItem from '@/components/ui/FilterItem'
 import MobileFilterButton from '@/components/ui/MobileFilterButton'
@@ -653,6 +654,13 @@ export default function SpeakingPageContent({
       <section className="pt-12 sm:pt-16 pb-8 sm:pb-12 bg-white dark:bg-zinc-900">
         <Container>
           <PageHeader title={title} description={description} />
+
+          {/* 登壇依頼CTA */}
+          <div className="mb-8 flex justify-center">
+            <CTAButton href={lang === 'ja' ? '/ja/speaking-request' : '/speaking-request'}>
+              {lang === 'ja' ? '登壇依頼はこちら' : 'Request Speaking Engagement'}
+            </CTAButton>
+          </div>
 
           {/* モバイル用検索バーとフィルターボタン */}
           <div className="lg:hidden mb-6 space-y-4">

--- a/src/components/ui/HubSpotForm.tsx
+++ b/src/components/ui/HubSpotForm.tsx
@@ -10,6 +10,15 @@ type HubSpotFormProps = {
   className?: string
 }
 
+/**
+ * Render a HubSpot form container and load/initialize HubSpot's forms script to mount the form.
+ *
+ * @param formId - The HubSpot form GUID to render.
+ * @param portalId - Optional HubSpot portal ID. If omitted, falls back to `process.env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID`.
+ * @param region - HubSpot region to use (e.g., `'na1'`); defaults to `'na1'`.
+ * @param className - Optional additional CSS class(es) applied to the form container.
+ * @returns A React element containing the HubSpot form container, or `null` if `formId` is falsy.
+ */
 export default function HubSpotForm({
   formId,
   portalId,
@@ -98,4 +107,3 @@ declare global {
     }
   }
 }
-

--- a/src/components/ui/HubSpotForm.tsx
+++ b/src/components/ui/HubSpotForm.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import Script from 'next/script'
+import { useEffect, useRef } from 'react'
+
+type HubSpotFormProps = {
+  formId: string
+  portalId?: string
+  region?: string
+  className?: string
+}
+
+export default function HubSpotForm({
+  formId,
+  portalId,
+  region = 'na1',
+  className = '',
+}: HubSpotFormProps) {
+  const formRef = useRef<HTMLDivElement>(null)
+  const scriptLoadedRef = useRef(false)
+
+  useEffect(() => {
+    // HubSpotスクリプトが読み込まれた後にフォームを初期化
+    if (scriptLoadedRef.current && formRef.current && window.hbspt) {
+      const targetId = formRef.current.id || `hubspot-form-${formId}`
+      if (!document.getElementById(targetId)) {
+        formRef.current.id = targetId
+      }
+
+      // 既存のフォームをクリアしてから新しいフォームを作成
+      if (formRef.current.querySelector('.hs-form')) {
+        return
+      }
+
+      window.hbspt.forms.create({
+        portalId: portalId || process.env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID,
+        formId,
+        target: `#${targetId}`,
+        region,
+      })
+    }
+  }, [formId, portalId, region])
+
+  const handleScriptLoad = () => {
+    scriptLoadedRef.current = true
+    // スクリプト読み込み後にフォームを初期化
+    if (formRef.current && window.hbspt) {
+      const targetId = formRef.current.id || `hubspot-form-${formId}`
+      if (!formRef.current.id) {
+        formRef.current.id = targetId
+      }
+
+      window.hbspt.forms.create({
+        portalId: portalId || process.env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID,
+        formId,
+        target: `#${targetId}`,
+        region,
+      })
+    }
+  }
+
+  // フォームIDが未設定の場合は何も表示しない
+  if (!formId) {
+    return null
+  }
+
+  return (
+    <>
+      <Script
+        type="text/javascript"
+        src="https://js.hsforms.net/forms/v2.js"
+        strategy="afterInteractive"
+        onLoad={handleScriptLoad}
+      />
+      <div
+        ref={formRef}
+        className={`hubspot-form-container ${className}`}
+        style={{
+          maxWidth: '100%',
+        }}
+      />
+    </>
+  )
+}
+
+// HubSpotの型定義を拡張
+declare global {
+  interface Window {
+    hbspt?: {
+      forms: {
+        create: (options: {
+          portalId?: string
+          formId: string
+          target: string
+          region?: string
+        }) => void
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
- HubSpotフォームコンポーネントを追加
- 登壇依頼フォームページを追加（英語版・日本語版）
- Speakingページに登壇依頼CTAを追加
- Speaking詳細ページに登壇依頼CTAを追加

レビューで指摘された問い合わせ・登壇依頼導線の欠如を解消

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated speaking request pages in English and Japanese with localized titles and descriptions.
  * Integrated HubSpot forms for submitting speaking engagement requests.
  * Added a reusable HubSpot form component to load and render forms client-side.
* **UI/Enhancements**
  * Added prominent call-to-action sections and buttons across speaking pages linking to the request forms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->