### PR TITLE
Ci task pre-push enforcement

### DIFF
--- a/.cursor/rules/pre-push-check.mdc
+++ b/.cursor/rules/pre-push-check.mdc
@@ -1,0 +1,112 @@
+---
+description: Push前の必須チェック
+alwaysApply: true
+---
+
+# Push前の必須チェック
+
+## ⚠️ CRITICAL: Push前の必須チェック
+
+**Cursor Cloud Agentがコードを編集・pushする際は、必ず以下のチェックを実行し、すべてパスすることを確認してからpushすること。**
+
+### 必須チェック項目
+
+1. **Lintチェック** (`npm run lint:check`)
+   - Biomeによるコード品質チェック
+   - フォーマット、リンターエラーの検出
+   - **失敗した場合は `npm run lint` で自動修正を試みる**
+
+2. **Unit Test** (`npm run test`)
+   - Vitestによるユニットテストの実行
+   - すべてのテストがパスすることを確認
+   - **失敗した場合はテストを修正する**
+
+3. **Buildチェック** (`npm run build`)
+   - TypeScriptコンパイルエラーの検出
+   - Next.jsビルドの成功確認
+   - **失敗した場合はTypeScriptエラーを修正する**
+
+### 実行手順
+
+**Push前に必ず以下を実行:**
+
+```bash
+# 1. Lintチェック
+npm run lint:check
+# 失敗した場合: npm run lint で自動修正
+
+# 2. Unit Test
+npm run test
+# 失敗した場合はテストを修正
+
+# 3. Buildチェック
+npm run build
+# 失敗した場合はTypeScriptエラーを修正
+
+# 4. すべてパスしたらpush
+git push
+```
+
+### Git Pre-push Hook
+
+プロジェクトにはGit pre-push hookが設定されており、push時に自動的に以下のチェックが実行されます：
+
+1. Lintチェック (`npm run lint:check`)
+2. Unit Test (`npm run test`)
+3. Buildチェック (`npm run build`)
+
+**すべてのチェックがパスしない限り、pushはブロックされます。**
+
+### AIエージェント向けの注意事項
+
+- **コードを編集した後、pushする前に必ず上記の3つのチェックを実行すること**
+- **チェックが失敗した場合は、pushせずにエラーを修正すること**
+- **Git pre-push hookが設定されているため、チェックをスキップしてpushすることはできない**
+- **チェックをスキップしたい場合は、`git push --no-verify` を使用できるが、これは推奨されない**
+
+### チェックをスキップする場合（非推奨）
+
+緊急時のみ、以下のコマンドでチェックをスキップできます：
+
+```bash
+git push --no-verify
+```
+
+**ただし、CIで失敗する可能性が高いため、通常は使用しないこと。**
+
+### トラブルシューティング
+
+**Lintエラーが発生した場合:**
+```bash
+npm run lint  # 自動修正を試みる
+npm run lint:check  # 再度チェック
+```
+
+**テストが失敗した場合:**
+```bash
+npm run test  # エラーメッセージを確認
+# テストファイルを修正
+npm run test  # 再度実行
+```
+
+**Buildエラーが発生した場合:**
+```bash
+npm run build  # エラーメッセージを確認
+# TypeScriptエラーを修正
+npm run build  # 再度実行
+```
+
+### チェックの目的
+
+これらのチェックは、以下の目的で実施されます：
+
+1. **コード品質の維持**: Lintチェックにより、コードスタイルと品質を統一
+2. **回帰の防止**: Unit Testにより、既存機能が壊れていないことを確認
+3. **型安全性の確保**: Buildチェックにより、TypeScriptの型エラーを検出
+4. **CIの失敗を防ぐ**: Push前にチェックすることで、GitHub ActionsでのCI失敗を防止
+
+### 参考
+
+- **CLAUDE.md**: プロジェクトの詳細な開発ガイドライン
+- **Git Hooks**: `.git/hooks/pre-push` に設定されているpre-push hook
+- **CI設定**: `.github/workflows/test.yml` に設定されているGitHub Actionsワークフロー

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,26 +412,50 @@ Before committing or pushing any code changes, you **MUST** run these commands a
 
 ```bash
 # 1. Run Biome linter/formatter check
-npm run lint
+npm run lint:check
 
-# 2. Build the project to verify no TypeScript errors
+# 2. Run unit tests
+npm run test
+
+# 3. Build the project to verify no TypeScript errors
 npm run build
 ```
 
 ### Why This Is Critical
 
-1. **Lint Check (`npm run lint`):**
+1. **Lint Check (`npm run lint:check`):**
    - Catches code quality issues, potential bugs, and style violations
    - Ensures accessibility (a11y) compliance
    - Validates TypeScript correctness
-   - **If lint fails:** Fix all issues before committing
+   - **If lint fails:** Run `npm run lint` to auto-fix issues, then re-check
 
-2. **Build Check (`npm run build`):**
+2. **Unit Test (`npm run test`):**
+   - Verifies all unit tests pass
+   - Prevents regression bugs
+   - Ensures code changes don't break existing functionality
+   - **If tests fail:** Fix failing tests before committing
+
+3. **Build Check (`npm run build`):**
    - Verifies TypeScript compilation succeeds
    - Catches type errors across the entire codebase
    - Ensures all imports and dependencies resolve correctly
    - Validates Next.js static generation works
    - **If build fails:** Fix all errors before committing
+
+### Git Pre-push Hook
+
+**A Git pre-push hook is configured** (`.git/hooks/pre-push`) that automatically runs all checks before allowing a push:
+
+1. Lint check (`npm run lint:check`)
+2. Unit tests (`npm run test`)
+3. Build check (`npm run build`)
+
+**If any check fails, the push will be blocked.** You must fix all issues before pushing.
+
+To manually run all checks:
+```bash
+npm run pre-push
+```
 
 ### Pre-commit Workflow
 
@@ -439,32 +463,41 @@ npm run build
 # 1. Make your code changes
 # ... edit files ...
 
-# 2. Run lint and fix issues
-npm run lint
+# 2. Run lint check
+npm run lint:check
+# If fails, run: npm run lint (auto-fix)
 
-# 3. Build and verify
+# 3. Run unit tests
+npm run test
+# Fix any failing tests
+
+# 4. Build and verify
 npm run build
+# Fix any TypeScript errors
 
-# 4. If both pass, commit your changes
+# 5. If all pass, commit your changes
 git add .
 git commit -m "feat: your commit message"
 
-# 5. Push to remote
+# 6. Push to remote (pre-push hook will run automatically)
 git push -u origin <branch-name>
 ```
 
 ### For AI Assistants
 
 **NEVER commit or push code without:**
-1. ✅ Running `npm run lint` and confirming it passes
-2. ✅ Running `npm run build` and confirming it succeeds
-3. ✅ Fixing any errors or warnings that appear
+1. ✅ Running `npm run lint:check` and confirming it passes
+2. ✅ Running `npm run test` and confirming all tests pass
+3. ✅ Running `npm run build` and confirming it succeeds
+4. ✅ Fixing any errors or warnings that appear
 
-**If either command fails:**
+**If any command fails:**
 - Read the error messages carefully
 - Fix all issues in the code
 - Re-run the checks
-- Only proceed when both commands succeed
+- Only proceed when all commands succeed
+
+**Note:** The Git pre-push hook will automatically block pushes if checks fail, but you should run checks manually before attempting to push to avoid delays.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:component:watch": "vitest --config vitest.component.config.ts",
     "test:component:ui": "vitest --ui --config vitest.component.config.ts",
     "test:component:coverage": "vitest run --coverage --config vitest.component.config.ts",
+    "pre-push": "npm run lint:check && npm run test && npm run build",
     "cf:build": "npx opennextjs-cloudflare build",
     "cf:preview": "npm run cf:build && npx wrangler dev",
     "cf:dev": "npm run cf:build && npx opennextjs-cloudflare preview",


### PR DESCRIPTION
Add Git pre-push hook and Cursor rules to enforce lint, unit test, and build checks before pushing.

This prevents CI task failures by ensuring code passes essential quality checks locally before being pushed to the remote repository.

---
<a href="https://cursor.com/background-agent?bcId=bc-89c8a25c-4016-43c1-9284-90319acbe1fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-89c8a25c-4016-43c1-9284-90319acbe1fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

