### PR TITLE
fix: 日本語ページの重複Headerを修正

### DIFF
--- a/src/app/ja/layout.tsx
+++ b/src/app/ja/layout.tsx
@@ -1,11 +1,5 @@
 import type { Metadata } from 'next'
 import { SITE_DESCRIPTION_JA, SITE_TITLE_JA } from '@/consts'
-import '../globals.css'
-import { ClarityAnalytics } from '@/components/ClarityAnalytics'
-import { DarkModeScript } from '@/components/DarkModeScript'
-import GoogleAnalytics from '@/components/GoogleAnalytics'
-import Footer from '@/components/tailwindui/Footer'
-import Header from '@/components/tailwindui/Header'
 
 export const metadata: Metadata = {
   title: SITE_TITLE_JA,
@@ -43,26 +37,5 @@ export const metadata: Metadata = {
 }
 
 export default function JapaneseLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html lang="ja" className="h-full antialiased">
-      <head>
-        <link rel="alternate" type="application/rss+xml" title="RSS" href="/projects/rss.xml" />
-      </head>
-      <body className="flex h-full flex-col bg-zinc-50 font-japanese japanese-typography dark:bg-black">
-        <GoogleAnalytics gaId="G-RV8PYHHYHN" />
-        <DarkModeScript />
-        <ClarityAnalytics />
-        <div className="fixed inset-0 flex justify-center sm:px-8">
-          <div className="flex w-full max-w-7xl lg:px-8">
-            <div className="w-full bg-white ring-1 ring-zinc-100 dark:bg-zinc-900 dark:ring-zinc-300/20" />
-          </div>
-        </div>
-        <div className="relative">
-          <Header />
-          <main>{children}</main>
-          <Footer />
-        </div>
-      </body>
-    </html>
-  )
+  return <>{children}</>
 }


### PR DESCRIPTION
## 問題

日本語ページ（`/ja/*`）でHeaderが2つ表示されていました。原因は、ルートレイアウト（`src/app/layout.tsx`）と日本語レイアウト（`src/app/ja/layout.tsx`）の両方に`Header`と`Footer`が含まれていたためです。

Next.js App Routerでは、ネストされたレイアウトは親レイアウトの`children`として描画されるため、`<html>`と`<body>`タグはルートレイアウトのみに存在すべきです。

## 修正内容

- `src/app/ja/layout.tsx`から`<html>`と`<body>`タグを削除
- `Header`と`Footer`コンポーネントを削除（ルートレイアウトに既に存在するため）
- `GoogleAnalytics`、`DarkModeScript`、`ClarityAnalytics`を削除（ルートレイアウトに既に存在するため）
- 固定背景の`<div>`を削除（ルートレイアウトに既に存在するため）
- `metadata`は保持（Next.jsがレイアウトのメタデータをマージするため）

## 注意事項

日本語ページ専用のフォント設定（`font-japanese japanese-typography`クラス）は今回の修正で削除されています。この問題は[Issue #118](https://github.com/hideokamoto/hidetaka.dev.2023/issues/118)で追跡しています。

## チェックリスト

- [x] Lintチェック (`npm run lint:check`)
- [x] テスト実行 (`npm run test`)
- [x] ビルドチェック (`npm run build`)
- [x] GitHub Issue作成 (#118)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the Japanese section layout by removing the header, footer, and analytics components.
  * Removed global styles and design elements from Japanese pages.
  * Dark mode functionality and RSS link removed from the Japanese section.
  * Pages now display with minimal structure, showing only content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->