### PR TITLE
fix: OG画像生成APIの開発環境での503エラーを修正

### DIFF
--- a/src/app/api/thumbnail/dev-notes/[id]/route.tsx
+++ b/src/app/api/thumbnail/dev-notes/[id]/route.tsx
@@ -3,6 +3,10 @@ import { SITE_CONFIG } from '@/config'
 import type { WPThought } from '@/libs/dataSources/types'
 import { logger } from '@/libs/logger'
 
+// Wranglerのローカル開発セッションエラーメッセージ
+// Service Bindingがローカル開発セッションを見つけられない場合のエラーメッセージ
+const WRANGLER_LOCAL_DEV_SESSION_ERROR = "Couldn't find a local dev session"
+
 // getCloudflareContextを動的インポートで取得（OpenNextのビルドプロセスで正しく解決されるように）
 async function getCloudflareContext(
   options: { async: true } | { async?: false } = { async: false },
@@ -27,6 +31,64 @@ async function getCloudflareContext(
   }
 }
 
+// WordPress APIからdev-noteを取得
+async function fetchDevNoteFromWordPress(postId: number): Promise<{ title: string }> {
+  const wpResponse = await fetch(
+    `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes/${postId}?_fields=id,title`,
+  )
+
+  if (!wpResponse.ok) {
+    if (wpResponse.status === 404) {
+      throw new Response('Post not found', { status: 404 })
+    }
+    logger.error('WordPress API error', {
+      status: wpResponse.status,
+      statusText: wpResponse.statusText,
+      postId,
+    })
+    throw new Response('Failed to fetch post', { status: wpResponse.status })
+  }
+
+  const note: WPThought = await wpResponse.json()
+
+  if (!note.title?.rendered) {
+    throw new Response('Post title not found', { status: 500 })
+  }
+
+  return { title: note.title.rendered }
+}
+
+// Service Bindingのフォールバック付きでOG画像を生成
+async function generateOGImageWithFallback(
+  _title: string,
+  ogImageGenerator: { fetch: typeof fetch } | undefined,
+  ogImageUrl: URL,
+  headers: Headers,
+): Promise<Response> {
+  const fallbackFetch = () => fetch(ogImageUrl, { headers })
+  let response: Response
+
+  if (ogImageGenerator) {
+    response = await ogImageGenerator.fetch(ogImageUrl, { headers })
+
+    // Service Bindingが503エラーを返し、ローカル開発セッションが見つからない場合は通常のfetchにフォールバック
+    if (response.status === 503) {
+      const responseBodyText = await response
+        .clone()
+        .text()
+        .catch(() => '')
+      if (responseBodyText.includes(WRANGLER_LOCAL_DEV_SESSION_ERROR)) {
+        response = await fallbackFetch()
+      }
+    }
+  } else {
+    // Service Bindingが利用できない場合は通常のfetchを使用
+    response = await fallbackFetch()
+  }
+
+  return response
+}
+
 /**
  * WordPressのdev-notes投稿タイプ用のサムネイル画像生成API
  */
@@ -39,30 +101,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
       return new Response('Invalid post ID', { status: 404 })
     }
 
-    // WordPress REST APIから記事を取得
-    const wpResponse = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes/${postId}?_fields=id,title`,
-    )
-
-    if (!wpResponse.ok) {
-      if (wpResponse.status === 404) {
-        return new Response('Post not found', { status: 404 })
-      }
-      logger.error('WordPress API error', {
-        status: wpResponse.status,
-        statusText: wpResponse.statusText,
-        postId,
-      })
-      return new Response('Failed to fetch post', { status: wpResponse.status })
-    }
-
-    const note: WPThought = await wpResponse.json()
-
-    if (!note.title?.rendered) {
-      return new Response('Post title not found', { status: 500 })
-    }
-
-    const title = note.title.rendered
+    const { title } = await fetchDevNoteFromWordPress(postId)
     logger.log('Generating thumbnail for dev-note', { postId, title })
 
     const context = (await getCloudflareContext({ async: true })) as {
@@ -74,11 +113,6 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     const typedEnv = context.env
     const ogImageGenerator = typedEnv.OG_IMAGE_GENERATOR
 
-    if (!ogImageGenerator) {
-      logger.error('OG_IMAGE_GENERATOR Service Binding is not available')
-      return new Response('Service Binding not available', { status: 500 })
-    }
-
     const ogImageUrl = new URL('https://cf-ogp-image-gen-worker.wp-kyoto.workers.dev/generate')
     ogImageUrl.searchParams.set('title', title)
     ogImageUrl.searchParams.set('siteUrl', SITE_CONFIG.url)
@@ -89,7 +123,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
       headers.set('Authorization', `Bearer ${authToken}`)
     }
 
-    const response = await ogImageGenerator.fetch(ogImageUrl, { headers })
+    const response = await generateOGImageWithFallback(title, ogImageGenerator, ogImageUrl, headers)
 
     if (!response.ok) {
       logger.error('OG image generation failed', {
@@ -111,6 +145,9 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
       headers: responseHeaders,
     })
   } catch (error) {
+    if (error instanceof Response) {
+      return error
+    }
     logger.error('Error generating thumbnail image', {
       error,
       postId: id,


### PR DESCRIPTION
## 問題

開発環境（Next.js dev server）で、OG画像生成API（`/api/thumbnail/thoughts/[id]`）にアクセスすると、503エラー（Service Unavailable）が発生していました。

エラーメッセージ：
```
Couldn't find a local dev session for the "default" entrypoint of service "cf-ogp-image-gen-worker" to proxy to
```

## 原因

Cloudflare WorkersのService Bindingが、ローカル開発環境でOG画像生成Worker（`cf-ogp-image-gen-worker`）への接続を見つけられないため、Service Binding経由のfetchが503エラーを返していました。

## 解決方法

Service Bindingが503を返し、レスポンスボディに「Couldn't find a local dev session」が含まれる場合、通常のHTTP fetchにフォールバックするように修正しました。

- Service Bindingが503を返した場合、レスポンスボディを確認
- ローカル開発セッションが見つからない場合、通常のfetchにフォールバック
- 本番環境（Cloudflare Workers）では引き続きService Bindingを優先的に使用

## 変更内容

- `src/app/api/thumbnail/thoughts/[id]/route.tsx`を修正
- Service Bindingが利用できない場合や503エラーが発生した場合のフォールバック処理を追加

## 動作確認

- 開発環境で`/api/thumbnail/thoughts/17803`にアクセスし、正常にレスポンス（200 OK）が返ることを確認
- 本番環境では引き続きService Bindingを使用するため、既存の動作に影響なし

## 関連

- 開発環境と本番環境の両方でOG画像生成APIが正常に動作するようになります

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of thumbnail generation for thoughts, dev-notes, and events by adding robust fallback flows so processing continues when the primary image-generator is unavailable.
  * Added a development-friendly retry path that falls back to a standard fetch when a local dev session is missing.
  * Preserves existing error responses, header construction, and caching behavior while adding clearer error logging.

* **Refactor**
  * Centralized title fetching and image-generation logic for more consistent handling and easier maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->