### PR TITLE
Category display implementation

### DIFF
--- a/src/components/containers/pages/DevNoteDetailPage.tsx
+++ b/src/components/containers/pages/DevNoteDetailPage.tsx
@@ -97,11 +97,24 @@ export default function DevNoteDetailPage({
               {note._embedded['wp:term']
                 .flat()
                 .filter((term) => term.taxonomy === 'category')
-                .map((category) => (
-                  <Tag key={category.id} variant="indigo" size="sm">
-                    {category.name}
-                  </Tag>
-                ))}
+                .map((category) => {
+                  // category.slugが既にエンコードされている可能性があるので、一度デコードしてからエンコード
+                  const normalizedSlug = category.slug.includes('%')
+                    ? decodeURIComponent(category.slug)
+                    : category.slug
+                  const categoryUrl = `/ja/writing/category/${encodeURIComponent(normalizedSlug)}`
+                  return (
+                    <Link key={category.id} href={categoryUrl}>
+                      <Tag
+                        variant="indigo"
+                        size="sm"
+                        className="cursor-pointer hover:bg-indigo-100 dark:hover:bg-indigo-900/30 transition-colors"
+                      >
+                        {category.name}
+                      </Tag>
+                    </Link>
+                  )
+                })}
             </div>
           )}
         </div>


### PR DESCRIPTION
Add clickable category links to `DevNoteDetailPage` to match the `BlogDetailPage` functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b43ef04-ba9f-45f1-8fe2-a2a273dce9a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b43ef04-ba9f-45f1-8fe2-a2a273dce9a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

