### PR TITLE
fix: revert hacky Tailwind solution for ArticleActions visibility

### DIFF
--- a/src/components/ui/ArticleActions.tsx
+++ b/src/components/ui/ArticleActions.tsx
@@ -29,17 +29,27 @@ export default function ArticleActions({
   const isJa = lang.startsWith('ja')
   const summaryLabel = isJa ? 'この記事の操作' : 'Article actions'
 
+  const actions = (
+    <>
+      <ViewMarkdownButton slug={slug} basePath={basePath} title={title} language={lang} />
+      <ArticleSummary content={contentHtml} locale={lang} />
+      {showTranslation && (
+        <BlogTranslation locale={lang} contentSelector={translationContentSelector} />
+      )}
+    </>
+  )
+
   return (
     <section className={cn(DETAIL_PAGE_SECTION_CLASS, className)} aria-label={summaryLabel}>
       {/* 
         スマホ: <details>でドロップダウン
-        PC: summaryを隠し、アクションは常時表示（UAのdisplay:noneは詳細度の高いセレクタで上書き）
+        PC: <details>は使わず、アクションは常時表示（UAの <details> 挙動に依存しない）
       */}
-      <details className="group">
+      <details className="group sm:hidden">
         <summary
           className={cn(
             getActionButtonStyles('secondary'),
-            '[&::-webkit-details-marker]:hidden justify-between sm:hidden',
+            '[&::-webkit-details-marker]:hidden justify-between',
           )}
         >
           <span>{summaryLabel}</span>
@@ -57,14 +67,12 @@ export default function ArticleActions({
           </svg>
         </summary>
 
-        <div className="mt-3 flex flex-col gap-3 sm:mt-0 sm:flex sm:flex-row sm:flex-wrap sm:items-start sm:[details:not([open])_>_&]:flex">
-          <ViewMarkdownButton slug={slug} basePath={basePath} title={title} language={lang} />
-          <ArticleSummary content={contentHtml} locale={lang} />
-          {showTranslation && (
-            <BlogTranslation locale={lang} contentSelector={translationContentSelector} />
-          )}
-        </div>
+        <div className="mt-3 flex flex-col gap-3">{actions}</div>
       </details>
+
+      <div className="mt-3 hidden flex-col gap-3 sm:mt-0 sm:flex sm:flex-row sm:flex-wrap sm:items-start">
+        {actions}
+      </div>
     </section>
   )
 }


### PR DESCRIPTION
## 問題

PR #121で実装された `sm:[details:not([open])_>_&]:flex` というTailwind CSSの任意値構文による解決方法は、`<details>` 要素が閉じている場合のブラウザのデフォルト `display: none` を上書きできず、実際には動作していませんでした。

## 解決方法

コミット `27c9e6b` の変更を元に戻し、元の実装（変更前）に復元しました。

- **スマホ用**: `<details className="group sm:hidden">` - PCでは非表示
- **PC用**: 別の `<div className="hidden sm:flex ...">` - PCでは表示

## この実装の利点

1. **ハックを使わない** - Tailwindの任意値構文に依存しない
2. **ブラウザのデフォルト動作に依存しない** - `<details>` の `display: none` の問題を回避
3. **確実に動作する** - 各画面サイズで適切に表示される
4. **コードの意図が明確** - スマホ用とPC用が明確に分離されている

## 変更内容

- コミット `27c9e6b` の変更を元に戻しました
- 変更前の実装（PC用とスマホ用で要素を分離）に復元しました

Fixes #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized article action components (markdown view, summaries, translations) into a shared responsive layout. Desktop now displays these actions persistently for improved accessibility, while mobile maintains a collapsed dropdown for optimal space efficiency across all viewports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->