### PR TITLE
Set up Chrome Translator API infrastructure

### DIFF
--- a/src/components/containers/pages/SpeakingDetailPage.tsx
+++ b/src/components/containers/pages/SpeakingDetailPage.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import Container from '@/components/tailwindui/Container'
-import ArticleSummary from '@/components/ui/ArticleSummary'
+import ArticleActions from '@/components/ui/ArticleActions'
 import DateDisplay from '@/components/ui/DateDisplay'
 import ProfileCard from '@/components/ui/ProfileCard'
 import RelatedArticles from '@/components/ui/RelatedArticles'
@@ -107,8 +107,17 @@ export default function SpeakingDetailPage({
           </div>
         </div>
 
-        {/* 記事要約 (Built-in AI) */}
-        <ArticleSummary content={event.content.rendered} locale={lang} className="mt-6" />
+        {/* 記事アクション（Markdown / 要約 / 翻訳） */}
+        <ArticleActions
+          lang={lang}
+          slug={event.slug}
+          basePath={basePath}
+          title={event.title.rendered}
+          contentHtml={event.content.rendered}
+          showTranslation
+          translationContentSelector="article"
+          className="mt-6"
+        />
 
         {/* コンテンツ */}
         <div


### PR DESCRIPTION
fix: #103

Replace ArticleSummary with ArticleActions in SpeakingDetailPage to provide both summarization and translation functionality for event reports.

Changes:
- Replace ArticleSummary import with ArticleActions
- Update component usage to include translation support
- Enable showTranslation prop and set translationContentSelector to "article"

This change automatically applies to:
- /event-reports/[slug] (English)
- /ja/event-reports/[slug] (Japanese)
- /ja/events/[slug] (Japanese)

Related to Chrome Translator API implementation (PR #115, #116)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Enhanced speaking detail page rendering with improved content display and translation action handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->