### PR TITLE
Add ArticleSummary component to dev-notes, news, and event-reports pages (#102)

### DIFF
--- a/src/components/containers/pages/DevNoteDetailPage.tsx
+++ b/src/components/containers/pages/DevNoteDetailPage.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import Container from '@/components/tailwindui/Container'
+import ArticleSummary from '@/components/ui/ArticleSummary'
 import DateDisplay from '@/components/ui/DateDisplay'
 import ProfileCard from '@/components/ui/ProfileCard'
 import RelatedArticles from '@/components/ui/RelatedArticles'
@@ -114,6 +115,9 @@ export default function DevNoteDetailPage({
           title={note.title.rendered}
           language="ja"
         />
+
+        {/* 記事要約 (Built-in AI) */}
+        <ArticleSummary content={note.content.rendered} locale="ja" className="mt-6" />
 
         {/* コンテンツ */}
         <div

--- a/src/components/containers/pages/NewsDetailPage.tsx
+++ b/src/components/containers/pages/NewsDetailPage.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import Container from '@/components/tailwindui/Container'
+import ArticleSummary from '@/components/ui/ArticleSummary'
 import DateDisplay from '@/components/ui/DateDisplay'
 import ProfileCard from '@/components/ui/ProfileCard'
 import RelatedArticles from '@/components/ui/RelatedArticles'
@@ -87,6 +88,9 @@ export default function NewsDetailPage({
           title={product.title.rendered}
           language={lang}
         />
+
+        {/* 記事要約 (Built-in AI) */}
+        <ArticleSummary content={product.content.rendered} locale={lang} className="mt-6" />
 
         {/* コンテンツ */}
         <div

--- a/src/components/containers/pages/SpeakingDetailPage.tsx
+++ b/src/components/containers/pages/SpeakingDetailPage.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import Container from '@/components/tailwindui/Container'
+import ArticleSummary from '@/components/ui/ArticleSummary'
 import DateDisplay from '@/components/ui/DateDisplay'
 import ProfileCard from '@/components/ui/ProfileCard'
 import RelatedArticles from '@/components/ui/RelatedArticles'
@@ -105,6 +106,9 @@ export default function SpeakingDetailPage({
             </Tag>
           </div>
         </div>
+
+        {/* 記事要約 (Built-in AI) */}
+        <ArticleSummary content={event.content.rendered} locale={lang} className="mt-6" />
 
         {/* コンテンツ */}
         <div


### PR DESCRIPTION
## 概要

ArticleSummaryコンポーネントをdev-notes、news、event-reportsページに統合しました。BlogDetailPageで確立されたパターンに従って実装しています。

## 変更内容

- **DevNoteDetailPage.tsx**: ArticleSummaryコンポーネントを追加
  - ViewMarkdownButtonの後、コンテンツの前に配置
  - `content={note.content.rendered}` と `locale="ja"` を渡す
  - `className="mt-6"` を適用

- **NewsDetailPage.tsx**: ArticleSummaryコンポーネントを追加
  - ViewMarkdownButtonの後、コンテンツの前に配置
  - `content={product.content.rendered}` と `locale={lang}` を渡す
  - `className="mt-6"` を適用

- **SpeakingDetailPage.tsx**: ArticleSummaryコンポーネントを追加
  - 日付とタイプバッジの後、コンテンツの前に配置
  - `content={event.content.rendered}` と `locale={lang}` を渡す
  - `className="mt-6"` を適用

## チェック済み

- ✅ `npm run test` - すべてのテストがパス
- ✅ `npm run build` - ビルドが成功
- ✅ `npm run cf:build` - Cloudflareビルドが成功
- ✅ リンターエラーなし

## 関連Issue

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-generated article summaries now display on detail pages for news, development notes, and speaking events, offering quick content overviews with multi-language support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->