### PR TITLE
fix: 静的プリレンダで壊れる Link のイベントハンドラをクライアント境界へ分離

### DIFF
--- a/src/components/BlogPosts/TransformedBlogContent.property.component.test.tsx
+++ b/src/components/BlogPosts/TransformedBlogContent.property.component.test.tsx
@@ -148,7 +148,7 @@ describe('TransformedBlogContent - Property-Based Tests', () => {
             const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
             // 極端に大きなHTMLを生成してエラーを誘発
-            const extremeHtml = '<p>'.repeat(10000) + 'https://example.com' + '</p>'.repeat(10000)
+            const extremeHtml = `${'<p>'.repeat(10000)}https://example.com${'</p>'.repeat(10000)}`
 
             const thought: WPThought = {
               id,

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -23,9 +23,6 @@ function getVariantStyle(variant: BadgeVariant): React.CSSProperties {
         color: 'var(--color-bg)',
         borderColor: 'var(--color-ink)',
       }
-    case 'status':
-    case 'gray':
-    case 'default':
     default:
       return {}
   }

--- a/src/components/ui/MonochromeLink.tsx
+++ b/src/components/ui/MonochromeLink.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import Link from 'next/link'
+import type { CSSProperties, ReactNode } from 'react'
+
+type MonochromeLinkProps = {
+  href: string
+  style: CSSProperties
+  children: ReactNode
+}
+
+export default function MonochromeLink({ href, style, children }: MonochromeLinkProps) {
+  return (
+    <Link
+      href={href}
+      style={style}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.color = 'var(--color-accent)'
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.color = 'var(--color-muted)'
+      }}
+    >
+      {children}
+    </Link>
+  )
+}

--- a/src/components/ui/Pagination.tsx
+++ b/src/components/ui/Pagination.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link'
+import MonochromeLink from '@/components/ui/MonochromeLink'
 import {
   calculateNextPage,
   calculatePrevPage,
@@ -56,18 +56,9 @@ export default function Pagination({ currentPage, totalPages, basePath, lang }: 
       }}
     >
       {prevPage ? (
-        <Link
-          href={prevHref}
-          style={monoStyle}
-          onMouseEnter={(e) => {
-            ;(e.currentTarget as HTMLAnchorElement).style.color = 'var(--color-accent)'
-          }}
-          onMouseLeave={(e) => {
-            ;(e.currentTarget as HTMLAnchorElement).style.color = 'var(--color-muted)'
-          }}
-        >
+        <MonochromeLink href={prevHref} style={monoStyle}>
           ← {prevText}
-        </Link>
+        </MonochromeLink>
       ) : (
         <span style={{ ...monoStyle, opacity: 0.4 }}>← {prevText}</span>
       )}
@@ -77,18 +68,9 @@ export default function Pagination({ currentPage, totalPages, basePath, lang }: 
       </span>
 
       {nextPage ? (
-        <Link
-          href={nextHref}
-          style={monoStyle}
-          onMouseEnter={(e) => {
-            ;(e.currentTarget as HTMLAnchorElement).style.color = 'var(--color-accent)'
-          }}
-          onMouseLeave={(e) => {
-            ;(e.currentTarget as HTMLAnchorElement).style.color = 'var(--color-muted)'
-          }}
-        >
+        <MonochromeLink href={nextHref} style={monoStyle}>
           {nextText} →
-        </Link>
+        </MonochromeLink>
       ) : (
         <span style={{ ...monoStyle, opacity: 0.4 }}>{nextText} →</span>
       )}

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link'
+import MonochromeLink from '@/components/ui/MonochromeLink'
 
 type SectionHeaderProps = {
   title: string
@@ -110,7 +110,7 @@ export default function SectionHeader({
         )}
       </div>
       {actionLabel && actionHref && (
-        <Link
+        <MonochromeLink
           href={actionHref}
           style={{
             gridColumn: 'span 3',
@@ -123,15 +123,9 @@ export default function SectionHeader({
             transition: 'color var(--duration-fast)',
             textDecoration: 'none',
           }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.color = 'var(--color-accent)'
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.color = 'var(--color-muted)'
-          }}
         >
           {actionLabel} →
-        </Link>
+        </MonochromeLink>
       )}
     </div>
   )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

GitHub Actions の `next build` が `/ja/blog` のプリレンダーで失敗していました。原因はサーバーコンポーネントから `next/link` に `onMouseEnter` / `onMouseLeave` を渡しており、静的生成時にシリアライズできないためです。

## 変更内容

- `MonochromeLink` クライアントコンポーネントを追加し、ホバーでアクセント色に変える処理をそこに集約
- `Pagination` と `SectionHeader` からイベントハンドラ付き `Link` を置き換え
- `Badge` の `switch` で `default` と重複していたフォールスルーケースを整理
- プロパティテストの文字列連結をテンプレートリテラルに変更（Biome の info 解消）

## 検証

ローカルで `pnpm run lint:check`、`pnpm run test`、`pnpm run test:coverage`、`MICROCMS_API_MODE=mock pnpm run build`、`MICROCMS_API_MODE=mock pnpm run cf:build` を実行し、すべて成功しました。

## メモ

リポジトリには CircleCI 設定がなく、CI は GitHub Actions のみです。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe26be56-a98f-4bd8-9fd1-ecc808d42fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe26be56-a98f-4bd8-9fd1-ecc808d42fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

