### PR TITLE
Remove MicroCMS event API calls from components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,7 +266,7 @@ MicroCMSProjectsRecord    // Work/projects
 ```
 
 **Secondary Sources:** Multi-source feed aggregation
-- WordPress REST API (`thoughts.ts`, `events.ts`)
+- WordPress REST API (`wordpress.ts`, `thoughts.ts`, `events.ts`)
 - Dev.to API (`devto.ts`)
 - Qiita RSS (`qiita.ts`)
 - Zenn RSS (`zenn.ts`)


### PR DESCRIPTION
- Remove reference to deprecated MicroCMSEventsRecord type
- Update content types list to only show MicroCMSProjectsRecord
- Clarify that WordPress events come from events.ts data source
- Add events.ts to WordPress REST API secondary sources section
- Document that all event data now comes from WordPress exclusively

This reflects the completed migration from MicroCMS events to WordPress-only event management, which simplifies the event data flow and eliminates the need for MicroCMS event-specific code in consumer components.