### PR TITLE
fix: enable translation for Dev Notes and News pages

### DIFF
--- a/src/components/containers/pages/DevNoteDetailPage.tsx
+++ b/src/components/containers/pages/DevNoteDetailPage.tsx
@@ -113,13 +113,15 @@ export default function DevNoteDetailPage({
           )}
         </div>
 
-        {/* 記事アクション（Markdown / 要約） */}
+        {/* 記事アクション（Markdown / 要約 / 翻訳） */}
         <ArticleActions
           lang={lang}
           slug={note.slug}
           basePath={basePath}
           title={note.title.rendered}
           contentHtml={note.content.rendered}
+          showTranslation
+          translationContentSelector="article"
         />
 
         {/* コンテンツ */}

--- a/src/components/containers/pages/NewsDetailPage.tsx
+++ b/src/components/containers/pages/NewsDetailPage.tsx
@@ -86,13 +86,15 @@ export default function NewsDetailPage({
           />
         </div>
 
-        {/* 記事アクション（Markdown / 要約） */}
+        {/* 記事アクション（Markdown / 要約 / 翻訳） */}
         <ArticleActions
           lang={lang}
           slug={product.slug}
           basePath={basePath}
           title={product.title.rendered}
           contentHtml={product.content.rendered}
+          showTranslation
+          translationContentSelector="article"
         />
 
         {/* コンテンツ */}


### PR DESCRIPTION
Add missing showTranslation and translationContentSelector props to ArticleActions component in DevNoteDetailPage and NewsDetailPage.

Changes:
- DevNoteDetailPage: Enable translation support for /ja/writing/dev-notes/[slug]
- NewsDetailPage: Enable translation support for /ja/news/[slug]

Both pages now provide:
- Markdown view
- Article summarization (Chrome Summarizer API)
- Translation (Chrome Translator API) ← newly enabled

This fixes the missing translation functionality reported for:
- https://hidetaka.dev/ja/writing/dev-notes/[slug]
- https://hidetaka.dev/ja/news/[slug]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Translation features now enabled for articles and developer notes, allowing users to view content in alternative languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->