### PR TITLE
Add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ out/
 
 # Dependencies
 node_modules/
+package-lock.json
 
 # Environment variables
 .env


### PR DESCRIPTION
## Summary
Updated the `.gitignore` file to exclude `package-lock.json` from version control.

## Changes
- Added `package-lock.json` to the ignored files list in `.gitignore`

## Rationale
This prevents the npm lockfile from being committed to the repository, allowing individual developers to maintain their own dependency resolution while keeping the repository focused on source code and configuration files.

https://claude.ai/code/session_01KG9gZfYm9MmSjVv7mjBKEj