### PR TITLE
feat: add project status model and badge display for work items

### DIFF
--- a/src/components/containers/pages/WorkPage.tsx
+++ b/src/components/containers/pages/WorkPage.tsx
@@ -837,7 +837,7 @@ export default function WorkPageContent({
                 {(filterCategory === 'all' || filterCategory === 'projects') &&
                   categorizedProjects.active.length > 0 && (
                     <div className="mb-12">
-                      <h3 className="mb-6 text-2xl font-bold text-slate-900 dark:text-white">
+                      <h3 className="mb-6 text-xl sm:text-2xl lg:text-3xl font-bold text-slate-900 dark:text-white">
                         {lang === 'ja' ? 'プロジェクト' : 'Projects'}
                       </h3>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
@@ -852,7 +852,7 @@ export default function WorkPageContent({
                 {(filterCategory === 'all' || filterCategory === 'books') &&
                   categorizedBooks.active.length > 0 && (
                     <div className="mb-12">
-                      <h3 className="mb-6 text-2xl font-bold text-slate-900 dark:text-white">
+                      <h3 className="mb-6 text-xl sm:text-2xl lg:text-3xl font-bold text-slate-900 dark:text-white">
                         {lang === 'ja' ? '書籍' : 'Books'}
                       </h3>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
@@ -867,7 +867,7 @@ export default function WorkPageContent({
                 {(filterCategory === 'all' || filterCategory === 'open-source') &&
                   categorizedOSS.active.length > 0 && (
                     <div className="mb-12">
-                      <h3 className="mb-6 text-2xl font-bold text-slate-900 dark:text-white">
+                      <h3 className="mb-6 text-xl sm:text-2xl lg:text-3xl font-bold text-slate-900 dark:text-white">
                         {lang === 'ja' ? 'オープンソース' : 'Open Source'}
                       </h3>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
@@ -882,7 +882,7 @@ export default function WorkPageContent({
                 {(filterCategory === 'all' || filterCategory === 'oss-contribution') &&
                   categorizedOSSContributions.active.length > 0 && (
                     <div className="mb-12">
-                      <h3 className="mb-6 text-2xl font-bold text-slate-900 dark:text-white">
+                      <h3 className="mb-6 text-xl sm:text-2xl lg:text-3xl font-bold text-slate-900 dark:text-white">
                         {lang === 'ja' ? 'OSS貢献' : 'OSS Contributions'}
                       </h3>
                       <div className="space-y-3">
@@ -909,7 +909,7 @@ export default function WorkPageContent({
                 {(filterCategory === 'all' || filterCategory === 'projects') &&
                   categorizedProjects.archived.length > 0 && (
                     <div className="mb-12">
-                      <h3 className="mb-6 text-2xl font-bold text-slate-900 dark:text-white">
+                      <h3 className="mb-6 text-xl sm:text-2xl lg:text-3xl font-bold text-slate-900 dark:text-white">
                         {lang === 'ja' ? 'プロジェクト' : 'Projects'}
                       </h3>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
@@ -924,7 +924,7 @@ export default function WorkPageContent({
                 {(filterCategory === 'all' || filterCategory === 'books') &&
                   categorizedBooks.archived.length > 0 && (
                     <div className="mb-12">
-                      <h3 className="mb-6 text-2xl font-bold text-slate-900 dark:text-white">
+                      <h3 className="mb-6 text-xl sm:text-2xl lg:text-3xl font-bold text-slate-900 dark:text-white">
                         {lang === 'ja' ? '書籍' : 'Books'}
                       </h3>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
@@ -939,7 +939,7 @@ export default function WorkPageContent({
                 {(filterCategory === 'all' || filterCategory === 'open-source') &&
                   categorizedOSS.archived.length > 0 && (
                     <div className="mb-12">
-                      <h3 className="mb-6 text-2xl font-bold text-slate-900 dark:text-white">
+                      <h3 className="mb-6 text-xl sm:text-2xl lg:text-3xl font-bold text-slate-900 dark:text-white">
                         {lang === 'ja' ? 'オープンソース' : 'Open Source'}
                       </h3>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
@@ -954,7 +954,7 @@ export default function WorkPageContent({
                 {(filterCategory === 'all' || filterCategory === 'oss-contribution') &&
                   categorizedOSSContributions.archived.length > 0 && (
                     <div className="mb-12">
-                      <h3 className="mb-6 text-2xl font-bold text-slate-900 dark:text-white">
+                      <h3 className="mb-6 text-xl sm:text-2xl lg:text-3xl font-bold text-slate-900 dark:text-white">
                         {lang === 'ja' ? 'OSS貢献' : 'OSS Contributions'}
                       </h3>
                       <div className="space-y-3">

--- a/src/components/containers/pages/WorkPage.tsx
+++ b/src/components/containers/pages/WorkPage.tsx
@@ -21,7 +21,9 @@ import type { WordPressPluginDetail } from '@/libs/dataSources/wporg'
 import type { MicroCMSProjectsRecord } from '@/libs/microCMS/types'
 import {
   getMicroCMSProjectStatus,
+  getStatusBadgeVariant,
   getStatusFromLastUpdate,
+  getStatusLabel,
   isActiveStatus,
   type UnifiedProjectStatus,
 } from '@/libs/projectStatus.utils'
@@ -53,35 +55,6 @@ function sortByDateDesc<T>(items: T[], getDate: (item: T) => string): T[] {
   })
 }
 
-// Map project status to badge variant
-function getStatusBadgeVariant(status: UnifiedProjectStatus): 'green' | 'gray' {
-  return status === 'active' ? 'green' : 'gray'
-}
-
-// Get status label for display
-function getStatusLabel(status: UnifiedProjectStatus, lang: string): string {
-  // Ensure status is a string for safety
-  if (!status || typeof status !== 'string') {
-    return lang === 'ja' ? 'アクティブ' : 'Active'
-  }
-
-  if (lang === 'ja') {
-    switch (status) {
-      case 'active':
-        return 'アクティブ'
-      case 'deprecated':
-        return '非推奨'
-      case 'archived':
-        return 'アーカイブ'
-      case 'completed':
-        return '完了'
-      default:
-        // Fallback to English label for unknown status
-        break
-    }
-  }
-  return status.charAt(0).toUpperCase() + status.slice(1)
-}
 
 // OSSアイテムをフィルタリングするヘルパー関数
 export function filterOSSItem(item: OSSItem, matchesSearch: (text: string) => boolean): boolean {

--- a/src/components/containers/pages/WorkPage.tsx
+++ b/src/components/containers/pages/WorkPage.tsx
@@ -55,7 +55,6 @@ function sortByDateDesc<T>(items: T[], getDate: (item: T) => string): T[] {
   })
 }
 
-
 // OSSアイテムをフィルタリングするヘルパー関数
 export function filterOSSItem(item: OSSItem, matchesSearch: (text: string) => boolean): boolean {
   if (item.type === 'project') {

--- a/src/libs/componentStyles.utils.ts
+++ b/src/libs/componentStyles.utils.ts
@@ -11,21 +11,21 @@ const BADGE_VARIANT_STYLES = {
   default: 'border-zinc-200 bg-zinc-50/80 dark:border-zinc-500/30 dark:bg-zinc-500/10',
   indigo: 'border-indigo-200 bg-indigo-50/80 dark:border-indigo-500/30 dark:bg-indigo-500/10',
   green: 'border-green-200 bg-green-50/80 dark:border-green-500/30 dark:bg-green-500/10',
-  gray: 'border-gray-200 bg-gray-50/80 dark:border-gray-500/30 dark:bg-gray-500/10',
+  gray: 'border-slate-300 bg-slate-100/80 dark:border-slate-600/50 dark:bg-slate-700/20',
 } as const
 
 const BADGE_TEXT_STYLES = {
   default: 'text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-400',
   indigo: 'text-sm font-semibold uppercase tracking-wider text-indigo-700 dark:text-indigo-400',
   green: 'text-sm font-semibold uppercase tracking-wider text-green-700 dark:text-green-400',
-  gray: 'text-sm font-semibold uppercase tracking-wider text-gray-700 dark:text-gray-400',
+  gray: 'text-sm font-semibold uppercase tracking-wider text-slate-700 dark:text-slate-400',
 } as const
 
 const BADGE_DOT_STYLES = {
   default: 'h-2 w-2 rounded-full bg-zinc-500 animate-pulse',
   indigo: 'h-2 w-2 rounded-full bg-indigo-500 animate-pulse',
   green: 'h-2 w-2 rounded-full bg-green-500 animate-pulse',
-  gray: 'h-2 w-2 rounded-full bg-gray-500 animate-pulse',
+  gray: 'h-2 w-2 rounded-full bg-slate-400 animate-pulse',
 } as const
 
 /**

--- a/src/libs/projectStatus.utils.ts
+++ b/src/libs/projectStatus.utils.ts
@@ -3,7 +3,7 @@
  * Determines active/deprecated status based on last update date
  */
 
-import type { MicroCMSProjectStatus } from './microCMS/types'
+import type { MicroCMSProjectStatus } from '@/libs/microCMS/types'
 
 /**
  * Status threshold in months (6 months)

--- a/src/libs/projectStatus.utils.ts
+++ b/src/libs/projectStatus.utils.ts
@@ -83,13 +83,24 @@ export function getStatusBadgeVariant(status: UnifiedProjectStatus): 'green' | '
  * @returns Localized status label
  */
 export function getStatusLabel(status: UnifiedProjectStatus, lang: string): string {
-  const labels: Record<UnifiedProjectStatus, Record<string, string>> = {
+  const isJapanese = lang.startsWith('ja')
+
+  if (!status || typeof status !== 'string') {
+    return isJapanese ? 'アクティブ' : 'Active'
+  }
+
+  const labels: Record<string, Record<string, string>> = {
     active: { ja: 'アクティブ', en: 'Active' },
     deprecated: { ja: '非推奨', en: 'Deprecated' },
     archived: { ja: 'アーカイブ', en: 'Archived' },
     completed: { ja: '完了', en: 'Completed' },
   }
 
-  const isJapanese = lang.startsWith('ja')
-  return labels[status][isJapanese ? 'ja' : 'en']
+  const entry = labels[status]
+  if (!entry) {
+    const capitalized = status.charAt(0).toUpperCase() + status.slice(1)
+    return capitalized
+  }
+
+  return entry[isJapanese ? 'ja' : 'en']
 }

--- a/src/libs/projectStatus.utils.ts
+++ b/src/libs/projectStatus.utils.ts
@@ -66,3 +66,30 @@ export function getStatusFromLastUpdate(lastUpdated: string | Date): 'active' | 
 export function getMicroCMSProjectStatus(status?: MicroCMSProjectStatus): UnifiedProjectStatus {
   return status || 'active'
 }
+
+/**
+ * Get the badge variant for a given status
+ * @param status - Project status
+ * @returns Badge variant: 'green' for active, 'gray' for others
+ */
+export function getStatusBadgeVariant(status: UnifiedProjectStatus): 'green' | 'gray' {
+  return status === 'active' ? 'green' : 'gray'
+}
+
+/**
+ * Get localized status label
+ * @param status - Project status
+ * @param lang - Language code ('ja' or 'en')
+ * @returns Localized status label
+ */
+export function getStatusLabel(status: UnifiedProjectStatus, lang: string): string {
+  const labels: Record<UnifiedProjectStatus, Record<string, string>> = {
+    active: { ja: 'アクティブ', en: 'Active' },
+    deprecated: { ja: '非推奨', en: 'Deprecated' },
+    archived: { ja: 'アーカイブ', en: 'Archived' },
+    completed: { ja: '完了', en: 'Completed' },
+  }
+
+  const isJapanese = lang.startsWith('ja')
+  return labels[status][isJapanese ? 'ja' : 'en']
+}


### PR DESCRIPTION
- Add MicroCMSProjectStatus type ('active' | 'deprecated' | 'archived' | 'completed')
- Update MicroCMSProjectsRecord to include optional status field
- Add 'green' and 'gray' variants to Badge component for status visualization
- Create projectStatus.utils.ts with status determination logic:
  - getStatusFromLastUpdate() determines status based on 6-month threshold
  - getStatusLabel() provides localized status labels
  - Helper utilities for status checking and badge variant mapping
- Update WorkPage to display status badges on all work items:
  - microCMS projects show explicit status field
  - npm packages auto-determine status from last publish date
  - WordPress plugins auto-determine status from last_updated date
- Implement Active Products and Archive section splitting:
  - Active Products section shows items with 'active' status
  - Archive section groups deprecated, archived, and completed items
  - Maintains existing category filtering within each section
  - Bilingual support for both English and Japanese work pages
- Supports backward compatibility: projects without explicit status default to 'active'

https://claude.ai/code/session_01Titf39RzRoKJzwH1Q9YDWK