### PR TITLE
Add Cloudflare AI model configuration to wrangler.jsonc

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,6 +3,9 @@
   "main": ".open-next/worker.js",
   "compatibility_date": "2025-08-16",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "vars": {
+    "CLOUDFLARE_AI_MODEL_NAME": "@cf/openai/gpt-oss-20b"
+  },
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"


### PR DESCRIPTION
## Summary
This change adds Cloudflare AI model configuration to the Wrangler configuration file, enabling the use of OpenAI's GPT OSS 20B model within the application.

## Changes
- Added `vars` section to `wrangler.jsonc` with `CLOUDFLARE_AI_MODEL_NAME` environment variable
- Set the model to `@cf/openai/gpt-oss-20b` for AI-powered features

## Details
The new environment variable makes the Cloudflare AI model name available to the worker application, allowing it to interact with Cloudflare's AI inference API using the specified open-source GPT model. This configuration will be accessible throughout the application via the `CLOUDFLARE_AI_MODEL_NAME` variable.