### PR TITLE
Add dev-notes and news to content negotiation

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -28,7 +28,7 @@ function acceptsMarkdown(request: NextRequest): boolean {
  */
 function isBlogPostUrl(pathname: string): boolean {
   // ブログ記事URLのパターン: /blog/[slug] または /ja/blog/[slug]
-  const blogPostPattern = /^\/(?:ja)?\/blog\/[^/]+$/
+  const blogPostPattern = /^\/(?:ja\/)?blog\/[^/]+$/
   // ページネーション、カテゴリページを除外
   const excludedPattern = /\/(page|category)\//
 


### PR DESCRIPTION
…news articles

- Add isDevNoteUrl() function to detect /writing/dev-notes/[slug] URLs
- Add getDevNoteMarkdownRewritePath() to rewrite dev-notes to API endpoints
- Add isNewsUrl() function to detect /news/[slug] URLs
- Add getNewsMarkdownRewritePath() to rewrite news to API endpoints
- Update handleContentNegotiation() to support all three content types
- Maintain consistent Vary: Accept header for proper cache separation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects dev-notes and news URLs and maps them to markdown-serving endpoints with language-aware query handling.
  * Content negotiation now skips non-Markdown requests early and applies proper rewrites for blogs, dev-notes, and news; preserves existing .md extension pathway.

* **Refactors**
  * Consolidated rewrite logic into a helper-based flow and normalized blog URL pattern handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->