### PR TITLE
Fix internal links opening in new tabs

### DIFF
--- a/src/components/containers/pages/WritingPage.tsx
+++ b/src/components/containers/pages/WritingPage.tsx
@@ -26,8 +26,20 @@ function UnifiedWritingCard({ item, lang }: { item: WritingItem; lang: string })
   const date = new Date(datetime)
   const imageUrl = item.image
 
-  // サイト内リンクかどうかを判定（/で始まるパス、または hidetaka.dev ドメイン）
-  const isInternalLink = href.startsWith('/') || href.includes('hidetaka.dev')
+  // サイト内リンクかどうかを判定
+  const isInternalLink = (() => {
+    // 相対パス（/で始まる）は常にサイト内リンク
+    if (href.startsWith('/')) return true
+
+    try {
+      // URLをパースしてホスト名をチェック
+      const url = new URL(href)
+      return url.hostname === 'hidetaka.dev' || url.hostname === 'www.hidetaka.dev'
+    } catch {
+      // パースに失敗した場合（相対パスの可能性）はサイト内リンクとして扱う
+      return true
+    }
+  })()
 
   const CardContent = (
     <article className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-white transition-all hover:border-indigo-300 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-700">


### PR DESCRIPTION
- Modified UnifiedWritingCard component to detect internal vs external links
- Internal links (starting with / or containing hidetaka.dev) now open in same tab
- External links (Zenn, Qiita, Dev.to, etc.) continue to open in new tab
- Fixes issue where Dev Notes articles were incorrectly opening in new tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Internal links now open in the current tab while external links open in a new tab with safe link attributes.
  * Preserves existing visual styling when links are wrapped.
  * Improves handling of malformed or ambiguous URLs by treating them as internal to avoid unexpected new-tab navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->