### PR TITLE
feat: UI全面リニューアル - デザインシステム導入とコンポーネント刷新 (renewal branch)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,11 @@
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 
+body {
+  font-feature-settings: "palt";
+  -webkit-font-smoothing: antialiased;
+}
+
 /* Blog content styling */
 .blog-content {
   @apply text-base sm:text-lg;
@@ -123,3 +128,287 @@
   }
 }
 
+/* ── Design System Tokens ─────────────────────────────── */
+:root {
+  /* Font aliases: bridge Tailwind font stacks to DS var names */
+  --font-sans: var(--font-zen-kaku), var(--font-inter-tight), system-ui, sans-serif;
+  --font-serif: var(--font-shippori), var(--font-inter-tight), Georgia, serif;
+  --font-mono: var(--font-jetbrains), ui-monospace, monospace;
+
+  --color-bg:        #f4f2ee;
+  --color-surface:   #efece7;
+  --color-surface-2: #e8e4dd;
+  --color-ink:       #141312;
+  --color-ink-2:     #2a2926;
+  --color-muted:     #6b6863;
+  --color-line:      rgba(20,19,18,.10);
+  --color-line-strong: rgba(20,19,18,.20);
+  --color-accent:    #ff5b29;
+  --color-accent-fg: #ffffff;
+  --color-accent-subtle: rgba(255,91,41,.10);
+
+  --space-1:  4px;  --space-2:  8px;  --space-3:  12px; --space-4:  16px;
+  --space-5:  20px; --space-6:  24px; --space-7:  32px; --space-8:  40px;
+  --space-9:  48px; --space-10: 64px; --space-11: 80px; --space-12: 96px;
+  --space-13: 120px;--space-14: 160px;
+
+  --text-2xs: 10px; --text-xs: 11px; --text-sm: 13px; --text-base: 15px;
+  --text-md: 18px;  --text-lg: 22px; --text-xl: 28px; --text-2xl: 36px;
+  --text-3xl: 48px; --text-4xl: 64px; --text-5xl: 96px;
+
+  --leading-tight:  1.1;  --leading-snug: 1.35; --leading-normal: 1.65; --leading-loose: 1.9;
+  --tracking-tight: -0.025em; --tracking-wide: 0.06em; --tracking-wider: 0.14em; --tracking-widest: 0.22em;
+
+  --page-max: 1440px; --page-px: 64px; --page-narrow: 1100px; --page-content: 720px;
+  --grid-gap: 24px;
+
+  --ease-out: cubic-bezier(.16,1,.3,1);
+  --duration-fast: 120ms; --duration-base: 200ms; --duration-slow: 400ms;
+}
+
+/* Bridge: support both .dark class (Tailwind) and [data-theme="dark"] (DS) */
+.dark, [data-theme="dark"] {
+  --color-bg:        #0d0c0b;
+  --color-surface:   #141312;
+  --color-surface-2: #1d1c1a;
+  --color-ink:       #f2efe9;
+  --color-ink-2:     #d8d4cc;
+  --color-muted:     #86827a;
+  --color-line:      rgba(242,239,233,.11);
+  --color-line-strong: rgba(242,239,233,.19);
+}
+
+/* ── DS Components ────────────────────────────────────── */
+
+/* Buttons */
+.ds-btn {
+  display: inline-flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-4) var(--space-7);
+  font-family: var(--font-sans); font-size: var(--text-sm); font-weight: 700;
+  letter-spacing: var(--tracking-wide); border: 1px solid transparent;
+  cursor: pointer; white-space: nowrap; text-decoration: none;
+  transition: background var(--duration-fast), color var(--duration-fast), border-color var(--duration-fast);
+}
+.ds-btn--primary { background: var(--color-ink); color: var(--color-bg); border-color: var(--color-ink); }
+.ds-btn--primary:hover { background: var(--color-accent); border-color: var(--color-accent); }
+.ds-btn--primary::after { content: "→"; margin-left: var(--space-1); }
+.ds-btn--secondary { background: transparent; color: var(--color-ink); border-color: var(--color-ink); }
+.ds-btn--secondary:hover { background: var(--color-ink); color: var(--color-bg); }
+.ds-btn--ghost { background: transparent; color: var(--color-muted); border-color: var(--color-line-strong); }
+.ds-btn--ghost:hover { color: var(--color-ink); border-color: var(--color-ink); }
+.ds-btn--sm { padding: var(--space-2) var(--space-4); font-size: var(--text-xs); }
+.ds-btn--lg { padding: var(--space-5) var(--space-9); font-size: var(--text-base); }
+
+/* Badge */
+.ds-badge {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  font-family: var(--font-mono); font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-wider); text-transform: uppercase;
+  padding: 3px var(--space-3); border: 1px solid var(--color-line-strong);
+  color: var(--color-muted); white-space: nowrap;
+}
+.ds-badge--accent { background: var(--color-accent); color: var(--color-accent-fg); border-color: var(--color-accent); }
+.ds-badge--ink { background: var(--color-ink); color: var(--color-bg); border-color: var(--color-ink); }
+.ds-badge--status::before {
+  content: ""; width: 6px; height: 6px; border-radius: 100px;
+  background: var(--color-accent);
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--color-accent) 22%, transparent);
+  animation: ds-pulse 2.4s infinite;
+}
+
+/* Tag */
+.ds-tag {
+  display: inline-block; font-family: var(--font-mono); font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide); padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-line-strong); color: var(--color-muted);
+  cursor: pointer;
+  transition: color var(--duration-fast), border-color var(--duration-fast), background var(--duration-fast);
+}
+.ds-tag:hover, .ds-tag[aria-pressed="true"] { color: var(--color-ink); border-color: var(--color-ink); }
+.ds-tag[aria-pressed="true"] { background: var(--color-ink); color: var(--color-bg); }
+
+/* Label */
+.ds-label {
+  font-family: var(--font-mono); font-size: var(--text-xs);
+  letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted);
+}
+.ds-label--accent { color: var(--color-accent); }
+
+/* Metrics */
+.ds-metrics {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid var(--color-line-strong); border-bottom: 1px solid var(--color-line-strong);
+}
+.ds-metrics--3 { grid-template-columns: repeat(3, 1fr); }
+.ds-metrics--5 { grid-template-columns: repeat(5, 1fr); }
+.ds-metric { padding: var(--space-6); border-right: 1px solid var(--color-line); }
+.ds-metric:last-child { border-right: 0; }
+.ds-metric__label { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted); margin-bottom: var(--space-3); }
+.ds-metric__value { display: flex; align-items: baseline; gap: var(--space-2); font-family: var(--font-sans); font-size: var(--text-3xl); font-weight: 900; letter-spacing: -0.025em; line-height: 1; }
+.ds-metric__unit { font-size: var(--text-sm); font-weight: 500; color: var(--color-muted); letter-spacing: 0; }
+
+/* Status block */
+.ds-status-block { border: 1px solid var(--color-line-strong); }
+.ds-status-row {
+  display: grid; grid-template-columns: 100px 1fr auto;
+  padding: var(--space-3) var(--space-4); gap: var(--space-4);
+  align-items: center; border-bottom: 1px solid var(--color-line);
+  font-family: var(--font-mono); font-size: var(--text-xs);
+}
+.ds-status-row:last-child { border-bottom: 0; }
+.ds-status-row__key { color: var(--color-muted); letter-spacing: var(--tracking-wider); text-transform: uppercase; }
+.ds-status-row__val { font-family: var(--font-sans); font-size: var(--text-sm); font-weight: 500; }
+.ds-status-dot { width: 6px; height: 6px; border-radius: 100px; background: var(--color-accent); box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-accent) 22%, transparent); animation: ds-pulse 2.4s infinite; }
+
+/* Entry row */
+.ds-entry {
+  display: grid; grid-template-columns: 72px 1fr auto;
+  gap: var(--space-5); padding-block: var(--space-5);
+  border-bottom: 1px solid var(--color-line); align-items: baseline;
+  transition: background var(--duration-fast);
+}
+.ds-entry:hover { background: color-mix(in oklab, var(--color-accent) 3%, transparent); }
+.ds-entry__no { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--color-muted); letter-spacing: var(--tracking-wide); padding-top: 4px; }
+.ds-entry__title { font-size: var(--text-base); font-weight: 600; line-height: 1.35; margin-bottom: var(--space-1); }
+.ds-entry__meta { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--color-muted); letter-spacing: var(--tracking-wide); margin-top: var(--space-2); }
+.ds-entry__date { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--color-muted); letter-spacing: var(--tracking-wide); white-space: nowrap; }
+
+/* Card */
+.ds-card {
+  background: var(--color-surface); border: 1px solid var(--color-line-strong);
+  padding: var(--space-7); display: flex; flex-direction: column; gap: var(--space-4);
+  transition: background var(--duration-fast);
+}
+.ds-card:hover { background: var(--color-surface-2); }
+.ds-card__eyebrow { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted); }
+.ds-card__title { font-size: var(--text-md); font-weight: 700; line-height: 1.35; letter-spacing: -0.025em; }
+.ds-card__body { font-size: var(--text-sm); line-height: var(--leading-loose); color: var(--color-ink-2); flex: 1; }
+.ds-card__tags { display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-2); }
+.ds-card__footer { display: flex; justify-content: space-between; align-items: center; padding-top: var(--space-4); border-top: 1px solid var(--color-line); font-family: var(--font-mono); font-size: var(--text-xs); color: var(--color-muted); }
+
+/* Panel grid */
+.ds-panel-grid { display: grid; gap: 1px; background: var(--color-line-strong); border: 1px solid var(--color-line-strong); }
+.ds-panel-grid--2 { grid-template-columns: repeat(2, 1fr); }
+.ds-panel-grid--3 { grid-template-columns: repeat(3, 1fr); }
+.ds-panel-grid--4 { grid-template-columns: repeat(4, 1fr); }
+.ds-panel-grid--5 { grid-template-columns: repeat(5, 1fr); }
+.ds-panel { background: var(--color-bg); padding: var(--space-7) var(--space-6); display: flex; flex-direction: column; gap: var(--space-4); }
+.ds-panel--surface { background: var(--color-surface); }
+.ds-panel__no { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted); }
+.ds-panel__title { font-size: var(--text-lg); font-weight: 700; letter-spacing: -0.025em; line-height: 1.35; }
+.ds-panel__body { font-size: var(--text-sm); line-height: var(--leading-loose); color: var(--color-ink-2); }
+.ds-panel__bullets { display: flex; flex-direction: column; gap: 6px; padding-top: var(--space-4); border-top: 1px solid var(--color-line); }
+.ds-panel__bullet { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--color-muted); display: grid; grid-template-columns: 20px 1fr; gap: var(--space-2); }
+.ds-panel__bullet::before { content: "→"; color: var(--color-accent); }
+
+/* Speak item */
+.ds-speak-item {
+  display: grid; grid-template-columns: 160px 1fr auto;
+  gap: var(--space-7); padding-block: var(--space-6);
+  border-bottom: 1px solid var(--color-line); align-items: start;
+}
+.ds-speak-item__date { font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-wider); color: var(--color-muted); padding-top: 4px; }
+.ds-speak-item__title { font-size: var(--text-base); font-weight: 600; line-height: 1.35; margin-bottom: var(--space-2); }
+.ds-speak-item__event { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--color-muted); letter-spacing: var(--tracking-wide); }
+
+/* Now strip */
+.ds-now-strip { display: grid; grid-template-columns: 160px 1fr auto; gap: var(--space-8); align-items: start; padding-block: var(--space-6); border-top: 1px solid var(--color-line); border-bottom: 1px solid var(--color-line); }
+.ds-now-strip__label { font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted); display: flex; align-items: center; gap: var(--space-3); }
+.ds-now-strip__label::before { content: ""; width: 8px; height: 8px; border-radius: 100px; background: var(--color-accent); box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-accent) 22%, transparent); animation: ds-pulse 2.4s infinite; flex-shrink: 0; }
+.ds-now-strip__body { font-size: var(--text-base); line-height: var(--leading-loose); color: var(--color-ink-2); }
+.ds-now-strip__date { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--color-muted); letter-spacing: var(--tracking-wide); white-space: nowrap; }
+
+/* CTA block */
+.ds-cta-block { text-align: center; padding-block: var(--space-13); border-top: 1px solid var(--color-line-strong); border-bottom: 1px solid var(--color-line-strong); margin-top: var(--space-13); }
+.ds-cta-block__pre { font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted); margin-bottom: var(--space-6); display: block; }
+.ds-cta-block__title { font-family: var(--font-sans); font-size: clamp(36px, 5vw, 64px); font-weight: 900; letter-spacing: -0.025em; line-height: 1.1; margin: 0 auto; max-width: 22ch; word-break: keep-all; line-break: strict; }
+.ds-cta-block__title em { font-style: normal; color: var(--color-accent); }
+.ds-cta-block__actions { display: flex; gap: var(--space-4); justify-content: center; flex-wrap: wrap; margin-top: var(--space-9); }
+
+/* Filter bar */
+.ds-filter-bar { display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; padding-block: var(--space-5); border-bottom: 1px solid var(--color-line); margin-bottom: var(--space-3); }
+.ds-filter-bar__label { font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted); margin-right: var(--space-2); }
+
+/* Pagination */
+.ds-pagination { display: flex; align-items: center; justify-content: space-between; padding-top: var(--space-7); border-top: 1px solid var(--color-line); margin-top: var(--space-8); font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-wider); text-transform: uppercase; color: var(--color-muted); }
+.ds-pagination a { color: var(--color-muted); }
+.ds-pagination a:hover { color: var(--color-accent); }
+
+/* Stack grid */
+.ds-stack-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 1px; background: var(--color-line-strong); border: 1px solid var(--color-line-strong); }
+.ds-stack-item { background: var(--color-bg); padding: var(--space-5); min-height: 130px; display: flex; flex-direction: column; justify-content: space-between; }
+.ds-stack-item__no { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-accent); }
+.ds-stack-item__name { font-size: var(--text-md); font-weight: 700; letter-spacing: -0.025em; }
+.ds-stack-item__desc { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--color-muted); letter-spacing: var(--tracking-wide); line-height: var(--leading-loose); margin-top: var(--space-2); }
+
+/* Back link */
+.ds-back-link { display: inline-flex; align-items: center; gap: var(--space-3); font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-wider); text-transform: uppercase; color: var(--color-muted); margin-bottom: var(--space-7); transition: color var(--duration-fast); }
+.ds-back-link::before { content: "←"; }
+.ds-back-link:hover { color: var(--color-accent); }
+
+/* Divider */
+.ds-divider { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: var(--space-5); margin-block: var(--space-9); font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted); }
+.ds-divider::before, .ds-divider::after { content: ""; height: 1px; background: var(--color-line-strong); }
+
+/* Page header (inner pages) */
+.ds-page-header { padding-block: var(--space-12) var(--space-10); border-bottom: 1px solid var(--color-line-strong); }
+.ds-page-header__eyebrow { font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted); margin-bottom: var(--space-5); display: flex; align-items: center; gap: var(--space-4); }
+.ds-page-header__eyebrow::before { content: ""; width: 32px; height: 1px; background: var(--color-accent); }
+.ds-page-header__title { font-family: var(--font-sans); font-size: var(--text-3xl); font-weight: 900; letter-spacing: -0.025em; line-height: 1.1; margin-bottom: var(--space-4); }
+.ds-page-header__sub { font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted); margin-top: var(--space-3); }
+.ds-page-header__meta { display: flex; gap: var(--space-7); margin-top: var(--space-6); font-family: var(--font-mono); font-size: var(--text-xs); color: var(--color-muted); letter-spacing: var(--tracking-wider); }
+
+/* Section header */
+.ds-sec-header { display: grid; grid-template-columns: repeat(12, 1fr); gap: var(--grid-gap); padding-bottom: var(--space-5); border-bottom: 1px solid var(--color-line-strong); margin-bottom: var(--space-7); align-items: baseline; }
+.ds-sec-header__no { grid-column: span 2; font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted); }
+.ds-sec-header__title { grid-column: span 7; font-family: var(--font-sans); font-size: var(--text-2xl); font-weight: 900; letter-spacing: -0.025em; line-height: 1.1; }
+.ds-sec-header__title small { display: block; font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted); font-weight: 400; margin-top: var(--space-3); }
+.ds-sec-header__action { grid-column: span 3; justify-self: end; font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-wider); text-transform: uppercase; color: var(--color-muted); transition: color var(--duration-fast); }
+.ds-sec-header__action:hover { color: var(--color-accent); }
+
+/* Site nav */
+.ds-site-nav { position: sticky; top: 0; z-index: 30; background: color-mix(in oklab, var(--color-bg), transparent 8%); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border-bottom: 1px solid var(--color-line); }
+.ds-site-nav__inner { max-width: var(--page-max); margin-inline: auto; padding-inline: var(--page-px); height: 56px; display: flex; align-items: center; gap: var(--space-8); }
+.ds-site-nav__logo { font-family: var(--font-mono); font-size: var(--text-sm); font-weight: 500; letter-spacing: var(--tracking-wide); color: var(--color-ink); flex-shrink: 0; }
+.ds-site-nav__logo strong { font-weight: 700; }
+.ds-site-nav__links { display: flex; align-items: center; gap: var(--space-7); margin-left: auto; }
+.ds-site-nav__link { font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted); transition: color var(--duration-fast); position: relative; }
+.ds-site-nav__link:hover, .ds-site-nav__link[aria-current="page"] { color: var(--color-ink); }
+.ds-site-nav__link[aria-current="page"]::after { content: ""; position: absolute; bottom: -4px; left: 0; right: 0; height: 1px; background: var(--color-accent); }
+.ds-theme-btn { all: unset; cursor: pointer; font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-wider); text-transform: uppercase; color: var(--color-muted); padding: var(--space-2) var(--space-3); border: 1px solid var(--color-line-strong); transition: color var(--duration-fast), border-color var(--duration-fast); }
+.ds-theme-btn:hover { color: var(--color-ink); border-color: var(--color-ink); }
+
+/* Site footer */
+.ds-site-footer { margin-top: var(--space-13); border-top: 1px solid var(--color-line-strong); padding-block: var(--space-10); }
+.ds-site-footer__inner { max-width: var(--page-max); margin-inline: auto; padding-inline: var(--page-px); display: grid; grid-template-columns: 1fr 1fr 1fr auto; gap: var(--space-7); align-items: start; }
+.ds-site-footer__brand { font-family: var(--font-mono); font-size: var(--text-sm); font-weight: 700; letter-spacing: var(--tracking-wide); margin-bottom: var(--space-3); }
+.ds-site-footer__copy { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--color-muted); letter-spacing: var(--tracking-wide); line-height: var(--leading-loose); }
+.ds-site-footer__nav-title { font-family: var(--font-mono); font-size: var(--text-2xs); letter-spacing: var(--tracking-widest); text-transform: uppercase; color: var(--color-muted); margin-bottom: var(--space-4); }
+.ds-site-footer__nav-link { display: block; font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-wide); color: var(--color-muted); margin-bottom: var(--space-3); transition: color var(--duration-fast); }
+.ds-site-footer__nav-link:hover { color: var(--color-ink); }
+.ds-site-footer__status { text-align: right; }
+.ds-site-footer__status-label { font-family: var(--font-mono); font-size: var(--text-xs); letter-spacing: var(--tracking-wider); text-transform: uppercase; color: var(--color-muted); }
+.ds-site-footer__status-dot { display: inline-block; width: 6px; height: 6px; border-radius: 100px; background: var(--color-accent); box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-accent) 22%, transparent); animation: ds-pulse 2.4s infinite; margin-right: var(--space-2); }
+
+/* Prose (article body) */
+.ds-prose { font-size: var(--text-base); line-height: var(--leading-loose); color: var(--color-ink-2); max-width: 64ch; }
+.ds-prose h2 { font-family: var(--font-sans); font-size: var(--text-xl); font-weight: 800; letter-spacing: -0.025em; color: var(--color-ink); margin-top: var(--space-10); margin-bottom: var(--space-5); padding-bottom: var(--space-3); border-bottom: 1px solid var(--color-line-strong); }
+.ds-prose h3 { font-family: var(--font-sans); font-size: var(--text-lg); font-weight: 700; color: var(--color-ink); margin-top: var(--space-8); margin-bottom: var(--space-4); }
+.ds-prose p { margin-bottom: var(--space-5); }
+.ds-prose strong { font-weight: 700; color: var(--color-ink); }
+.ds-prose a { color: var(--color-accent); text-decoration: underline; text-underline-offset: 3px; }
+.ds-prose a:hover { opacity: .8; }
+.ds-prose code { font-family: var(--font-mono); font-size: .88em; background: var(--color-surface); border: 1px solid var(--color-line-strong); padding: 1px 6px; letter-spacing: 0; }
+.ds-prose pre { background: var(--color-ink); color: var(--color-bg); font-family: var(--font-mono); font-size: var(--text-sm); line-height: var(--leading-loose); padding: var(--space-6); overflow-x: auto; margin-block: var(--space-7); }
+.ds-prose pre code { background: transparent; border: 0; padding: 0; color: inherit; font-size: inherit; }
+.ds-prose blockquote { border-left: 3px solid var(--color-accent); margin-left: 0; padding-left: var(--space-6); color: var(--color-muted); font-size: var(--text-md); font-family: var(--font-serif); line-height: var(--leading-loose); margin-block: var(--space-7); }
+.ds-prose ul { padding-left: var(--space-5); margin-bottom: var(--space-5); }
+.ds-prose ul li { list-style: "— "; margin-bottom: var(--space-2); }
+.ds-prose ol { padding-left: var(--space-5); margin-bottom: var(--space-5); }
+.ds-prose ol li { list-style: decimal; margin-bottom: var(--space-2); }
+.ds-prose hr { border: 0; border-top: 1px solid var(--color-line-strong); margin-block: var(--space-9); }
+
+@keyframes ds-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: .45; }
+}

--- a/src/app/ja/page.tsx
+++ b/src/app/ja/page.tsx
@@ -1,17 +1,20 @@
 import FeaturedContent from '@/components/containers/FeaturedContent'
 import Hero from '@/components/Hero/Hero'
 import Capabilities from '@/components/home/Capabilities'
+import HomeCTA from '@/components/home/HomeCTA'
+import SpeakingSection from '@/components/home/SpeakingSection'
 import StackShowcase from '@/components/home/StackShowcase'
 
 export default async function HomePage() {
   const lang = 'ja'
-
   return (
     <>
       <Hero lang={lang} />
       <Capabilities lang={lang} />
       <StackShowcase lang={lang} />
       <FeaturedContent lang={lang} />
+      <SpeakingSection lang={lang} />
+      <HomeCTA lang={lang} />
     </>
   )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { Inter_Tight, JetBrains_Mono, Shippori_Mincho, Zen_Kaku_Gothic_New } from 'next/font/google'
 import { SITE_DESCRIPTION, SITE_TITLE } from '@/consts'
 import './globals.css'
 import { ClarityAnalytics } from '@/components/ClarityAnalytics'
@@ -7,6 +8,34 @@ import GoogleAnalytics from '@/components/GoogleAnalytics'
 import SentryProvider from '@/components/providers/SentryProvider'
 import Footer from '@/components/tailwindui/Footer'
 import Header from '@/components/tailwindui/Header'
+
+const zenKaku = Zen_Kaku_Gothic_New({
+  weight: ['400', '500', '700', '900'],
+  subsets: ['latin'],
+  variable: '--font-zen-kaku',
+  display: 'swap',
+})
+
+const shipporiMincho = Shippori_Mincho({
+  weight: ['500', '600', '700', '800'],
+  subsets: ['latin'],
+  variable: '--font-shippori',
+  display: 'swap',
+})
+
+const jetbrainsMono = JetBrains_Mono({
+  weight: ['400', '500'],
+  subsets: ['latin'],
+  variable: '--font-jetbrains',
+  display: 'swap',
+})
+
+const interTight = Inter_Tight({
+  weight: ['400', '500', '600', '700'],
+  subsets: ['latin'],
+  variable: '--font-inter-tight',
+  display: 'swap',
+})
 
 export const metadata: Metadata = {
   title: SITE_TITLE,
@@ -45,20 +74,18 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className="h-full antialiased">
+    <html
+      lang="en"
+      className={`h-full ${zenKaku.variable} ${shipporiMincho.variable} ${jetbrainsMono.variable} ${interTight.variable}`}
+    >
       <head>
         <link rel="alternate" type="application/rss+xml" title="RSS" href="/projects/rss.xml" />
       </head>
-      <body className="flex h-full flex-col bg-zinc-50 dark:bg-black">
+      <body className="flex h-full flex-col bg-[#f4f2ee] dark:bg-[#0d0c0b]">
         <SentryProvider>
           <GoogleAnalytics gaId="G-RV8PYHHYHN" />
           <DarkModeScript />
           <ClarityAnalytics />
-          <div className="fixed inset-0 flex justify-center sm:px-8">
-            <div className="flex w-full max-w-7xl lg:px-4">
-              <div className="w-full bg-white ring-1 ring-zinc-100 dark:bg-zinc-900 dark:ring-zinc-300/20" />
-            </div>
-          </div>
           <div className="relative">
             <Header />
             <main>{children}</main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,20 @@
 import FeaturedContent from '@/components/containers/FeaturedContent'
 import Hero from '@/components/Hero/Hero'
 import Capabilities from '@/components/home/Capabilities'
+import HomeCTA from '@/components/home/HomeCTA'
+import SpeakingSection from '@/components/home/SpeakingSection'
 import StackShowcase from '@/components/home/StackShowcase'
 
 export default async function HomePage() {
   const lang = 'en'
-
   return (
     <>
       <Hero lang={lang} />
       <Capabilities lang={lang} />
       <StackShowcase lang={lang} />
       <FeaturedContent lang={lang} />
+      <SpeakingSection lang={lang} />
+      <HomeCTA lang={lang} />
     </>
   )
 }

--- a/src/components/DarkModeScript.tsx
+++ b/src/components/DarkModeScript.tsx
@@ -1,23 +1,26 @@
 'use client'
-
 import { useEffect } from 'react'
 
 export function DarkModeScript() {
   useEffect(() => {
     const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
 
+    function applyTheme(isDark: boolean) {
+      if (isDark) {
+        document.documentElement.classList.add('dark')
+        document.documentElement.dataset.theme = 'dark'
+      } else {
+        document.documentElement.classList.remove('dark')
+        document.documentElement.dataset.theme = 'light'
+      }
+    }
+
     function updateMode() {
       const isSystemDarkMode = darkModeMediaQuery.matches
       const isDarkMode =
         window.localStorage.isDarkMode === 'true' ||
         (!('isDarkMode' in window.localStorage) && isSystemDarkMode)
-
-      if (isDarkMode) {
-        document.documentElement.classList.add('dark')
-      } else {
-        document.documentElement.classList.remove('dark')
-      }
-
+      applyTheme(isDarkMode)
       if (isDarkMode === isSystemDarkMode) {
         delete window.localStorage.isDarkMode
       }
@@ -38,12 +41,10 @@ export function DarkModeScript() {
     updateMode()
     darkModeMediaQuery.addEventListener('change', updateModeWithoutTransitions)
     window.addEventListener('storage', updateModeWithoutTransitions)
-
     return () => {
       darkModeMediaQuery.removeEventListener('change', updateModeWithoutTransitions)
       window.removeEventListener('storage', updateModeWithoutTransitions)
     }
   }, [])
-
   return null
 }

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,82 +1,147 @@
-import GitHubIcon from '@/components/tailwindui/SocialIcons/GitHub'
-import LinkedInIcon from '@/components/tailwindui/SocialIcons/LinkedIn'
-import TwitterIcon from '@/components/tailwindui/SocialIcons/Twitter'
-import SocialLink from '@/components/tailwindui/SocialLink'
-import BackgroundDecoration from '@/components/ui/BackgroundDecoration'
-import Badge from '@/components/ui/Badge'
-import CTAButton from '@/components/ui/CTAButton'
-import ProfileImage from '@/components/ui/ProfileImage'
+import Image from 'next/image'
 import { SITE_CONFIG } from '@/config'
 
+type StatusRow = { key: string; value: string; live?: boolean }
+
+function StatusTable({ rows }: { rows: StatusRow[] }) {
+  return (
+    <div className="border border-stone-900/20 dark:border-stone-100/20">
+      {rows.map((row) => (
+        <div
+          key={row.key}
+          className="grid grid-cols-[110px_1fr_auto] items-center gap-4 px-3.5 py-3 border-b last:border-b-0 border-stone-900/10 dark:border-stone-100/10"
+        >
+          <span className="font-mono text-[11px] tracking-[0.14em] uppercase text-stone-500 dark:text-stone-400">
+            {row.key}
+          </span>
+          <span className="font-sans text-[13px] font-medium text-stone-900 dark:text-stone-100">
+            {row.value}
+          </span>
+          {row.live && (
+            <span className="w-1.5 h-1.5 rounded-full bg-vermilion shadow-[0_0_0_3px_rgba(255,91,41,0.22)]" />
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export default function Hero({ lang }: { lang: string }) {
-  const name = SITE_CONFIG.author.name
-  const role = lang === 'ja' ? '開発者' : 'Developer'
-  const tagline =
-    lang === 'ja'
-      ? 'SaaSの収益を最大化するエンジニアリング'
-      : 'Engineering that maximizes SaaS revenue'
+  const isJa = lang.startsWith('ja')
 
-  const description =
-    lang === 'ja'
-      ? 'Stripe、AWS Serverless、WordPressを専門とする開発者。EC ASP開発とStripe Developer Advocateとしての経験を活かし、SaaS・ECサイトの収益最大化を支援します。'
-      : 'Engineering partner specializing in Stripe, AWS Serverless, and WordPress. Leveraging experience in EC ASP development and as a Stripe Developer Advocate to help SaaS and e-commerce sites maximize revenue.'
+  const statusRows: StatusRow[] = [
+    { key: 'Status', value: isJa ? '受付中 / Q2 2026' : 'Available / Q2 2026', live: true },
+    { key: 'Role', value: 'Eng. Partner' },
+    { key: 'Base', value: 'Kyoto · JP' },
+    { key: 'Lang', value: 'JP / EN' },
+  ]
 
-  const ctaText = lang === 'ja' ? 'プロジェクトを見る' : 'View my projects'
-  const ctaHref = lang === 'ja' ? '/ja/work' : '/work'
+  const metricsItems = [
+    { label: 'Years of Experience', value: '12', unit: '+ years' },
+    { label: 'Production Projects', value: '80', unit: '+ shipped' },
+    { label: 'Talks & Workshops', value: '60', unit: '+ sessions' },
+    { label: 'Open-source Pkgs', value: '14', unit: 'on npm' },
+  ]
 
   return (
-    <section className="relative overflow-hidden bg-gradient-to-br from-white via-indigo-50/30 to-purple-50/20 dark:from-zinc-900 dark:via-indigo-950/30 dark:to-purple-950/20 -mt-[var(--header-height)] pt-[var(--header-height)]">
-      <BackgroundDecoration variant="hero" />
+    <section className="border-b border-stone-900/20 dark:border-stone-100/20">
+      <div className="mx-auto max-w-[1440px] px-16">
+        {/* Top bar */}
+        <div className="grid grid-cols-3 py-3 border-b border-stone-900/10 dark:border-stone-100/10">
+          <span className="font-mono text-[11px] tracking-[0.14em] uppercase text-stone-500">
+            Hidetaka.dev / INDEX
+          </span>
+          <span className="font-mono text-[11px] tracking-[0.14em] uppercase text-stone-500 text-center hidden sm:block">
+            DEVELOPER EXPERIENCE ENGINEER · KYOTO, JP
+          </span>
+          <span className="font-mono text-[11px] tracking-[0.14em] uppercase text-stone-500 text-right">
+            REV. 2026 / JA · EN
+          </span>
+        </div>
 
-      <div className="relative mx-auto max-w-7xl px-6 py-24 sm:px-8 sm:py-32 lg:px-12 lg:py-40">
-        <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-16 lg:gap-20">
-          {/* Left: Content */}
-          <div className="flex-1 space-y-10 lg:max-w-2xl">
-            <div className="space-y-6">
-              <Badge label={role} variant="indigo" />
-              <h1 className="text-5xl sm:text-6xl lg:text-7xl font-extrabold leading-tight text-slate-900 dark:text-white">
-                {name}
-              </h1>
-              <p className="text-2xl sm:text-3xl font-bold text-indigo-700 dark:text-indigo-300">
-                {tagline}
-              </p>
+        {/* Main grid */}
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 pt-8 pb-16">
+          {/* Left: content */}
+          <div className="lg:col-span-8">
+            <div className="font-mono text-[11px] tracking-[0.2em] uppercase text-stone-500 mb-4">
+              &#9675; Hidetaka Okamoto / 岡本 秀高
             </div>
-
-            <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
-              {description}
+            <h1 className="font-sans font-black text-[clamp(64px,10.5vw,156px)] leading-[0.88] tracking-[-0.04em] text-stone-950 dark:text-stone-50">
+              {isJa ? (
+                <>
+                  開発者体験を、
+                  <br />
+                  事業にする。
+                </>
+              ) : (
+                <>
+                  Design developer
+                  <br />
+                  experience.
+                </>
+              )}
+            </h1>
+            <div className="font-mono text-[12px] tracking-[0.28em] uppercase text-stone-500 mt-6">
+              DESIGNING DEVELOPER EXPERIENCE · FOR SAAS &amp; COMMERCE
+            </div>
+            <p className="font-serif text-[20px] leading-[1.55] mt-8 max-w-[22em] tracking-[-0.005em] text-stone-800 dark:text-stone-200">
+              {isJa ? (
+                <>
+                  Stripe・AWS Serverless・WordPress を軸に、
+                  <mark className="bg-vermilion text-white px-1.5">SaaS と EC の収益導線</mark>
+                  を設計・実装するエンジニアリングパートナーです。
+                </>
+              ) : (
+                <>
+                  Engineering partner specializing in Stripe, AWS Serverless &amp; WordPress,
+                  designing{' '}
+                  <mark className="bg-vermilion text-white px-1.5">
+                    revenue-driving developer experiences
+                  </mark>{' '}
+                  for SaaS and commerce.
+                </>
+              )}
             </p>
-
-            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-6 pt-4">
-              <CTAButton href={ctaHref}>{ctaText}</CTAButton>
-              <div className="flex items-center gap-5">
-                <SocialLink
-                  href={SITE_CONFIG.social.twitter.url}
-                  aria-label={SITE_CONFIG.social.twitter.ariaLabel}
-                  icon={TwitterIcon}
-                >
-                  <span className="sr-only">{SITE_CONFIG.social.twitter.ariaLabel}</span>
-                </SocialLink>
-                <SocialLink
-                  href={SITE_CONFIG.social.github.url}
-                  aria-label={SITE_CONFIG.social.github.ariaLabel}
-                  icon={GitHubIcon}
-                >
-                  <span className="sr-only">{SITE_CONFIG.social.github.ariaLabel}</span>
-                </SocialLink>
-                <SocialLink
-                  href={SITE_CONFIG.social.linkedin.url}
-                  aria-label={SITE_CONFIG.social.linkedin.ariaLabel}
-                  icon={LinkedInIcon}
-                >
-                  <span className="sr-only">{SITE_CONFIG.social.linkedin.ariaLabel}</span>
-                </SocialLink>
-              </div>
-            </div>
           </div>
 
-          {/* Right: Image */}
-          <ProfileImage src="/images/profile.jpg" alt={name} size="lg" />
+          {/* Right: portrait + status */}
+          <div className="lg:col-span-4 flex flex-col gap-4">
+            <div className="relative aspect-[3/4] border border-stone-900/20 dark:border-stone-100/20 overflow-hidden">
+              <Image
+                src="/images/profile.jpg"
+                alt={SITE_CONFIG.author.name}
+                fill
+                className="object-cover"
+                priority
+                sizes="(max-width: 1024px) 100vw, 33vw"
+              />
+              <div className="absolute top-3 left-3 bg-stone-950 dark:bg-stone-50 text-stone-50 dark:text-stone-950 font-mono text-[10px] px-2 py-1.5 tracking-[0.1em]">
+                PORTRAIT / 2026
+              </div>
+            </div>
+            <StatusTable rows={statusRows} />
+          </div>
         </div>
+
+        {/* Metrics bar */}
+        <dl className="grid grid-cols-2 lg:grid-cols-4 border-t border-b border-stone-900/20 dark:border-stone-100/20">
+          {metricsItems.map((m, i) => (
+            <div
+              key={m.label}
+              className={`px-6 py-5 ${i < metricsItems.length - 1 ? 'border-r border-stone-900/10 dark:border-stone-100/10' : ''}`}
+            >
+              <dt className="font-mono text-[10px] tracking-[0.16em] uppercase text-stone-500 mb-2.5">
+                {m.label}
+              </dt>
+              <dd className="flex items-baseline gap-1.5 font-sans font-bold text-[40px] leading-none tracking-[-0.02em] text-stone-950 dark:text-stone-50">
+                {m.value}
+                <small className="text-[13px] font-medium text-stone-500 tracking-normal">
+                  {m.unit}
+                </small>
+              </dd>
+            </div>
+          ))}
+        </dl>
       </div>
     </section>
   )

--- a/src/components/containers/FeaturedContent.tsx
+++ b/src/components/containers/FeaturedContent.tsx
@@ -1,9 +1,4 @@
-import Image from 'next/image'
 import Link from 'next/link'
-import Container from '@/components/tailwindui/Container'
-import BackgroundDecoration from '@/components/ui/BackgroundDecoration'
-import DateDisplay from '@/components/ui/DateDisplay'
-import Tag from '@/components/ui/Tag'
 import { loadBlogPosts } from '@/libs/dataSources/blogs'
 import type { FeedItem } from '@/libs/dataSources/types'
 import { parseDateSafely } from '@/libs/dateDisplay.utils'
@@ -11,344 +6,154 @@ import { MicroCMSAPI } from '@/libs/microCMS/apis'
 import { createMicroCMSClient } from '@/libs/microCMS/client'
 import type { MicroCMSProjectsRecord } from '@/libs/microCMS/types'
 
-// ============================================================================
-// Content Cards
-// ============================================================================
-
-function ArticleCard({
-  article,
-  lang,
-  variant = 'default',
-}: {
-  article: FeedItem
-  lang: string
-  variant?: 'featured' | 'default'
-}) {
-  const href = article.href
-  const title = article.title
-  const description = article.description
-  const datetime = article.datetime
-
-  // Parse date safely - returns null for invalid dates instead of falling back to current date
-  const date = parseDateSafely(datetime, {
-    articleTitle: title,
-    source: article.dataSource?.name,
+function WriteRow({ no, item }: { no: string; item: FeedItem }) {
+  const date = parseDateSafely(item.datetime, {
+    articleTitle: item.title,
+    source: item.dataSource?.name,
   })
-
-  // Skip rendering article if date is invalid
-  // This prevents showing articles with corrupted or missing date data
-  if (!date) {
-    return null
-  }
-
-  const CardWrapper = ({ children }: { children: React.ReactNode }) => {
-    return (
-      <a href={href} target="_blank" rel="noopener noreferrer" className="group block h-full">
-        {children}
-      </a>
-    )
-  }
-
-  if (variant === 'featured') {
-    return (
-      <CardWrapper>
-        <article className="relative h-full overflow-hidden rounded-3xl border border-zinc-200 bg-gradient-to-br from-white via-indigo-50/50 to-purple-50/30 p-10 transition-all hover:border-indigo-300 hover:shadow-2xl dark:border-zinc-800 dark:from-zinc-900 dark:via-indigo-950/30 dark:to-purple-950/20 dark:hover:border-indigo-700">
-          <div className="flex flex-col gap-6">
-            <div className="flex items-center justify-between">
-              <DateDisplay
-                date={date}
-                lang={lang}
-                format="short"
-                className="text-sm font-bold text-indigo-600 dark:text-indigo-400"
-              />
-              {article.dataSource && (
-                <Tag variant="indigo" size="md" className="px-4 py-1.5 font-bold">
-                  {article.dataSource.name}
-                </Tag>
-              )}
-            </div>
-
-            <h3 className="text-3xl font-extrabold leading-tight tracking-tight text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">
-              {title}
-            </h3>
-
-            <p className="text-base leading-relaxed text-slate-700 dark:text-slate-300 line-clamp-4">
-              {description}
-              {description.length >= 200 ? '...' : ''}
-            </p>
-
-            <div className="mt-auto flex items-center gap-2 text-sm font-bold text-indigo-600 dark:text-indigo-400">
-              <span>{lang === 'ja' ? '記事を読む' : 'Read article'}</span>
-              <span className="transition-transform group-hover:translate-x-1">→</span>
-            </div>
-          </div>
-        </article>
-      </CardWrapper>
-    )
-  }
-
+  if (!date) return null
+  const dateStr = `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`
+  const source = item.dataSource?.name ?? ''
   return (
-    <CardWrapper>
-      <article className="flex h-full flex-col rounded-xl border border-zinc-200 bg-white p-6 transition-all hover:border-indigo-300 hover:shadow-lg dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-700">
-        <div className="flex items-center justify-between mb-3">
-          <DateDisplay
-            date={date}
-            lang={lang}
-            format="short"
-            className="text-xs font-semibold text-slate-500 dark:text-slate-400"
-          />
-          {article.dataSource && (
-            <Tag variant="default" size="sm" className="text-[10px]">
-              {article.dataSource.name}
-            </Tag>
-          )}
-        </div>
-
-        <h3 className="text-lg font-bold leading-tight text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors mb-3">
-          {title}
-        </h3>
-
-        <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400 line-clamp-2 flex-1">
-          {description}
-          {description.length >= 120 ? '...' : ''}
-        </p>
-      </article>
-    </CardWrapper>
+    <a href={item.href} target="_blank" rel="noopener noreferrer" className="ds-entry">
+      <span className="ds-entry__no">{no}</span>
+      <p className="ds-entry__title">{item.title}</p>
+      <span className="ds-entry__date">
+        {source ? `${source} · ` : ''}
+        {dateStr}
+      </span>
+    </a>
   )
 }
 
-function ProjectCard({
+function ProjectRow({
+  no,
   project,
   lang,
-  variant = 'default',
 }: {
+  no: string
   project: MicroCMSProjectsRecord
   lang: string
-  variant?: 'featured' | 'default'
 }) {
   const href = lang === 'ja' ? `/ja/work/${project.id}` : `/work/${project.id}`
   const date = project.published_at ? new Date(project.published_at) : null
-
-  if (variant === 'featured') {
-    return (
-      <Link href={href} className="group block">
-        <article className="relative overflow-hidden rounded-3xl border border-zinc-200 bg-white transition-all hover:border-purple-300 hover:shadow-2xl dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-purple-700">
-          {/* Large Image - Top */}
-          {project.image && (
-            <div className="relative aspect-video w-full overflow-hidden">
-              <Image
-                src={project.image.url}
-                alt={project.title}
-                fill
-                className="object-cover transition-transform duration-500 group-hover:scale-110"
-                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 66vw, 50vw"
-                priority
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent" />
-            </div>
-          )}
-
-          {/* Content - Bottom */}
-          <div className="p-8 lg:p-10">
-            <div className="flex flex-col gap-4">
-              {date && (
-                <DateDisplay
-                  date={date}
-                  lang={lang}
-                  format="short"
-                  className="text-sm font-semibold text-purple-600 dark:text-purple-400"
-                />
-              )}
-
-              <h3 className="text-2xl font-bold leading-tight tracking-tight text-slate-900 dark:text-white group-hover:text-purple-600 dark:group-hover:text-purple-400 transition-colors lg:text-3xl">
-                {project.title}
-              </h3>
-
-              {project.tags && project.tags.length > 0 && (
-                <div className="flex flex-wrap gap-2">
-                  {project.tags.slice(0, 4).map((tag) => (
-                    <Tag key={tag} variant="purple" size="md">
-                      {tag}
-                    </Tag>
-                  ))}
-                </div>
-              )}
-
-              <div className="mt-4 flex items-center gap-2 text-sm font-semibold text-purple-600 dark:text-purple-400">
-                <span>{lang === 'ja' ? '詳細を見る' : 'View project'}</span>
-                <span className="transition-transform group-hover:translate-x-1">→</span>
-              </div>
-            </div>
-          </div>
-        </article>
-      </Link>
-    )
-  }
-
+  const dateStr = date
+    ? `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}`
+    : ''
+  const tags = project.tags?.slice(0, 2).join(' · ') ?? ''
   return (
-    <Link href={href} className="group block">
-      <article className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-white transition-all hover:border-purple-300 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-purple-700">
-        {/* Image - Top, larger */}
-        {project.image && (
-          <div className="relative aspect-[4/3] w-full overflow-hidden">
-            <Image
-              src={project.image.url}
-              alt={project.title}
-              fill
-              className="object-cover transition-transform duration-500 group-hover:scale-110"
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-            />
-          </div>
-        )}
-
-        {/* Content - Bottom */}
-        <div className="p-5 lg:p-6">
-          <div className="flex flex-col gap-3">
-            {date && (
-              <DateDisplay
-                date={date}
-                lang={lang}
-                format="short"
-                className="text-xs font-semibold text-slate-500 dark:text-slate-400"
-              />
-            )}
-
-            <h3 className="text-lg font-bold leading-tight text-slate-900 dark:text-white group-hover:text-purple-600 dark:group-hover:text-purple-400 transition-colors">
-              {project.title}
-            </h3>
-
-            {project.tags && project.tags.length > 0 && (
-              <div className="flex flex-wrap gap-2">
-                {project.tags.slice(0, 3).map((tag) => (
-                  <Tag key={tag} variant="purple" size="sm">
-                    {tag}
-                  </Tag>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-      </article>
+    <Link href={href} className="ds-entry">
+      <span className="ds-entry__no">{no}</span>
+      <p className="ds-entry__title">{project.title}</p>
+      <span className="ds-entry__date">
+        {tags}
+        {tags && dateStr ? ' · ' : ''}
+        {dateStr}
+      </span>
     </Link>
   )
 }
 
-// ============================================================================
-// Main Section - Unified Content Stream
-// ============================================================================
-
 export default async function FeaturedContent({ lang }: { lang: string }) {
+  const isJa = lang.startsWith('ja')
   const microCMS = new MicroCMSAPI(createMicroCMSClient())
 
-  // Fetch all content
-  const { items: externalPosts } = await loadBlogPosts(lang === 'ja' ? 'ja' : 'en')
+  const { items: externalPosts } = await loadBlogPosts(isJa ? 'ja' : 'en')
   const allProjects = await microCMS.listAllProjects()
 
-  // Prepare unified content
-  // Filter articles with valid dates to prevent ArticleCard from returning null
   const articles: FeedItem[] = externalPosts
-    .map((article) => ({
-      article,
-      date: parseDateSafely(article.datetime, {
-        articleTitle: article.title,
-        source: article.dataSource?.name,
-      }),
+    .map((a) => ({
+      a,
+      date: parseDateSafely(a.datetime, { articleTitle: a.title, source: a.dataSource?.name }),
     }))
-    .filter((item): item is { article: FeedItem; date: Date } => item.date !== null)
+    .filter((x): x is { a: FeedItem; date: Date } => x.date !== null)
     .sort((a, b) => b.date.getTime() - a.date.getTime())
-    .map(({ article }) => article)
+    .map(({ a }) => a)
+    .slice(0, 5)
 
   const projects = allProjects
     .filter((p) => p.published_at)
-    .sort((a, b) => {
-      const dateA = a.published_at || ''
-      const dateB = b.published_at || ''
-      return new Date(dateB).getTime() - new Date(dateA).getTime()
-    })
-
-  // Get featured items (most recent)
-  const featuredArticle = articles[0]
-  const featuredProject = projects[0]
-  const otherArticles = articles.slice(1, 4)
-  const otherProjects = projects.slice(1, 4)
-
-  const viewAllText = lang === 'ja' ? 'すべて見る' : 'View All'
-  const latestArticlesText = lang === 'ja' ? '最新記事' : 'Latest Articles'
-  const featuredProjectsText = lang === 'ja' ? '注目プロジェクト' : 'Featured Projects'
+    .sort((a, b) => new Date(b.published_at!).getTime() - new Date(a.published_at!).getTime())
+    .slice(0, 5)
 
   return (
-    <section className="relative py-24 sm:py-32">
-      <BackgroundDecoration variant="section" />
-
-      <Container>
-        <div className="relative space-y-32">
-          {/* Latest Articles Section */}
-          {articles.length > 0 && (
-            <div>
-              <div className="flex items-center justify-between mb-12">
-                <h2 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white sm:text-4xl">
-                  {latestArticlesText}
-                </h2>
-                <Link
-                  href={lang === 'ja' ? '/ja/writing' : '/writing'}
-                  className="group flex items-center gap-1.5 text-sm font-semibold text-indigo-600 transition-all hover:text-indigo-700 hover:gap-2 dark:text-indigo-400 dark:hover:text-indigo-300"
+    <section
+      style={{
+        borderTop: '1px solid var(--color-line-strong)',
+        borderBottom: '1px solid var(--color-line-strong)',
+      }}
+    >
+      <div className="mx-auto max-w-[1440px] px-8 sm:px-16 py-16">
+        <div
+          style={{ display: 'grid', gridTemplateColumns: '1fr', gap: '3rem' }}
+          className="lg:grid-cols-2"
+        >
+          {/* Writing column */}
+          <div>
+            <div className="ds-sec-header" style={{ marginBottom: '0.5rem' }}>
+              <span className="ds-sec-header__no">W</span>
+              <h2 className="ds-sec-header__title">
+                {isJa ? '執筆' : 'Writing'}
+                <small
+                  style={{
+                    display: 'block',
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 'var(--text-2xs)',
+                    letterSpacing: '0.18em',
+                    textTransform: 'uppercase',
+                    color: 'var(--color-muted)',
+                    fontWeight: 400,
+                    marginTop: '4px',
+                  }}
                 >
-                  <span>{viewAllText}</span>
-                  <span className="transition-transform group-hover:translate-x-0.5">→</span>
-                </Link>
-              </div>
-
-              <div className="grid gap-8 lg:grid-cols-3">
-                {/* Featured Article */}
-                {featuredArticle && (
-                  <div className="lg:col-span-2">
-                    <ArticleCard article={featuredArticle} lang={lang} variant="featured" />
-                  </div>
-                )}
-
-                {/* Other Articles */}
-                <div className="grid gap-6 lg:grid-cols-1">
-                  {otherArticles.map((article) => (
-                    <ArticleCard key={article.href} article={article} lang={lang} />
-                  ))}
-                </div>
-              </div>
+                  {isJa ? '記事・連載' : 'Articles & Series'}
+                </small>
+              </h2>
+              <Link href={isJa ? '/ja/writing' : '/writing'} className="ds-sec-header__action">
+                {isJa ? '一覧へ →' : 'View all →'}
+              </Link>
             </div>
-          )}
+            {articles.map((a, i) => (
+              <WriteRow key={a.href} no={String(i + 1).padStart(3, '0')} item={a} />
+            ))}
+          </div>
 
-          {/* Featured Projects Section */}
-          {projects.length > 0 && (
-            <div>
-              <div className="flex items-center justify-between mb-12">
-                <h2 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white sm:text-4xl">
-                  {featuredProjectsText}
-                </h2>
-                <Link
-                  href={lang === 'ja' ? '/ja/work' : '/work'}
-                  className="group flex items-center gap-1.5 text-sm font-semibold text-indigo-600 transition-all hover:text-indigo-700 hover:gap-2 dark:text-indigo-400 dark:hover:text-indigo-300"
+          {/* Projects column */}
+          <div>
+            <div className="ds-sec-header" style={{ marginBottom: '0.5rem' }}>
+              <span className="ds-sec-header__no">P</span>
+              <h2 className="ds-sec-header__title">
+                {isJa ? 'プロジェクト' : 'Projects'}
+                <small
+                  style={{
+                    display: 'block',
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 'var(--text-2xs)',
+                    letterSpacing: '0.18em',
+                    textTransform: 'uppercase',
+                    color: 'var(--color-muted)',
+                    fontWeight: 400,
+                    marginTop: '4px',
+                  }}
                 >
-                  <span>{viewAllText}</span>
-                  <span className="transition-transform group-hover:translate-x-0.5">→</span>
-                </Link>
-              </div>
-
-              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                {/* Featured Project - Full width on mobile, spans 2 columns on desktop */}
-                {featuredProject && (
-                  <div className="sm:col-span-2 lg:col-span-2">
-                    <ProjectCard project={featuredProject} lang={lang} variant="featured" />
-                  </div>
-                )}
-
-                {/* Other Projects - Compact cards */}
-                {otherProjects.map((project) => (
-                  <ProjectCard key={project.id} project={project} lang={lang} />
-                ))}
-              </div>
+                  {isJa ? 'プロジェクト・OSS' : 'Projects & OSS'}
+                </small>
+              </h2>
+              <Link href={isJa ? '/ja/work' : '/work'} className="ds-sec-header__action">
+                {isJa ? '一覧へ →' : 'View all →'}
+              </Link>
             </div>
-          )}
+            {projects.map((p, i) => (
+              <ProjectRow
+                key={p.id}
+                no={`A/${String(i + 1).padStart(2, '0')}`}
+                project={p}
+                lang={lang}
+              />
+            ))}
+          </div>
         </div>
-      </Container>
+      </div>
     </section>
   )
 }

--- a/src/components/containers/pages/AboutPage.tsx
+++ b/src/components/containers/pages/AboutPage.tsx
@@ -1,14 +1,6 @@
 import Image from 'next/image'
+import Link from 'next/link'
 import Profile from '@/components/content/Profile'
-import Container from '@/components/tailwindui/Container'
-import SocialLink, {
-  GitHubIcon,
-  LinkedInIcon,
-  TwitterIcon,
-} from '@/components/tailwindui/SocialLink'
-import BackgroundDecoration from '@/components/ui/BackgroundDecoration'
-import PageHeader from '@/components/ui/PageHeader'
-import ProfileImage from '@/components/ui/ProfileImage'
 import SectionHeader from '@/components/ui/SectionHeader'
 import { SITE_CONFIG } from '@/config'
 
@@ -18,7 +10,7 @@ function SpeakerProfile({ lang }: { lang: 'ja' | 'en' }) {
       <>
         DigitalCubeのBizDevとして、SaaSやECサイトの収益を増やすための方法・生成AIを使った効率化や新しい事業モデルの模索などに挑戦している。前職では
         <a
-          className="text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 underline"
+          style={{ color: 'var(--color-accent)', textDecoration: 'underline' }}
           href="https://stripe.com/docs"
         >
           Stripe
@@ -34,7 +26,7 @@ function SpeakerProfile({ lang }: { lang: 'ja' | 'en' }) {
     <>
       Hide (ひで pronounced &quot;Hee-Day&quot;) is a Business Development professional at{' '}
       <a
-        className="text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 underline"
+        style={{ color: 'var(--color-accent)', textDecoration: 'underline' }}
         href="https://en.digitalcube.jp/"
       >
         DigitalCube
@@ -43,7 +35,7 @@ function SpeakerProfile({ lang }: { lang: 'ja' | 'en' }) {
       improvements using generative AI, and developing new business models. Previously, he was a
       Developer Advocate at{' '}
       <a
-        className="text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 underline"
+        style={{ color: 'var(--color-accent)', textDecoration: 'underline' }}
         href="https://stripe.com/docs"
       >
         Stripe
@@ -51,7 +43,7 @@ function SpeakerProfile({ lang }: { lang: 'ja' | 'en' }) {
       , where he worked on writing, coding, and teaching how to integrate online payments. He has
       organized several community conferences including WordCamp Kansai 2024 and{' '}
       <a
-        className="text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 underline"
+        style={{ color: 'var(--color-accent)', textDecoration: 'underline' }}
         href="https://connect2019.jpstripes.com/"
       >
         JP_Stripes Connect 2019
@@ -63,33 +55,44 @@ function SpeakerProfile({ lang }: { lang: 'ja' | 'en' }) {
   )
 }
 
-type ExperienceCardProps = {
+type ExperienceItem = {
+  no: string
   title: string
   period: string
   description: string
   highlights?: string[]
 }
 
-function ExperienceCard({ title, period, description, highlights }: ExperienceCardProps) {
+function ExperiencePanel({ item }: { item: ExperienceItem }) {
   return (
-    <article className="group relative flex h-full flex-col rounded-2xl border border-zinc-200 bg-white p-8 transition-all hover:shadow-md hover:border-indigo-200 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-800">
-      <div className="flex items-start justify-between gap-4 mb-4">
-        <h3 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-white">
-          {title}
-        </h3>
-        <span className="text-sm font-medium text-slate-500 dark:text-slate-400 whitespace-nowrap">
-          {period}
+    <article className="ds-panel">
+      <span className="ds-panel__no">{item.no}</span>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          gap: '1rem',
+        }}
+      >
+        <h3 className="ds-panel__title">{item.title}</h3>
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 'var(--text-xs)',
+            color: 'var(--color-muted)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {item.period}
         </span>
       </div>
-      <p className="text-base leading-relaxed text-slate-700 dark:text-slate-400 mb-6">
-        {description}
-      </p>
-      {highlights && highlights.length > 0 && (
-        <ul className="mt-auto space-y-3 text-sm leading-6 text-slate-600 dark:text-slate-400">
-          {highlights.map((highlight) => (
-            <li key={highlight} className="flex items-start gap-3">
-              <span className="mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-indigo-600 dark:bg-indigo-400" />
-              <span>{highlight}</span>
+      <p className="ds-panel__body">{item.description}</p>
+      {item.highlights && item.highlights.length > 0 && (
+        <ul className="ds-panel__bullets">
+          {item.highlights.map((h) => (
+            <li key={h} className="ds-panel__bullet">
+              {h}
             </li>
           ))}
         </ul>
@@ -98,42 +101,18 @@ function ExperienceCard({ title, period, description, highlights }: ExperienceCa
   )
 }
 
-function CertificationBadge({ title, link, src }: { title: string; link?: string; src: string }) {
-  const content = (
-    <div className="group relative transition-transform hover:scale-105">
-      <Image
-        src={src}
-        width={120}
-        height={120}
-        alt={title}
-        className="rounded-lg shadow-sm group-hover:shadow-md transition-shadow"
-      />
-    </div>
-  )
-
-  if (link) {
-    return (
-      <a href={link} target="_blank" rel="noopener noreferrer" className="block" aria-label={title}>
-        {content}
-      </a>
-    )
-  }
-
-  return content
-}
-
 export default function AboutPageContent({ lang }: { lang: 'ja' | 'en' }) {
   const isJa = lang.startsWith('ja')
 
-  const pageTitle = isJa ? 'Hidetaka Okamotoについて' : 'About Hidetaka Okamoto'
   const pageDescription = isJa
     ? 'SaaSやECサイトの収益最大化を支援するエンジニア。Stripe、AWS Serverless、WordPressを専門としています。'
     : 'Engineering partner specializing in Stripe, AWS Serverless, and WordPress. Helping SaaS and e-commerce sites maximize revenue.'
 
-  const experiences: ExperienceCardProps[] = isJa
+  const experiences: ExperienceItem[] = isJa
     ? [
         {
-          title: 'DigitalCube - Business Development',
+          no: '01',
+          title: 'DigitalCube — Business Development',
           period: '2024 - 現在',
           description:
             'SaaSやECサイトの収益を増やすための方法・生成AIを使った効率化や新しい事業モデルの模索などに挑戦しています。',
@@ -144,7 +123,8 @@ export default function AboutPageContent({ lang }: { lang: 'ja' | 'en' }) {
           ],
         },
         {
-          title: 'Stripe - Developer Advocate',
+          no: '02',
+          title: 'Stripe — Developer Advocate',
           period: '2019 - 2024',
           description:
             '開発者・ユーザーコミュニティとの対話やコンテンツ・サンプルの提供に取り組みました。',
@@ -155,7 +135,8 @@ export default function AboutPageContent({ lang }: { lang: 'ja' | 'en' }) {
           ],
         },
         {
-          title: 'DigitalCube - Lead Software Engineer',
+          no: '03',
+          title: 'DigitalCube — Lead Software Engineer',
           period: '2015 - 2019',
           description:
             'プラグイン開発、オープンソースプロジェクト、SaaSアプリケーションダッシュボードの開発に従事しました。',
@@ -168,7 +149,8 @@ export default function AboutPageContent({ lang }: { lang: 'ja' | 'en' }) {
       ]
     : [
         {
-          title: 'DigitalCube - Business Development',
+          no: '01',
+          title: 'DigitalCube — Business Development',
           period: '2024 - Present',
           description:
             'Working on methods to increase revenue for SaaS and EC sites, exploring efficiency improvements using generative AI, and developing new business models.',
@@ -179,7 +161,8 @@ export default function AboutPageContent({ lang }: { lang: 'ja' | 'en' }) {
           ],
         },
         {
-          title: 'Stripe - Developer Advocate',
+          no: '02',
+          title: 'Stripe — Developer Advocate',
           period: '2019 - 2024',
           description:
             'Worked on writing, coding, and teaching how to integrate online payments. Engaged with developer and user communities.',
@@ -190,7 +173,8 @@ export default function AboutPageContent({ lang }: { lang: 'ja' | 'en' }) {
           ],
         },
         {
-          title: 'DigitalCube - Lead Software Engineer',
+          no: '03',
+          title: 'DigitalCube — Lead Software Engineer',
           period: '2015 - 2019',
           description:
             'Focused on building plugins, open source projects, and developing SaaS application dashboards.',
@@ -225,114 +209,268 @@ export default function AboutPageContent({ lang }: { lang: 'ja' | 'en' }) {
     },
   ]
 
-  const certificationsTitle = isJa ? '認定証' : 'Certifications'
   const experienceTitle = isJa ? '経歴' : 'Experience'
+  const certificationsTitle = isJa ? '認定証' : 'Certifications'
   const connectTitle = isJa ? '連絡先' : 'Connect'
+  const moreAboutTitle = isJa ? '詳細プロフィール' : 'More About Me'
+  const profileTitle = isJa ? 'プロフィール' : 'Profile'
 
   return (
     <>
-      {/* Hero Section */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-white via-indigo-50/40 to-purple-50/30 dark:from-zinc-900 dark:via-indigo-950/30 dark:to-purple-950/20 -mt-[var(--header-height)] pt-[var(--header-height)]">
-        <BackgroundDecoration variant="hero" />
+      {/* Hero */}
+      <section style={{ borderBottom: '1px solid var(--color-line-strong)' }}>
+        <div className="mx-auto max-w-[1440px] px-8 sm:px-16">
+          {/* Top bar */}
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr auto',
+              padding: '0.75rem 0',
+              borderBottom: '1px solid var(--color-line)',
+            }}
+          >
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 'var(--text-2xs)',
+                letterSpacing: '0.14em',
+                textTransform: 'uppercase',
+                color: 'var(--color-muted)',
+              }}
+            >
+              Hidetaka.dev / ABOUT
+            </span>
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 'var(--text-2xs)',
+                letterSpacing: '0.14em',
+                textTransform: 'uppercase',
+                color: 'var(--color-muted)',
+              }}
+            >
+              {isJa ? 'プロフィール' : 'ABOUT · PROFILE'}
+            </span>
+          </div>
 
-        <Container className="relative py-24 sm:py-32 lg:py-40">
-          <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-16 lg:gap-20">
-            {/* Left: Content */}
-            <div className="flex-1 space-y-8 lg:max-w-2xl">
-              <PageHeader title={pageTitle} description={pageDescription} />
-              <div className="space-y-6 text-base leading-relaxed text-slate-600 dark:text-slate-400">
+          {/* Main grid */}
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr',
+              gap: '3rem',
+              paddingTop: '3rem',
+              paddingBottom: '4rem',
+            }}
+            className="lg:grid-cols-[1fr_320px]"
+          >
+            {/* Left */}
+            <div>
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 'var(--text-2xs)',
+                  letterSpacing: '0.2em',
+                  textTransform: 'uppercase',
+                  color: 'var(--color-muted)',
+                  marginBottom: '1rem',
+                }}
+              >
+                &#9675; {profileTitle}
+              </div>
+              <h1
+                style={{
+                  fontFamily: 'var(--font-sans)',
+                  fontWeight: 900,
+                  fontSize: 'clamp(40px,6vw,80px)',
+                  lineHeight: 1,
+                  letterSpacing: '-0.03em',
+                  color: 'var(--color-ink)',
+                  marginBottom: '1.5rem',
+                }}
+              >
+                {isJa ? 'Hidetaka\nOkamoto' : 'Hidetaka\nOkamoto'}
+              </h1>
+              <p
+                style={{
+                  fontFamily: 'var(--font-serif)',
+                  fontSize: 'var(--text-md)',
+                  lineHeight: 'var(--leading-loose)',
+                  color: 'var(--color-ink-2)',
+                  maxWidth: '38em',
+                }}
+              >
+                {pageDescription}
+              </p>
+              <div
+                style={{
+                  marginTop: '2rem',
+                  fontFamily: 'var(--font-serif)',
+                  fontSize: 'var(--text-base)',
+                  lineHeight: 'var(--leading-loose)',
+                  color: 'var(--color-ink-2)',
+                  maxWidth: '38em',
+                }}
+              >
                 <Profile lang={lang} />
               </div>
             </div>
 
-            {/* Right: Image */}
-            <ProfileImage src="/images/profile.jpg" alt="Hidetaka Okamoto" size="lg" />
-          </div>
-        </Container>
-      </section>
-
-      {/* Experience Section */}
-      <section className="relative py-24 sm:py-32">
-        <Container>
-          <SectionHeader
-            title={experienceTitle}
-            description={isJa ? 'これまでの経験と専門性' : 'Professional experience and expertise'}
-            align="center"
-          />
-
-          <div className="mt-20 grid gap-8 lg:grid-cols-3 lg:gap-10">
-            {experiences.map((experience) => (
-              <ExperienceCard key={experience.title} {...experience} />
-            ))}
-          </div>
-
-          {/* Additional Profile */}
-          <div className="mt-16 max-w-3xl mx-auto">
-            <div className="rounded-2xl border border-zinc-200 bg-white p-10 dark:border-zinc-800 dark:bg-zinc-900">
-              <h3 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-white mb-6">
-                {isJa ? '詳細プロフィール' : 'More About Me'}
-              </h3>
-              <div className="space-y-6 text-base leading-relaxed text-slate-700 dark:text-slate-400">
-                <SpeakerProfile lang={lang} />
-              </div>
+            {/* Right: portrait */}
+            <div
+              style={{
+                position: 'relative',
+                aspectRatio: '3/4',
+                border: '1px solid var(--color-line-strong)',
+                overflow: 'hidden',
+              }}
+            >
+              <Image
+                src="/images/profile.jpg"
+                alt="Hidetaka Okamoto"
+                fill
+                className="object-cover"
+                sizes="(max-width: 1024px) 100vw, 320px"
+                priority
+              />
             </div>
           </div>
-        </Container>
+        </div>
       </section>
 
-      {/* Certifications Section */}
-      <section className="relative py-24 sm:py-32 bg-white dark:bg-zinc-900">
-        <Container>
+      {/* Experience */}
+      <section style={{ borderBottom: '1px solid var(--color-line-strong)' }}>
+        <div className="mx-auto max-w-[1440px] px-8 sm:px-16 py-16">
           <SectionHeader
-            title={certificationsTitle}
-            description={isJa ? 'Stripe認定資格' : 'Stripe certifications'}
-            align="center"
+            no="01"
+            title={experienceTitle}
+            titleSub={isJa ? 'これまでの経験と専門性' : 'Professional experience and expertise'}
           />
 
-          <div className="mt-16 flex flex-wrap justify-center gap-8 lg:gap-10">
-            {certifications.map((cert) => (
-              <CertificationBadge key={cert.title} {...cert} />
+          <div className="ds-panel-grid ds-panel-grid--3" style={{ marginTop: '2rem' }}>
+            {experiences.map((exp) => (
+              <ExperiencePanel key={exp.no} item={exp} />
             ))}
           </div>
-        </Container>
+
+          {/* Additional profile */}
+          <div style={{ marginTop: '2rem' }}>
+            <article className="ds-panel" style={{ maxWidth: '800px' }}>
+              <h3 className="ds-panel__title">{moreAboutTitle}</h3>
+              <p className="ds-panel__body">
+                <SpeakerProfile lang={lang} />
+              </p>
+            </article>
+          </div>
+        </div>
       </section>
 
-      {/* Connect Section */}
-      <section className="relative py-24 sm:py-32">
-        <Container>
+      {/* Certifications */}
+      <section style={{ borderBottom: '1px solid var(--color-line-strong)' }}>
+        <div className="mx-auto max-w-[1440px] px-8 sm:px-16 py-16">
           <SectionHeader
-            title={connectTitle}
-            description={isJa ? 'SNSやGitHubでフォローしてください' : 'Follow me on social media'}
-            align="center"
+            no="02"
+            title={certificationsTitle}
+            titleSub={isJa ? 'Stripe認定資格' : 'Stripe certifications'}
           />
 
-          <div className="mt-16 flex justify-center">
-            <ul className="space-y-6">
-              <SocialLink
-                href={SITE_CONFIG.social.twitter.url}
-                icon={TwitterIcon}
-                aria-label={SITE_CONFIG.social.twitter.ariaLabel}
-              >
-                {isJa ? 'Twitterでフォロー' : 'Follow on Twitter'}
-              </SocialLink>
-              <SocialLink
-                href={SITE_CONFIG.social.github.url}
-                icon={GitHubIcon}
-                aria-label={SITE_CONFIG.social.github.ariaLabel}
-              >
-                {isJa ? 'GitHubでフォロー' : 'Follow on GitHub'}
-              </SocialLink>
-              <SocialLink
-                href={SITE_CONFIG.social.linkedin.url}
-                icon={LinkedInIcon}
-                aria-label={SITE_CONFIG.social.linkedin.ariaLabel}
-              >
-                {isJa ? 'LinkedInでフォロー' : 'Follow on LinkedIn'}
-              </SocialLink>
-            </ul>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '2rem', marginTop: '2rem' }}>
+            {certifications.map((cert) =>
+              cert.link ? (
+                <a
+                  key={cert.title}
+                  href={cert.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={cert.title}
+                >
+                  <Image src={cert.src} width={120} height={120} alt={cert.title} />
+                </a>
+              ) : (
+                <Image key={cert.title} src={cert.src} width={120} height={120} alt={cert.title} />
+              ),
+            )}
           </div>
-        </Container>
+        </div>
       </section>
+
+      {/* Connect */}
+      <section>
+        <div className="mx-auto max-w-[1440px] px-8 sm:px-16 py-16">
+          <SectionHeader
+            no="03"
+            title={connectTitle}
+            titleSub={isJa ? 'SNSやGitHubでフォローしてください' : 'Follow me on social media'}
+          />
+
+          <div
+            style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', marginTop: '2rem' }}
+          >
+            <Link
+              href={SITE_CONFIG.social.twitter.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ds-btn ds-btn--secondary"
+              style={{ width: 'fit-content' }}
+              aria-label={SITE_CONFIG.social.twitter.ariaLabel}
+            >
+              Twitter / X →
+            </Link>
+            <Link
+              href={SITE_CONFIG.social.github.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ds-btn ds-btn--secondary"
+              style={{ width: 'fit-content' }}
+              aria-label={SITE_CONFIG.social.github.ariaLabel}
+            >
+              GitHub →
+            </Link>
+            <Link
+              href={SITE_CONFIG.social.linkedin.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ds-btn ds-btn--secondary"
+              style={{ width: 'fit-content' }}
+              aria-label={SITE_CONFIG.social.linkedin.ariaLabel}
+            >
+              LinkedIn →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <div className="mx-auto max-w-[1440px] px-8 sm:px-16">
+        <div className="ds-cta-block">
+          <span className="ds-cta-block__pre">{isJa ? 'お問い合わせ' : 'Get In Touch'}</span>
+          <h2 className="ds-cta-block__title">
+            {isJa ? (
+              <>
+                一緒に<em>プロジェクト</em>を<br />
+                始めませんか？
+              </>
+            ) : (
+              <>
+                Let&apos;s build something
+                <br />
+                <em>together.</em>
+              </>
+            )}
+          </h2>
+          <div className="ds-cta-block__actions">
+            <a href="mailto:hello@hidetaka.dev" className="ds-btn ds-btn--primary ds-btn--lg">
+              {isJa ? 'メールで相談する' : 'Get in touch'}
+            </a>
+            <Link
+              href={isJa ? '/ja/work' : '/work'}
+              className="ds-btn ds-btn--secondary ds-btn--lg"
+            >
+              {isJa ? '制作物を見る' : 'View my work'}
+            </Link>
+          </div>
+        </div>
+      </div>
     </>
   )
 }

--- a/src/components/containers/pages/BlogDetailPage.tsx
+++ b/src/components/containers/pages/BlogDetailPage.tsx
@@ -88,32 +88,33 @@ export default function BlogDetailPage({
   return (
     <Container className="mt-16 sm:mt-32">
       {/* パンくずリスト */}
-      <nav aria-label="Breadcrumb" className="mb-8">
-        <ol className="flex items-center space-x-2">
+      <nav
+        aria-label="Breadcrumb"
+        className="mb-8"
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 'var(--text-xs)',
+          letterSpacing: '0.1em',
+          color: 'var(--color-muted)',
+        }}
+      >
+        <ol style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <li>
-            <div className="flex items-center text-sm">
-              <Link
-                href={basePath}
-                className="font-medium text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100 transition-colors"
-              >
-                {blogLabel}
-              </Link>
-              <svg
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                aria-hidden="true"
-                className="ml-2 size-5 shrink-0 text-slate-300 dark:text-slate-600"
-              >
-                <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-              </svg>
-            </div>
+            <Link href={basePath} style={{ color: 'var(--color-muted)' }}>
+              {blogLabel}
+            </Link>
           </li>
-          <li>
-            <div className="flex items-center text-sm">
-              <span className="font-medium text-slate-900 dark:text-slate-100 line-clamp-1">
-                {thought.title.rendered}
-              </span>
-            </div>
+          <li style={{ opacity: 0.4 }}>/</li>
+          <li
+            style={{
+              color: 'var(--color-ink)',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              maxWidth: '40ch',
+            }}
+          >
+            {thought.title.rendered}
           </li>
         </ol>
       </nav>
@@ -143,7 +144,16 @@ export default function BlogDetailPage({
 
           {/* タイトル */}
           <header className="mb-6">
-            <h1 className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 sm:text-5xl">
+            <h1
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontWeight: 900,
+                fontSize: 'clamp(28px,4vw,48px)',
+                lineHeight: 1.1,
+                letterSpacing: '-0.025em',
+                color: 'var(--color-ink)',
+              }}
+            >
               {thought.title.rendered}
             </h1>
           </header>
@@ -220,36 +230,26 @@ export default function BlogDetailPage({
           {(previousThought || nextThought) && (
             <nav
               aria-label="記事ナビゲーション"
-              className="mt-16 pt-8 border-t border-zinc-200 dark:border-zinc-700 lg:hidden"
+              className="ds-pagination lg:hidden"
+              style={{ marginTop: '4rem' }}
             >
-              <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
-                {/* 次の記事 */}
+              <div>
                 {nextThought && (
                   <Link
                     href={`${basePath}/${nextThought.slug}`}
-                    className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors"
+                    className="ds-btn ds-btn--ghost ds-btn--sm"
                   >
-                    <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
-                      ← {nextLabel}
-                    </span>
-                    <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
-                      {nextThought.title.rendered}
-                    </span>
+                    ← {nextLabel}
                   </Link>
                 )}
-
-                {/* 前の記事 */}
+              </div>
+              <div>
                 {previousThought && (
                   <Link
                     href={`${basePath}/${previousThought.slug}`}
-                    className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors text-right"
+                    className="ds-btn ds-btn--ghost ds-btn--sm"
                   >
-                    <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
-                      {previousLabel} →
-                    </span>
-                    <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
-                      {previousThought.title.rendered}
-                    </span>
+                    {previousLabel} →
                   </Link>
                 )}
               </div>

--- a/src/components/containers/pages/BlogPage.tsx
+++ b/src/components/containers/pages/BlogPage.tsx
@@ -1,10 +1,7 @@
 import Link from 'next/link'
-import Container from '@/components/tailwindui/Container'
 import DateDisplay from '@/components/ui/DateDisplay'
 import PageHeader from '@/components/ui/PageHeader'
 import Pagination from '@/components/ui/Pagination'
-import SidebarLayout from '@/components/ui/SidebarLayout'
-import Tag from '@/components/ui/Tag'
 import type { CategoryWithCount } from '@/libs/dataSources/thoughts'
 import type { BlogItem } from '@/libs/dataSources/types'
 
@@ -18,173 +15,6 @@ type BlogPageProps = {
   categories?: CategoryWithCount[]
 }
 
-// ブログ記事カードコンポーネント
-function BlogCard({ item, lang }: { item: BlogItem; lang: string }) {
-  const date = new Date(item.datetime)
-
-  return (
-    <Link href={item.href} className="group block">
-      <article className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-white transition-all hover:border-indigo-300 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-700">
-        <div className="p-5 lg:p-6">
-          <div className="flex flex-col gap-3">
-            {/* Date and Categories */}
-            <div className="flex items-center gap-3 flex-wrap">
-              <DateDisplay
-                date={date}
-                lang={lang}
-                format="short"
-                className="text-xs font-semibold text-slate-500 dark:text-slate-400"
-              />
-              {item.categories &&
-                item.categories.length > 0 &&
-                item.categories.map((category) => (
-                  <Tag key={category.id} variant="indigo" size="sm">
-                    {category.name}
-                  </Tag>
-                ))}
-            </div>
-
-            {/* Title */}
-            <h3 className="text-lg font-bold leading-tight text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">
-              {item.title}
-            </h3>
-
-            {/* Description */}
-            {item.description && (
-              <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400 line-clamp-3">
-                {item.description}
-                {item.description.length >= 150 ? '...' : ''}
-              </p>
-            )}
-
-            {/* Read more indicator */}
-            <div className="flex items-center text-sm font-medium text-indigo-600 dark:text-indigo-400 mt-1">
-              {lang === 'ja' ? '続きを読む' : 'Read more'}
-              <svg className="ml-1 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 5l7 7-7 7"
-                />
-              </svg>
-            </div>
-          </div>
-        </div>
-      </article>
-    </Link>
-  )
-}
-
-// 記事が見つからない場合のメッセージコンポーネント
-function NoArticlesMessage({ lang }: { lang: string }) {
-  if (lang === 'ja') {
-    return (
-      <div className="py-12 text-center">
-        <p className="text-slate-600 dark:text-slate-400">記事が見つかりませんでした。</p>
-      </div>
-    )
-  }
-
-  return (
-    <div className="py-12 text-center">
-      <div className="max-w-2xl mx-auto space-y-4">
-        <p className="text-slate-600 dark:text-slate-400">No articles found in English.</p>
-        <div className="rounded-lg border border-indigo-200 bg-indigo-50 dark:border-indigo-800 dark:bg-indigo-900/20 p-6">
-          <p className="text-sm text-slate-700 dark:text-slate-300 mb-4">
-            However, we have articles available in Japanese! You can view them using a translation
-            tool if needed.
-          </p>
-          <Link
-            href="/ja/blog"
-            className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600"
-          >
-            View Japanese Blog
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </Link>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// サイドバーコンポーネント
-function BlogSidebar({
-  categories,
-  basePath,
-  lang,
-  currentCategorySlug,
-}: {
-  categories: CategoryWithCount[]
-  basePath: string
-  lang: string
-  currentCategorySlug?: string
-}) {
-  const categoryTitle = lang === 'ja' ? 'カテゴリ' : 'Categories'
-  const allText = lang === 'ja' ? 'すべて' : 'All'
-
-  // basePathからカテゴリ部分を除去して、ブログのベースパスを取得
-  // basePathが `/ja/blog/category/xxx` の場合は `/ja/blog` に
-  // basePathが `/ja/blog` の場合はそのまま
-  const blogBasePath = basePath.includes('/category/') ? basePath.split('/category/')[0] : basePath
-
-  return (
-    <div className="hidden lg:block space-y-6">
-      <div>
-        <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-slate-900 dark:text-white">
-          {categoryTitle}
-        </h3>
-        <nav className="space-y-1">
-          <Link
-            href={blogBasePath}
-            className={`w-full flex items-center justify-between rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors ${
-              !currentCategorySlug
-                ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-400'
-                : 'text-slate-700 hover:bg-zinc-50 dark:text-slate-300 dark:hover:bg-zinc-800'
-            }`}
-          >
-            <span>{allText}</span>
-          </Link>
-          {categories.map((category) => {
-            // category.slugが既にエンコードされている可能性があるので、一度デコードしてからエンコード
-            const normalizedSlug = category.slug.includes('%')
-              ? decodeURIComponent(category.slug)
-              : category.slug
-            const categoryUrl = `${blogBasePath}/category/${encodeURIComponent(normalizedSlug)}`
-            const isActive =
-              currentCategorySlug === category.slug || currentCategorySlug === normalizedSlug
-            return (
-              <Link
-                key={category.id}
-                href={categoryUrl}
-                className={`w-full flex items-center justify-between rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-400'
-                    : 'text-slate-700 hover:bg-zinc-50 dark:text-slate-300 dark:hover:bg-zinc-800'
-                }`}
-              >
-                <span>{category.name}</span>
-                <span
-                  className={`ml-2 rounded-full px-2 py-0.5 text-xs ${
-                    isActive
-                      ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
-                      : 'bg-zinc-100 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-400'
-                  }`}
-                >
-                  {category.count > 20 ? '20+' : category.count}
-                </span>
-              </Link>
-            )
-          })}
-        </nav>
-      </div>
-    </div>
-  )
-}
-
-// ページタイトルと説明文を取得するヘルパー関数
 function getPageContent(lang: string, categoryName?: string) {
   const title = categoryName
     ? lang === 'ja'
@@ -216,74 +46,124 @@ export default function BlogPageContent({
 }: BlogPageProps) {
   const { title, description } = getPageContent(lang, categoryName)
 
-  // 現在のカテゴリslugを取得（URLから）
   const currentCategorySlug = categoryName
     ? categories.find((cat) => cat.name === categoryName)?.slug
     : undefined
 
+  const blogBasePath = basePath.includes('/category/') ? basePath.split('/category/')[0] : basePath
+
+  const categoryTitle = lang === 'ja' ? 'カテゴリ' : 'Categories'
+  const allText = lang === 'ja' ? 'すべて' : 'All'
+
   return (
-    <section className="pt-12 sm:pt-16 pb-8 sm:pb-12 bg-white dark:bg-zinc-900">
-      <Container>
-        <PageHeader title={title} description={description} />
+    <section className="mx-auto max-w-[1440px] px-8 sm:px-16 pt-12 pb-20">
+      <PageHeader eyebrow="BLOG" title={title} sub={description} />
 
-        {/* サイドバーとメインコンテンツ */}
-        {categories.length > 0 ? (
-          <SidebarLayout
-            sidebar={
-              <BlogSidebar
-                categories={categories}
-                basePath={basePath}
-                lang={lang}
-                currentCategorySlug={currentCategorySlug}
-              />
-            }
+      {/* Category filter bar */}
+      {categories.length > 0 && (
+        <div className="ds-filter-bar">
+          <span className="ds-filter-bar__label">{categoryTitle}</span>
+          <Link
+            href={blogBasePath}
+            className="ds-tag"
+            aria-pressed={!currentCategorySlug ? 'true' : 'false'}
           >
-            {/* 記事グリッド */}
-            {thoughts.length > 0 ? (
-              <>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
-                  {thoughts.map((item) => (
-                    <BlogCard key={item.id || item.href} item={item} lang={lang} />
-                  ))}
-                </div>
+            {allText}
+          </Link>
+          {categories.map((category) => {
+            const normalizedSlug = category.slug.includes('%')
+              ? decodeURIComponent(category.slug)
+              : category.slug
+            const categoryUrl = `${blogBasePath}/category/${encodeURIComponent(normalizedSlug)}`
+            const isActive =
+              currentCategorySlug === category.slug || currentCategorySlug === normalizedSlug
+            return (
+              <Link
+                key={category.id}
+                href={categoryUrl}
+                className="ds-tag"
+                aria-pressed={isActive ? 'true' : 'false'}
+              >
+                {category.name}{' '}
+                <small style={{ opacity: 0.6 }}>
+                  {category.count > 20 ? '20+' : category.count}
+                </small>
+              </Link>
+            )
+          })}
+        </div>
+      )}
 
-                {/* ページネーション */}
-                <Pagination
-                  currentPage={currentPage}
-                  totalPages={totalPages}
-                  basePath={basePath}
-                  lang={lang}
-                />
-              </>
-            ) : (
-              <NoArticlesMessage lang={lang} />
-            )}
-          </SidebarLayout>
-        ) : (
-          <>
-            {/* 記事グリッド */}
-            {thoughts.length > 0 ? (
-              <>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
-                  {thoughts.map((item) => (
-                    <BlogCard key={item.id || item.href} item={item} lang={lang} />
-                  ))}
-                </div>
+      {/* Entry list */}
+      {thoughts.length > 0 ? (
+        <>
+          <div>
+            {thoughts.map((item, i) => {
+              const date = new Date(item.datetime)
+              return (
+                <Link key={item.id || item.href} href={item.href} className="ds-entry">
+                  <span className="ds-entry__no">
+                    {String(i + 1 + (currentPage - 1) * 10).padStart(3, '0')}
+                  </span>
+                  <div>
+                    <p className="ds-entry__title">{item.title}</p>
+                    {item.categories && item.categories.length > 0 && (
+                      <p className="ds-entry__meta">
+                        {item.categories.map((c) => c.name).join(' · ')}
+                      </p>
+                    )}
+                    {item.description && (
+                      <p className="ds-entry__meta">
+                        {item.description.length > 100
+                          ? `${item.description.substring(0, 100)}…`
+                          : item.description}
+                      </p>
+                    )}
+                  </div>
+                  <DateDisplay date={date} lang={lang} format="short" className="ds-entry__date" />
+                </Link>
+              )
+            })}
+          </div>
 
-                {/* ページネーション */}
-                <Pagination
-                  currentPage={currentPage}
-                  totalPages={totalPages}
-                  basePath={basePath}
-                  lang={lang}
-                />
-              </>
-            ) : (
-              <NoArticlesMessage lang={lang} />
-            )}
-          </>
-        )}
-      </Container>
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            basePath={basePath}
+            lang={lang}
+          />
+        </>
+      ) : (
+        <div style={{ padding: '3rem 0' }}>
+          {lang === 'ja' ? (
+            <p
+              style={{
+                color: 'var(--color-muted)',
+                fontFamily: 'var(--font-mono)',
+                fontSize: 'var(--text-sm)',
+              }}
+            >
+              記事が見つかりませんでした。
+            </p>
+          ) : (
+            <div>
+              <p
+                style={{
+                  color: 'var(--color-muted)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 'var(--text-sm)',
+                  marginBottom: '1rem',
+                }}
+              >
+                No articles found in English.
+              </p>
+              <Link href="/ja/blog" className="ds-btn ds-btn--secondary ds-btn--sm">
+                View Japanese Blog →
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
     </section>
   )
 }

--- a/src/components/containers/pages/DevNoteDetailPage.tsx
+++ b/src/components/containers/pages/DevNoteDetailPage.tsx
@@ -51,33 +51,37 @@ export default function DevNoteDetailPage({
   return (
     <Container className="mt-16 sm:mt-32">
       {/* パンくずリスト */}
-      <nav aria-label="Breadcrumb" className="mb-8">
-        <ol className="flex items-center space-x-2">
+      <nav
+        aria-label="Breadcrumb"
+        className="mb-8"
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 'var(--text-xs)',
+          letterSpacing: '0.1em',
+          color: 'var(--color-muted)',
+        }}
+      >
+        <ol style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <li>
-            <div className="flex items-center text-sm">
-              <Link
-                href={lang === 'ja' ? '/ja/writing' : '/writing'}
-                aria-label={lang === 'ja' ? `${writingLabel}に戻る` : `Go to ${writingLabel}`}
-                className="font-medium text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100 transition-colors"
-              >
-                {writingLabel}
-              </Link>
-              <svg
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                aria-hidden="true"
-                className="ml-2 size-5 shrink-0 text-slate-300 dark:text-slate-600"
-              >
-                <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-              </svg>
-            </div>
+            <Link
+              href={lang === 'ja' ? '/ja/writing' : '/writing'}
+              aria-label={lang === 'ja' ? `${writingLabel}に戻る` : `Go to ${writingLabel}`}
+              style={{ color: 'var(--color-muted)' }}
+            >
+              {writingLabel}
+            </Link>
           </li>
-          <li>
-            <div className="flex items-center text-sm">
-              <span className="font-medium text-slate-900 dark:text-slate-100 line-clamp-1">
-                {note.title.rendered}
-              </span>
-            </div>
+          <li style={{ opacity: 0.4 }}>/</li>
+          <li
+            style={{
+              color: 'var(--color-ink)',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              maxWidth: '40ch',
+            }}
+          >
+            {note.title.rendered}
           </li>
         </ol>
       </nav>
@@ -107,7 +111,16 @@ export default function DevNoteDetailPage({
 
           {/* タイトル */}
           <header className="mb-6">
-            <h1 className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 sm:text-5xl">
+            <h1
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontWeight: 900,
+                fontSize: 'clamp(28px,4vw,48px)',
+                lineHeight: 1.1,
+                letterSpacing: '-0.025em',
+                color: 'var(--color-ink)',
+              }}
+            >
               {note.title.rendered}
             </h1>
           </header>
@@ -184,38 +197,26 @@ export default function DevNoteDetailPage({
           {(previousNote || nextNote) && (
             <nav
               aria-label={lang === 'ja' ? 'Dev Notesナビゲーション' : 'Dev Notes navigation'}
-              className="mt-16 pt-8 border-t border-zinc-200 dark:border-zinc-700 lg:hidden"
+              className="ds-pagination lg:hidden"
+              style={{ marginTop: '4rem' }}
             >
-              <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
-                {/* 次の記事 */}
+              <div>
                 {nextNote && (
                   <Link
                     href={`${basePath}/${nextNote.slug}`}
-                    aria-label={`${nextLabel}: ${nextNote.title.rendered}`}
-                    className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors"
+                    className="ds-btn ds-btn--ghost ds-btn--sm"
                   >
-                    <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
-                      ← {nextLabel}
-                    </span>
-                    <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
-                      {nextNote.title.rendered}
-                    </span>
+                    ← {nextLabel}
                   </Link>
                 )}
-
-                {/* 前の記事 */}
+              </div>
+              <div>
                 {previousNote && (
                   <Link
                     href={`${basePath}/${previousNote.slug}`}
-                    aria-label={`${previousLabel}: ${previousNote.title.rendered}`}
-                    className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors text-right"
+                    className="ds-btn ds-btn--ghost ds-btn--sm"
                   >
-                    <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
-                      {previousLabel} →
-                    </span>
-                    <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
-                      {previousNote.title.rendered}
-                    </span>
+                    {previousLabel} →
                   </Link>
                 )}
               </div>

--- a/src/components/containers/pages/EventDetailPage.tsx
+++ b/src/components/containers/pages/EventDetailPage.tsx
@@ -38,39 +38,49 @@ export default function EventDetailPage({
     <Container className="mt-16 sm:mt-32">
       <article className="max-w-3xl mx-auto">
         {/* パンくずリスト */}
-        <nav aria-label="Breadcrumb" className="mb-8">
-          <ol className="flex items-center space-x-2">
+        <nav
+          aria-label="Breadcrumb"
+          className="mb-8"
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 'var(--text-xs)',
+            letterSpacing: '0.1em',
+            color: 'var(--color-muted)',
+          }}
+        >
+          <ol style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <li>
-              <div className="flex items-center text-sm">
-                <Link
-                  href={basePath}
-                  className="font-medium text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100 transition-colors"
-                >
-                  {eventLabel}
-                </Link>
-                <svg
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                  aria-hidden="true"
-                  className="ml-2 size-5 shrink-0 text-slate-300 dark:text-slate-600"
-                >
-                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-                </svg>
-              </div>
+              <Link href={basePath} style={{ color: 'var(--color-muted)' }}>
+                {eventLabel}
+              </Link>
             </li>
-            <li>
-              <div className="flex items-center text-sm">
-                <span className="font-medium text-slate-900 dark:text-slate-100 line-clamp-1">
-                  {event.title.rendered}
-                </span>
-              </div>
+            <li style={{ opacity: 0.4 }}>/</li>
+            <li
+              style={{
+                color: 'var(--color-ink)',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                maxWidth: '40ch',
+              }}
+            >
+              {event.title.rendered}
             </li>
           </ol>
         </nav>
 
         {/* タイトル */}
         <header className="mb-6">
-          <h1 className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 sm:text-5xl">
+          <h1
+            style={{
+              fontFamily: 'var(--font-sans)',
+              fontWeight: 900,
+              fontSize: 'clamp(28px,4vw,48px)',
+              lineHeight: 1.1,
+              letterSpacing: '-0.025em',
+              color: 'var(--color-ink)',
+            }}
+          >
             {event.title.rendered}
           </h1>
         </header>
@@ -129,36 +139,26 @@ export default function EventDetailPage({
         {(previousEvent || nextEvent) && (
           <nav
             aria-label="記事ナビゲーション"
-            className="mt-16 pt-8 border-t border-zinc-200 dark:border-zinc-700"
+            className="ds-pagination"
+            style={{ marginTop: '4rem' }}
           >
-            <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
-              {/* 次の記事 */}
+            <div>
               {nextEvent && (
                 <Link
                   href={`${basePath}/${nextEvent.slug}`}
-                  className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors"
+                  className="ds-btn ds-btn--ghost ds-btn--sm"
                 >
-                  <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
-                    ← {nextLabel}
-                  </span>
-                  <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
-                    {nextEvent.title.rendered}
-                  </span>
+                  ← {nextLabel}
                 </Link>
               )}
-
-              {/* 前の記事 */}
+            </div>
+            <div>
               {previousEvent && (
                 <Link
                   href={`${basePath}/${previousEvent.slug}`}
-                  className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors text-right"
+                  className="ds-btn ds-btn--ghost ds-btn--sm"
                 >
-                  <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
-                    {previousLabel} →
-                  </span>
-                  <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
-                    {previousEvent.title.rendered}
-                  </span>
+                  {previousLabel} →
                 </Link>
               )}
             </div>

--- a/src/components/containers/pages/NewsDetailPage.tsx
+++ b/src/components/containers/pages/NewsDetailPage.tsx
@@ -40,39 +40,49 @@ export default function NewsDetailPage({
     <Container className="mt-16 sm:mt-32">
       <article className="max-w-3xl mx-auto">
         {/* パンくずリスト */}
-        <nav aria-label="Breadcrumb" className="mb-8">
-          <ol className="flex items-center space-x-2">
+        <nav
+          aria-label="Breadcrumb"
+          className="mb-8"
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 'var(--text-xs)',
+            letterSpacing: '0.1em',
+            color: 'var(--color-muted)',
+          }}
+        >
+          <ol style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <li>
-              <div className="flex items-center text-sm">
-                <Link
-                  href={basePath}
-                  className="font-medium text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100 transition-colors"
-                >
-                  {newsLabel}
-                </Link>
-                <svg
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                  aria-hidden="true"
-                  className="ml-2 size-5 shrink-0 text-slate-300 dark:text-slate-600"
-                >
-                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-                </svg>
-              </div>
+              <Link href={basePath} style={{ color: 'var(--color-muted)' }}>
+                {newsLabel}
+              </Link>
             </li>
-            <li>
-              <div className="flex items-center text-sm">
-                <span className="font-medium text-slate-900 dark:text-slate-100 line-clamp-1">
-                  {product.title.rendered}
-                </span>
-              </div>
+            <li style={{ opacity: 0.4 }}>/</li>
+            <li
+              style={{
+                color: 'var(--color-ink)',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                maxWidth: '40ch',
+              }}
+            >
+              {product.title.rendered}
             </li>
           </ol>
         </nav>
 
         {/* タイトル */}
         <header className="mb-6">
-          <h1 className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 sm:text-5xl">
+          <h1
+            style={{
+              fontFamily: 'var(--font-sans)',
+              fontWeight: 900,
+              fontSize: 'clamp(28px,4vw,48px)',
+              lineHeight: 1.1,
+              letterSpacing: '-0.025em',
+              color: 'var(--color-ink)',
+            }}
+          >
             {product.title.rendered}
           </h1>
         </header>
@@ -136,36 +146,26 @@ export default function NewsDetailPage({
         {(previousProduct || nextProduct) && (
           <nav
             aria-label="記事ナビゲーション"
-            className="mt-16 pt-8 border-t border-zinc-200 dark:border-zinc-700"
+            className="ds-pagination"
+            style={{ marginTop: '4rem' }}
           >
-            <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
-              {/* 次の記事 */}
+            <div>
               {nextProduct && (
                 <Link
                   href={`${basePath}/${nextProduct.slug}`}
-                  className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors"
+                  className="ds-btn ds-btn--ghost ds-btn--sm"
                 >
-                  <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
-                    ← {nextLabel}
-                  </span>
-                  <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
-                    {nextProduct.title.rendered}
-                  </span>
+                  ← {nextLabel}
                 </Link>
               )}
-
-              {/* 前の記事 */}
+            </div>
+            <div>
               {previousProduct && (
                 <Link
                   href={`${basePath}/${previousProduct.slug}`}
-                  className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors text-right"
+                  className="ds-btn ds-btn--ghost ds-btn--sm"
                 >
-                  <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
-                    {previousLabel} →
-                  </span>
-                  <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
-                    {previousProduct.title.rendered}
-                  </span>
+                  {previousLabel} →
                 </Link>
               )}
             </div>

--- a/src/components/containers/pages/NewsPage.tsx
+++ b/src/components/containers/pages/NewsPage.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link'
-import Container from '@/components/tailwindui/Container'
 import DateDisplay from '@/components/ui/DateDisplay'
 import PageHeader from '@/components/ui/PageHeader'
 import type { BlogItem } from '@/libs/dataSources/types'
@@ -7,68 +6,6 @@ import type { BlogItem } from '@/libs/dataSources/types'
 type NewsPageProps = {
   lang: string
   products: BlogItem[]
-}
-
-// 製品ニュースカードコンポーネント
-function NewsCard({ item, lang }: { item: BlogItem; lang: string }) {
-  const date = new Date(item.datetime)
-
-  return (
-    <Link href={item.href} className="group block">
-      <article className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-white transition-all hover:border-indigo-300 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-700">
-        <div className="p-5 lg:p-6">
-          <div className="flex flex-col gap-3">
-            {/* Date */}
-            <div className="flex items-center gap-3 flex-wrap">
-              <DateDisplay
-                date={date}
-                lang={lang}
-                format="short"
-                className="text-xs font-semibold text-slate-500 dark:text-slate-400"
-              />
-            </div>
-
-            {/* Title */}
-            <h3 className="text-lg font-bold leading-tight text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">
-              {item.title}
-            </h3>
-
-            {/* Description */}
-            {item.description && (
-              <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400 line-clamp-3">
-                {item.description}
-                {item.description.length >= 150 ? '...' : ''}
-              </p>
-            )}
-
-            {/* Read more indicator */}
-            <div className="flex items-center text-sm font-medium text-indigo-600 dark:text-indigo-400 mt-1">
-              {lang === 'ja' ? '続きを読む' : 'Read more'}
-              <svg className="ml-1 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 5l7 7-7 7"
-                />
-              </svg>
-            </div>
-          </div>
-        </div>
-      </article>
-    </Link>
-  )
-}
-
-// 記事が見つからない場合のメッセージコンポーネント
-function NoArticlesMessage({ lang }: { lang: string }) {
-  return (
-    <div className="py-12 text-center">
-      <p className="text-slate-600 dark:text-slate-400">
-        {lang === 'ja' ? '製品ニュースが見つかりませんでした。' : 'No product news found.'}
-      </p>
-    </div>
-  )
 }
 
 export default function NewsPageContent({ lang, products }: NewsPageProps) {
@@ -79,21 +16,43 @@ export default function NewsPageContent({ lang, products }: NewsPageProps) {
       : 'Product releases, updates, and announcements for my projects and libraries.'
 
   return (
-    <section className="pt-12 sm:pt-16 pb-8 sm:pb-12 bg-white dark:bg-zinc-900">
-      <Container>
-        <PageHeader title={title} description={description} />
+    <section className="mx-auto max-w-[1440px] px-8 sm:px-16 pt-12 pb-20">
+      <PageHeader eyebrow="NEWS" title={title} sub={description} />
 
-        {/* 記事グリッド */}
-        {products.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8">
-            {products.map((item) => (
-              <NewsCard key={item.id || item.href} item={item} lang={lang} />
-            ))}
-          </div>
-        ) : (
-          <NoArticlesMessage lang={lang} />
-        )}
-      </Container>
+      {products.length > 0 ? (
+        <div>
+          {products.map((item, i) => {
+            const date = new Date(item.datetime)
+            return (
+              <Link key={item.id || item.href} href={item.href} className="ds-entry">
+                <span className="ds-entry__no">{String(i + 1).padStart(3, '0')}</span>
+                <div>
+                  <p className="ds-entry__title">{item.title}</p>
+                  {item.description && (
+                    <p className="ds-entry__meta">
+                      {item.description.length > 120
+                        ? `${item.description.substring(0, 120)}…`
+                        : item.description}
+                    </p>
+                  )}
+                </div>
+                <DateDisplay date={date} lang={lang} format="short" className="ds-entry__date" />
+              </Link>
+            )
+          })}
+        </div>
+      ) : (
+        <p
+          style={{
+            color: 'var(--color-muted)',
+            padding: '3rem 0',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 'var(--text-sm)',
+          }}
+        >
+          {lang === 'ja' ? '製品ニュースが見つかりませんでした。' : 'No product news found.'}
+        </p>
+      )}
     </section>
   )
 }

--- a/src/components/containers/pages/SpeakingDetailPage.tsx
+++ b/src/components/containers/pages/SpeakingDetailPage.tsx
@@ -42,33 +42,37 @@ export default function SpeakingDetailPage({
   return (
     <Container className="mt-16 sm:mt-32">
       {/* パンくずリスト */}
-      <nav aria-label="Breadcrumb" className="mb-8">
-        <ol className="flex items-center space-x-2">
+      <nav
+        aria-label="Breadcrumb"
+        className="mb-8"
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 'var(--text-xs)',
+          letterSpacing: '0.1em',
+          color: 'var(--color-muted)',
+        }}
+      >
+        <ol style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <li>
-            <div className="flex items-center text-sm">
-              <Link
-                href={basePath}
-                aria-label={lang === 'ja' ? `${speakingLabel}に戻る` : `Go to ${speakingLabel}`}
-                className="font-medium text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100 transition-colors"
-              >
-                {speakingLabel}
-              </Link>
-              <svg
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                aria-hidden="true"
-                className="ml-2 size-5 shrink-0 text-slate-300 dark:text-slate-600"
-              >
-                <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-              </svg>
-            </div>
+            <Link
+              href={basePath}
+              aria-label={lang === 'ja' ? `${speakingLabel}に戻る` : `Go to ${speakingLabel}`}
+              style={{ color: 'var(--color-muted)' }}
+            >
+              {speakingLabel}
+            </Link>
           </li>
-          <li>
-            <div className="flex items-center text-sm">
-              <span className="font-medium text-slate-900 dark:text-slate-100 line-clamp-1">
-                {event.title.rendered}
-              </span>
-            </div>
+          <li style={{ opacity: 0.4 }}>/</li>
+          <li
+            style={{
+              color: 'var(--color-ink)',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              maxWidth: '40ch',
+            }}
+          >
+            {event.title.rendered}
           </li>
         </ol>
       </nav>
@@ -97,7 +101,16 @@ export default function SpeakingDetailPage({
 
           {/* タイトル */}
           <header className="mb-6">
-            <h1 className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 sm:text-5xl">
+            <h1
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontWeight: 900,
+                fontSize: 'clamp(28px,4vw,48px)',
+                lineHeight: 1.1,
+                letterSpacing: '-0.025em',
+                color: 'var(--color-ink)',
+              }}
+            >
               {event.title.rendered}
             </h1>
           </header>
@@ -154,38 +167,26 @@ export default function SpeakingDetailPage({
               aria-label={
                 lang === 'ja' ? 'イベントレポートナビゲーション' : 'Event report navigation'
               }
-              className="mt-16 pt-8 border-t border-zinc-200 dark:border-zinc-700 lg:hidden"
+              className="ds-pagination lg:hidden"
+              style={{ marginTop: '4rem' }}
             >
-              <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
-                {/* 次の記事 */}
+              <div>
                 {nextEvent && (
                   <Link
                     href={`${basePath}/${nextEvent.slug}`}
-                    aria-label={`${nextLabel}: ${nextEvent.title.rendered}`}
-                    className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors"
+                    className="ds-btn ds-btn--ghost ds-btn--sm"
                   >
-                    <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
-                      ← {nextLabel}
-                    </span>
-                    <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
-                      {nextEvent.title.rendered}
-                    </span>
+                    ← {nextLabel}
                   </Link>
                 )}
-
-                {/* 前の記事 */}
+              </div>
+              <div>
                 {previousEvent && (
                   <Link
                     href={`${basePath}/${previousEvent.slug}`}
-                    aria-label={`${previousLabel}: ${previousEvent.title.rendered}`}
-                    className="group flex flex-col flex-1 p-4 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors text-right"
+                    className="ds-btn ds-btn--ghost ds-btn--sm"
                   >
-                    <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
-                      {previousLabel} →
-                    </span>
-                    <span className="text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors line-clamp-2">
-                      {previousEvent.title.rendered}
-                    </span>
+                    {previousLabel} →
                   </Link>
                 )}
               </div>

--- a/src/components/containers/pages/SpeakingPage.tsx
+++ b/src/components/containers/pages/SpeakingPage.tsx
@@ -3,45 +3,10 @@
 import Link from 'next/link'
 import { useCallback, useMemo, useState } from 'react'
 import Container from '@/components/tailwindui/Container'
-import DateDisplay from '@/components/ui/DateDisplay'
-import FilterItem from '@/components/ui/FilterItem'
-import MobileFilterButton from '@/components/ui/MobileFilterButton'
-import MobileFilterDrawer, { type FilterGroup } from '@/components/ui/MobileFilterDrawer'
 import PageHeader from '@/components/ui/PageHeader'
-import SearchBar from '@/components/ui/SearchBar'
-import SidebarLayout from '@/components/ui/SidebarLayout'
-import Tag from '@/components/ui/Tag'
 import type { WPEvent } from '@/libs/dataSources/types'
 
 type FilterYear = string | null
-
-// 外部リンクアイコンコンポーネント
-function ExternalLinkIcon({ className = 'ml-1 h-4 w-4' }: { className?: string }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-      />
-    </svg>
-  )
-}
-
-// イベントリンクコンポーネント
-function EventLinks({ lang, link }: { lang: string; link: string }) {
-  return (
-    <Link
-      href={link}
-      className="flex items-center text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
-      onClick={(e) => e.stopPropagation()}
-    >
-      {lang === 'ja' ? '記事を読む' : 'Read Article'}
-      <ExternalLinkIcon />
-    </Link>
-  )
-}
 
 // イベントデータを取得するヘルパー関数
 function getEventData(event: WPEvent, basePath: string) {
@@ -60,8 +25,7 @@ function getEventData(event: WPEvent, basePath: string) {
   }
 }
 
-// Speakingカードコンポーネント
-function SpeakingCard({
+function SpeakingEntryRow({
   event,
   lang,
   basePath,
@@ -70,149 +34,41 @@ function SpeakingCard({
   lang: string
   basePath: string
 }) {
-  const { date, year, title, description, link } = getEventData(event, basePath)
+  const { date, title, description, link } = getEventData(event, basePath)
+  const dateStr = `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`
 
   return (
-    <Link href={link} className="group block">
-      <article className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-white transition-all hover:border-indigo-300 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-700">
-        {/* Content */}
-        <div className="p-5 lg:p-6">
-          <div className="flex flex-col gap-3">
-            {/* Date and Year */}
-            <div className="flex items-center gap-3 flex-wrap">
-              <DateDisplay
-                date={date}
-                lang={lang}
-                format="short"
-                className="text-xs font-semibold text-slate-500 dark:text-slate-400"
-              />
-              <Tag variant="default" size="sm">
-                {year}
-              </Tag>
+    <Link href={link} style={{ display: 'block', color: 'inherit', textDecoration: 'none' }}>
+      <div className="ds-speak-item">
+        <div className="ds-speak-item__date">{dateStr}</div>
+        <div>
+          <div className="ds-speak-item__title">{title}</div>
+          {description && (
+            <div className="ds-speak-item__event">
+              {description}
+              {description.length >= 150 ? '...' : ''}
             </div>
-
-            {/* Title */}
-            <h3 className="text-lg font-bold leading-tight text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">
-              {title}
-            </h3>
-
-            {/* Description */}
-            {description && (
-              <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400 line-clamp-3">
-                {description}
-                {description.length > 150 ? '...' : ''}
-              </p>
-            )}
-
-            {/* Links */}
-            <div className="flex items-center gap-4 mt-2">
-              <EventLinks lang={lang} link={link} />
-            </div>
-          </div>
+          )}
         </div>
-      </article>
+        <div
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 'var(--text-xs)',
+            color: 'var(--color-accent)',
+            whiteSpace: 'nowrap',
+            paddingTop: '4px',
+          }}
+        >
+          {lang === 'ja' ? '記事を読む →' : 'Read →'}
+        </div>
+      </div>
     </Link>
   )
 }
 
-// サイドバーコンポーネント（デスクトップ用）
-function Sidebar({
-  searchQuery,
-  onSearchChange,
-  filterYear,
-  onFilterYearChange,
-  availableYears,
-  counts,
-  lang,
-}: {
-  searchQuery: string
-  onSearchChange: (value: string) => void
-  filterYear: FilterYear
-  onFilterYearChange: (year: FilterYear) => void
-  availableYears: string[]
-  counts: {
-    all: number
-    byYear: Record<string, number>
-  }
-  lang: string
-}) {
-  const searchPlaceholder = lang === 'ja' ? '検索...' : 'Search...'
-  const yearTitle = lang === 'ja' ? '年' : 'Year'
-  const allText = lang === 'ja' ? 'すべて' : 'All'
-
-  return (
-    <div className="hidden lg:block space-y-6">
-      {/* 検索バー */}
-      <div>
-        <SearchBar value={searchQuery} onChange={onSearchChange} placeholder={searchPlaceholder} />
-      </div>
-
-      {/* 年フィルター */}
-      {availableYears.length > 0 && (
-        <div>
-          <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-slate-900 dark:text-white">
-            {yearTitle}
-          </h3>
-          <nav className="space-y-1">
-            <FilterItem
-              active={filterYear === null}
-              onClick={() => onFilterYearChange(null)}
-              count={counts.all}
-            >
-              {allText}
-            </FilterItem>
-            {availableYears.map((year) => (
-              <FilterItem
-                key={year}
-                active={filterYear === year}
-                onClick={() => onFilterYearChange(year)}
-                count={counts.byYear[year] || 0}
-              >
-                {year}
-              </FilterItem>
-            ))}
-          </nav>
-        </div>
-      )}
-    </div>
-  )
-}
-
-// フィルターグループ作成のヘルパー関数
 type FilterGroupCounts = {
   all: number
   byYear: Record<string, number>
-}
-
-function createYearFilterGroup(
-  lang: string,
-  filterYear: FilterYear,
-  availableYears: string[],
-  counts: FilterGroupCounts,
-  setFilterYear: (year: FilterYear) => void,
-): FilterGroup {
-  const allText = lang === 'ja' ? 'すべて' : 'All'
-  const yearTitle = lang === 'ja' ? '年' : 'Year'
-
-  return {
-    title: yearTitle,
-    items: [
-      {
-        id: 'year-all',
-        label: allText,
-        active: filterYear === null,
-        count: counts.all,
-        onClick: () => setFilterYear(null),
-      },
-      ...availableYears.map((year) => ({
-        id: `year-${year}`,
-        label: year,
-        active: filterYear === year,
-        count: counts.byYear[year] || 0,
-        onClick: () => setFilterYear(year),
-      })),
-    ],
-  }
 }
 
 export default function SpeakingPageContent({
@@ -226,7 +82,6 @@ export default function SpeakingPageContent({
 }) {
   const [searchQuery, setSearchQuery] = useState('')
   const [filterYear, setFilterYear] = useState<FilterYear>(null)
-  const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false)
 
   // 利用可能な年を抽出
   const availableYears = useMemo(() => {
@@ -281,7 +136,7 @@ export default function SpeakingPageContent({
   }, [events, matchesFilters, matchesSearch])
 
   // カウント計算
-  const counts = useMemo(() => {
+  const counts: FilterGroupCounts = useMemo(() => {
     const byYear: Record<string, number> = {}
 
     // 年別カウント
@@ -304,89 +159,79 @@ export default function SpeakingPageContent({
     lang === 'ja'
       ? 'これまでに登壇・講演したイベントやカンファレンスを紹介しています。'
       : "A collection of events and conferences where I've given talks and presentations."
-  const filterButtonText = lang === 'ja' ? 'フィルター' : 'Filter'
-
-  // アクティブなフィルターの数を計算
-  const activeFilterCount = useMemo(() => {
-    let count = 0
-    if (filterYear !== null) count++
-    return count
-  }, [filterYear])
-
-  // フィルターグループを構築
-  const filterGroups = useMemo<FilterGroup[]>(() => {
-    const groups: FilterGroup[] = []
-
-    // 年フィルター
-    if (availableYears.length > 0) {
-      groups.push(createYearFilterGroup(lang, filterYear, availableYears, counts, setFilterYear))
-    }
-
-    return groups
-  }, [lang, filterYear, availableYears, counts])
 
   return (
-    <>
-      {/* モバイル用フィルタードロワー */}
-      <MobileFilterDrawer
-        isOpen={isMobileFilterOpen}
-        onClose={() => setIsMobileFilterOpen(false)}
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
-        searchPlaceholder={lang === 'ja' ? '検索...' : 'Search...'}
-        filterGroups={filterGroups}
-        title={filterButtonText}
+    <Container>
+      <PageHeader
+        title={title}
+        eyebrow={lang === 'ja' ? '§ Speaking / 登壇' : '§ Speaking / Talks'}
+        description={description}
+        meta={[`${counts.all} ${lang === 'ja' ? '件' : 'sessions'}`]}
       />
 
-      {/* Heroセクション + メインコンテンツ */}
-      <section className="pt-12 sm:pt-16 pb-8 sm:pb-12 bg-white dark:bg-zinc-900">
-        <Container>
-          <PageHeader title={title} description={description} />
-
-          {/* モバイル用検索バーとフィルターボタン */}
-          <div className="lg:hidden mb-6 space-y-4">
-            <SearchBar
-              value={searchQuery}
-              onChange={setSearchQuery}
-              placeholder={lang === 'ja' ? '検索...' : 'Search...'}
-            />
-            <MobileFilterButton
-              onClick={() => setIsMobileFilterOpen(true)}
-              activeFilterCount={activeFilterCount}
-              label={filterButtonText}
-            />
-          </div>
-
-          <SidebarLayout
-            sidebar={
-              <Sidebar
-                searchQuery={searchQuery}
-                onSearchChange={setSearchQuery}
-                filterYear={filterYear}
-                onFilterYearChange={setFilterYear}
-                availableYears={availableYears}
-                counts={counts}
-                lang={lang}
-              />
-            }
+      {/* Filter bar */}
+      <div className="ds-filter-bar">
+        <span className="ds-filter-bar__label">{lang === 'ja' ? '年' : 'Year'}</span>
+        <button
+          type="button"
+          className="ds-tag"
+          aria-pressed={filterYear === null}
+          onClick={() => setFilterYear(null)}
+        >
+          {lang === 'ja' ? 'すべて' : 'All'} ({counts.all})
+        </button>
+        {availableYears.map((year) => (
+          <button
+            key={year}
+            type="button"
+            className="ds-tag"
+            aria-pressed={filterYear === year}
+            onClick={() => setFilterYear(filterYear === year ? null : year)}
           >
-            {/* イベントグリッド */}
-            {filteredEvents.length > 0 ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
-                {filteredEvents.map((event) => (
-                  <SpeakingCard key={event.id} event={event} lang={lang} basePath={basePath} />
-                ))}
-              </div>
-            ) : (
-              <div className="py-12 text-center">
-                <p className="text-slate-600 dark:text-slate-400">
-                  {lang === 'ja' ? '該当するイベントが見つかりませんでした。' : 'No events found.'}
-                </p>
-              </div>
-            )}
-          </SidebarLayout>
-        </Container>
-      </section>
-    </>
+            {year} ({counts.byYear[year] || 0})
+          </button>
+        ))}
+        {/* Search */}
+        <input
+          type="search"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder={lang === 'ja' ? '検索...' : 'Search...'}
+          style={{
+            marginLeft: 'auto',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 'var(--text-xs)',
+            letterSpacing: 'var(--tracking-wide)',
+            background: 'transparent',
+            border: '1px solid var(--color-line-strong)',
+            color: 'var(--color-ink)',
+            padding: 'var(--space-2) var(--space-4)',
+            outline: 'none',
+            width: '200px',
+          }}
+        />
+      </div>
+
+      {/* Events list */}
+      {filteredEvents.length > 0 ? (
+        <div>
+          {filteredEvents.map((event) => (
+            <SpeakingEntryRow key={event.id} event={event} lang={lang} basePath={basePath} />
+          ))}
+        </div>
+      ) : (
+        <div
+          style={{
+            padding: 'var(--space-12) 0',
+            textAlign: 'center',
+            color: 'var(--color-muted)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 'var(--text-xs)',
+          }}
+        >
+          {lang === 'ja' ? '該当するイベントが見つかりませんでした。' : 'No events found.'}
+        </div>
+      )}
+    </Container>
   )
 }

--- a/src/components/containers/pages/WorkPage.tsx
+++ b/src/components/containers/pages/WorkPage.tsx
@@ -1,19 +1,10 @@
 'use client'
 
-import Image from 'next/image'
 import Link from 'next/link'
 import { useCallback, useMemo, useState } from 'react'
-import Container from '@/components/tailwindui/Container'
-import { GitHubIcon, LinkedInIcon, TwitterIcon } from '@/components/tailwindui/SocialLink'
-import BackgroundDecoration from '@/components/ui/BackgroundDecoration'
 import DateDisplay from '@/components/ui/DateDisplay'
-import FilterItem from '@/components/ui/FilterItem'
-import MobileFilterButton from '@/components/ui/MobileFilterButton'
-import MobileFilterDrawer, { type FilterGroup } from '@/components/ui/MobileFilterDrawer'
 import PageHeader from '@/components/ui/PageHeader'
-import SearchBar from '@/components/ui/SearchBar'
-import SidebarLayout from '@/components/ui/SidebarLayout'
-import Tag from '@/components/ui/Tag'
+import SectionHeader from '@/components/ui/SectionHeader'
 import { SITE_CONFIG } from '@/config'
 import type { NPMRegistrySearchResult } from '@/libs/dataSources/npmjs'
 import type { WordPressPluginDetail } from '@/libs/dataSources/wporg'
@@ -26,7 +17,6 @@ type OSSItem =
   | { type: 'npm'; data: NPMRegistrySearchResult }
   | { type: 'wordpress'; data: WordPressPluginDetail }
 
-// OSSアイテムをフィルタリングするヘルパー関数
 export function filterOSSItem(item: OSSItem, matchesSearch: (text: string) => boolean): boolean {
   if (item.type === 'project') {
     const p = item.data
@@ -50,375 +40,30 @@ export function filterOSSItem(item: OSSItem, matchesSearch: (text: string) => bo
   )
 }
 
-// OSSアイテムの日付を取得するヘルパー関数
 function getOSSItemDate(item: OSSItem): string {
-  if (item.type === 'project') {
-    return item.data.published_at || ''
-  }
-  if (item.type === 'npm') {
-    return item.data.package.date
-  }
+  if (item.type === 'project') return item.data.published_at || ''
+  if (item.type === 'npm') return item.data.package.date
   return item.data.added
 }
 
-// 統一されたWorkカードコンポーネント（プロジェクト用）
-function UnifiedProjectCard({ project, lang }: { project: MicroCMSProjectsRecord; lang: string }) {
-  const href = lang === 'ja' ? `/ja/work/${project.id}` : `/work/${project.id}`
-  const date = project.published_at ? new Date(project.published_at) : null
-
-  return (
-    <Link href={href} className="group block">
-      <article className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-white transition-all hover:border-indigo-300 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-700">
-        {/* Image - Top */}
-        {project.image && (
-          <div className="relative aspect-[4/3] w-full overflow-hidden">
-            <Image
-              src={project.image.url}
-              alt={project.title}
-              fill
-              className="object-cover transition-transform duration-500 group-hover:scale-110"
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-            />
-          </div>
-        )}
-
-        {/* Content - Bottom */}
-        <div className="p-5 lg:p-6">
-          <div className="flex flex-col gap-3">
-            {date && (
-              <DateDisplay
-                date={date}
-                lang={lang}
-                format="short"
-                className="text-xs font-semibold text-slate-500 dark:text-slate-400"
-              />
-            )}
-
-            <h3 className="text-lg font-bold leading-tight text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">
-              {project.title}
-            </h3>
-
-            {project.about && (
-              <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400 line-clamp-2">
-                {project.about.replace(/<[^>]*>/g, '').substring(0, 120)}
-                {project.about.replace(/<[^>]*>/g, '').length > 120 ? '...' : ''}
-              </p>
-            )}
-
-            {project.tags && project.tags.length > 0 && (
-              <div className="flex flex-wrap gap-2">
-                {project.tags.slice(0, 3).map((tag) => (
-                  <Tag key={tag} variant="indigo" size="sm">
-                    {tag}
-                  </Tag>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-      </article>
-    </Link>
-  )
+function getOSSItemHref(item: OSSItem, lang: string): string {
+  if (item.type === 'project')
+    return lang === 'ja' ? `/ja/work/${item.data.id}` : `/work/${item.data.id}`
+  if (item.type === 'npm') return (item.data as NPMRegistrySearchResult).package.links.npm
+  return `https://wordpress.org/plugins/${(item.data as WordPressPluginDetail).slug}`
 }
 
-// 統一されたOSSカードコンポーネント
-function UnifiedOSSCard({
-  item,
-  lang,
-}: {
-  item: { type: 'npm' | 'wordpress'; data: NPMRegistrySearchResult | WordPressPluginDetail }
-  lang: string
-}) {
-  if (item.type === 'npm') {
-    const pkg = (item.data as NPMRegistrySearchResult).package
-    const date = new Date(pkg.date)
-    const href = pkg.links.npm
-
-    return (
-      <a href={href} target="_blank" rel="noopener noreferrer" className="group block">
-        <article className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-white transition-all hover:border-indigo-300 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-700">
-          {/* Content */}
-          <div className="p-5 lg:p-6">
-            <div className="flex flex-col gap-3">
-              <DateDisplay
-                date={date}
-                lang={lang}
-                format="short"
-                className="text-xs font-semibold text-slate-500 dark:text-slate-400"
-              />
-
-              <h3 className="text-lg font-bold leading-tight text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">
-                {pkg.name}
-              </h3>
-
-              {pkg.description && (
-                <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400 line-clamp-2">
-                  {pkg.description}
-                </p>
-              )}
-
-              <Tag variant="indigo" size="sm">
-                npm
-              </Tag>
-            </div>
-          </div>
-        </article>
-      </a>
-    )
-  } else {
-    const plugin = item.data as WordPressPluginDetail
-    const date = new Date(plugin.added)
-    const href = `https://wordpress.org/plugins/${plugin.slug}`
-
-    return (
-      <a href={href} target="_blank" rel="noopener noreferrer" className="group block">
-        <article className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-white transition-all hover:border-indigo-300 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-700">
-          {/* Content */}
-          <div className="p-5 lg:p-6">
-            <div className="flex flex-col gap-3">
-              <DateDisplay
-                date={date}
-                lang={lang}
-                format="short"
-                className="text-xs font-semibold text-slate-500 dark:text-slate-400"
-              />
-
-              <h3 className="text-lg font-bold leading-tight text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">
-                {plugin.name}
-              </h3>
-
-              {plugin.short_description && (
-                <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400 line-clamp-2">
-                  {plugin.short_description}
-                </p>
-              )}
-
-              <Tag variant="indigo" size="sm">
-                WordPress
-              </Tag>
-            </div>
-          </div>
-        </article>
-      </a>
-    )
-  }
+function getOSSItemTitle(item: OSSItem): string {
+  if (item.type === 'project') return (item.data as MicroCMSProjectsRecord).title
+  if (item.type === 'npm') return (item.data as NPMRegistrySearchResult).package.name
+  return (item.data as WordPressPluginDetail).name
 }
 
-// OSS Contributionリンク（GitHubリンクのみ）
-function OSSContributionLink({ project }: { project: MicroCMSProjectsRecord }) {
-  return (
-    <a
-      href={project.url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="group flex items-center justify-between rounded-lg border border-zinc-200 bg-white px-4 py-3 transition-all hover:border-indigo-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-700"
-    >
-      <div className="flex flex-col gap-1">
-        <span className="text-sm font-semibold text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">
-          {project.title}
-        </span>
-        {project.about && (
-          <span className="text-xs text-slate-600 dark:text-slate-400 line-clamp-1">
-            {project.about.replace(/<[^>]*>/g, '').substring(0, 80)}
-            {project.about.replace(/<[^>]*>/g, '').length > 80 ? '...' : ''}
-          </span>
-        )}
-      </div>
-      <svg
-        className="h-5 w-5 shrink-0 text-slate-400 transition-transform group-hover:translate-x-1 group-hover:text-indigo-600 dark:text-slate-500 dark:group-hover:text-indigo-400"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-      >
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-      </svg>
-    </a>
-  )
-}
-
-// 統計バーコンポーネント
-function StatsBar({
-  projectCount,
-  ossCount,
-  bookCount,
-  npmCount,
-  lang,
-}: {
-  projectCount: number
-  ossCount: number
-  bookCount: number
-  npmCount: number
-  lang: string
-}) {
-  const stats = [
-    {
-      value: projectCount,
-      label: lang === 'ja' ? 'プロジェクト' : 'Projects',
-    },
-    {
-      value: ossCount,
-      label: lang === 'ja' ? 'OSS' : 'Open Source',
-    },
-    {
-      value: bookCount,
-      label: lang === 'ja' ? '書籍' : 'Books',
-    },
-    {
-      value: npmCount,
-      label: lang === 'ja' ? 'npm' : 'npm Packages',
-    },
-  ]
-
-  return (
-    <div className="mb-12 grid grid-cols-2 sm:grid-cols-4 gap-4">
-      {stats.map((stat, index) => (
-        <div
-          key={index}
-          className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4 text-center transition-all hover:border-indigo-300 hover:shadow-md dark:hover:border-indigo-700"
-        >
-          <div className="text-3xl font-bold text-indigo-600 dark:text-indigo-400">
-            {stat.value}
-          </div>
-          <div className="mt-2 text-sm text-slate-600 dark:text-slate-400">{stat.label}</div>
-        </div>
-      ))}
-    </div>
-  )
-}
-
-// CTAコンポーネント
-function WorkCTA({ lang }: { lang: string }) {
-  const title =
-    lang === 'ja' ? '一緒にプロジェクトを始めませんか？' : 'Interested in working together?'
-  const subtitle = lang === 'ja' ? 'お気軽にご連絡ください。' : 'Feel free to reach out'
-
-  return (
-    <section className="py-12 sm:py-16 bg-slate-50 dark:bg-zinc-800/50 border-t border-zinc-200 dark:border-zinc-700">
-      <Container>
-        <div className="mx-auto max-w-2xl text-center">
-          <h2 className="text-3xl sm:text-4xl font-bold text-slate-900 dark:text-white mb-4">
-            {title}
-          </h2>
-          <p className="text-lg text-slate-600 dark:text-slate-400 mb-8">{subtitle}</p>
-
-          {/* ソーシャルリンク */}
-          <div className="flex justify-center gap-4">
-            <a
-              href={SITE_CONFIG.social.twitter.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={SITE_CONFIG.social.twitter.ariaLabel}
-              className="group flex items-center justify-center h-12 w-12 rounded-lg bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 transition hover:border-indigo-300 hover:bg-indigo-50 dark:hover:border-indigo-700 dark:hover:bg-zinc-800"
-            >
-              <TwitterIcon className="h-5 w-5 fill-slate-500 transition group-hover:fill-indigo-600 dark:fill-slate-400 dark:group-hover:fill-indigo-400" />
-            </a>
-            <a
-              href={SITE_CONFIG.social.github.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={SITE_CONFIG.social.github.ariaLabel}
-              className="group flex items-center justify-center h-12 w-12 rounded-lg bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 transition hover:border-indigo-300 hover:bg-indigo-50 dark:hover:border-indigo-700 dark:hover:bg-zinc-800"
-            >
-              <GitHubIcon className="h-5 w-5 fill-slate-500 transition group-hover:fill-indigo-600 dark:fill-slate-400 dark:group-hover:fill-indigo-400" />
-            </a>
-            <a
-              href={SITE_CONFIG.social.linkedin.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={SITE_CONFIG.social.linkedin.ariaLabel}
-              className="group flex items-center justify-center h-12 w-12 rounded-lg bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 transition hover:border-indigo-300 hover:bg-indigo-50 dark:hover:border-indigo-700 dark:hover:bg-zinc-800"
-            >
-              <LinkedInIcon className="h-5 w-5 fill-slate-500 transition group-hover:fill-indigo-600 dark:fill-slate-400 dark:group-hover:fill-indigo-400" />
-            </a>
-          </div>
-        </div>
-      </Container>
-    </section>
-  )
-}
-
-// サイドバーコンポーネント
-function Sidebar({
-  searchQuery,
-  onSearchChange,
-  filterCategory,
-  onFilterChange,
-  counts,
-  lang,
-}: {
-  searchQuery: string
-  onSearchChange: (value: string) => void
-  filterCategory: FilterCategory
-  onFilterChange: (category: FilterCategory) => void
-  counts: {
-    all: number
-    projects: number
-    'open-source': number
-    books: number
-    'oss-contribution': number
-  }
-  lang: string
-}) {
-  const searchPlaceholder = lang === 'ja' ? '検索...' : 'Search...'
-  const filterTitle = lang === 'ja' ? 'カテゴリ' : 'Category'
-  const allText = lang === 'ja' ? 'すべて' : 'All'
-  const projectsText = lang === 'ja' ? 'プロジェクト' : 'Projects'
-  const openSourceText = lang === 'ja' ? 'オープンソース' : 'Open Source'
-  const booksText = lang === 'ja' ? '書籍' : 'Books'
-  const ossContributionText = lang === 'ja' ? 'OSS貢献' : 'OSS Contributions'
-
-  return (
-    <div className="hidden lg:block space-y-6">
-      {/* 検索バー */}
-      <div>
-        <SearchBar value={searchQuery} onChange={onSearchChange} placeholder={searchPlaceholder} />
-      </div>
-
-      {/* フィルター */}
-      <div>
-        <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-slate-900 dark:text-white">
-          {filterTitle}
-        </h3>
-        <nav className="space-y-1">
-          <FilterItem
-            active={filterCategory === 'all'}
-            onClick={() => onFilterChange('all')}
-            count={counts.all}
-          >
-            {allText}
-          </FilterItem>
-          <FilterItem
-            active={filterCategory === 'projects'}
-            onClick={() => onFilterChange('projects')}
-            count={counts.projects}
-          >
-            {projectsText}
-          </FilterItem>
-          <FilterItem
-            active={filterCategory === 'open-source'}
-            onClick={() => onFilterChange('open-source')}
-            count={counts['open-source']}
-          >
-            {openSourceText}
-          </FilterItem>
-          <FilterItem
-            active={filterCategory === 'books'}
-            onClick={() => onFilterChange('books')}
-            count={counts.books}
-          >
-            {booksText}
-          </FilterItem>
-          <FilterItem
-            active={filterCategory === 'oss-contribution'}
-            onClick={() => onFilterChange('oss-contribution')}
-            count={counts['oss-contribution']}
-          >
-            {ossContributionText}
-          </FilterItem>
-        </nav>
-      </div>
-    </div>
-  )
+function getOSSItemMeta(item: OSSItem): string {
+  if (item.type === 'npm') return 'npm'
+  if (item.type === 'wordpress') return 'WordPress'
+  const p = item.data as MicroCMSProjectsRecord
+  return p.tags?.slice(0, 2).join(' · ') ?? ''
 }
 
 export default function WorkPageContent({
@@ -434,17 +79,12 @@ export default function WorkPageContent({
 }) {
   const [searchQuery, setSearchQuery] = useState('')
   const [filterCategory, setFilterCategory] = useState<FilterCategory>('all')
-  const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false)
 
-  // プロジェクトをタイプ別に分類
   const booksProjects = projects.filter((p) => p.project_type?.includes('books'))
   const ownedOSSProjects = projects.filter((p) => p.project_type?.includes('owned_oss'))
   const ossContributionProjects = projects.filter((p) =>
     p.project_type?.includes('oss_contribution'),
   )
-
-  // プロジェクト（books, owned_oss, oss_contribution以外のすべて）
-  // applications, guest_posts, community_activitiesなど
   const mainProjects = projects.filter((p) => {
     const types = p.project_type || []
     return (
@@ -454,7 +94,6 @@ export default function WorkPageContent({
     )
   })
 
-  // オープンソース（owned_oss + NPM + WordPress）
   const allOSSItems = useMemo(
     () => [
       ...ownedOSSProjects.map((p) => ({ type: 'project' as const, data: p })),
@@ -464,85 +103,75 @@ export default function WorkPageContent({
     [ownedOSSProjects, npmPackages, wpPlugins],
   )
 
-  // 検索フィルター関数
   const matchesSearch = useCallback(
     (text: string): boolean => {
       if (!searchQuery.trim()) return true
-      const query = searchQuery.toLowerCase()
-      return text.toLowerCase().includes(query)
+      return text.toLowerCase().includes(searchQuery.toLowerCase())
     },
     [searchQuery],
   )
 
-  // フィルターと検索を適用
   const filteredProjects = useMemo(() => {
-    let items: MicroCMSProjectsRecord[] = []
-
-    if (filterCategory === 'all' || filterCategory === 'projects') {
-      items = [...mainProjects]
-    } else if (filterCategory === 'oss-contribution') {
-      items = [...ossContributionProjects]
-    }
-
-    return items.filter(
-      (p) =>
-        matchesSearch(p.title) ||
-        (p.about && matchesSearch(p.about.replace(/<[^>]*>/g, ''))) ||
-        p.tags?.some((tag) => matchesSearch(tag)),
+    if (
+      filterCategory !== 'all' &&
+      filterCategory !== 'projects' &&
+      filterCategory !== 'oss-contribution'
     )
+      return []
+    const items =
+      filterCategory === 'oss-contribution'
+        ? ossContributionProjects
+        : filterCategory === 'all' || filterCategory === 'projects'
+          ? mainProjects
+          : []
+    return items
+      .filter(
+        (p) =>
+          matchesSearch(p.title) ||
+          (p.about && matchesSearch(p.about.replace(/<[^>]*>/g, ''))) ||
+          p.tags?.some((tag) => matchesSearch(tag)),
+      )
+      .sort(
+        (a, b) =>
+          new Date(b.published_at || '').getTime() - new Date(a.published_at || '').getTime(),
+      )
   }, [filterCategory, mainProjects, ossContributionProjects, matchesSearch])
 
   const filteredBooks = useMemo(() => {
     if (filterCategory !== 'all' && filterCategory !== 'books') return []
-
-    return booksProjects.filter(
-      (p) =>
-        matchesSearch(p.title) ||
-        (p.about && matchesSearch(p.about.replace(/<[^>]*>/g, ''))) ||
-        p.tags?.some((tag) => matchesSearch(tag)),
-    )
+    return booksProjects
+      .filter(
+        (p) =>
+          matchesSearch(p.title) ||
+          (p.about && matchesSearch(p.about.replace(/<[^>]*>/g, ''))) ||
+          p.tags?.some((tag) => matchesSearch(tag)),
+      )
+      .sort(
+        (a, b) =>
+          new Date(b.published_at || '').getTime() - new Date(a.published_at || '').getTime(),
+      )
   }, [filterCategory, booksProjects, matchesSearch])
 
   const filteredOSS = useMemo(() => {
     if (filterCategory !== 'all' && filterCategory !== 'open-source') return []
-
-    return allOSSItems.filter((item) => filterOSSItem(item, matchesSearch))
+    return allOSSItems
+      .filter((item) => filterOSSItem(item, matchesSearch))
+      .sort((a, b) => new Date(getOSSItemDate(b)).getTime() - new Date(getOSSItemDate(a)).getTime())
   }, [filterCategory, allOSSItems, matchesSearch])
 
   const filteredOSSContributions = useMemo(() => {
     if (filterCategory !== 'all' && filterCategory !== 'oss-contribution') return []
-
-    return ossContributionProjects.filter(
-      (p) => matchesSearch(p.title) || (p.about && matchesSearch(p.about.replace(/<[^>]*>/g, ''))),
-    )
+    return ossContributionProjects
+      .filter(
+        (p) =>
+          matchesSearch(p.title) || (p.about && matchesSearch(p.about.replace(/<[^>]*>/g, ''))),
+      )
+      .sort(
+        (a, b) =>
+          new Date(b.published_at || '').getTime() - new Date(a.published_at || '').getTime(),
+      )
   }, [filterCategory, ossContributionProjects, matchesSearch])
 
-  // 日付順にソート
-  filteredProjects.sort((a, b) => {
-    const dateA = a.published_at || ''
-    const dateB = b.published_at || ''
-    return new Date(dateB).getTime() - new Date(dateA).getTime()
-  })
-
-  filteredBooks.sort((a, b) => {
-    const dateA = a.published_at || ''
-    const dateB = b.published_at || ''
-    return new Date(dateB).getTime() - new Date(dateA).getTime()
-  })
-
-  filteredOSSContributions.sort((a, b) => {
-    const dateA = a.published_at || ''
-    const dateB = b.published_at || ''
-    return new Date(dateB).getTime() - new Date(dateA).getTime()
-  })
-
-  filteredOSS.sort((a, b) => {
-    const dateA = getOSSItemDate(a)
-    const dateB = getOSSItemDate(b)
-    return new Date(dateB).getTime() - new Date(dateA).getTime()
-  })
-
-  // カウント計算
   const counts = useMemo(
     () => ({
       all:
@@ -558,228 +187,270 @@ export default function WorkPageContent({
     [mainProjects.length, allOSSItems.length, ossContributionProjects.length, booksProjects.length],
   )
 
-  // テキスト
-  const title = lang === 'ja' ? '制作物' : 'Work'
-  const description =
-    lang === 'ja'
-      ? '開発者・BizDevとして10年以上のキャリアから生まれたプロダクト、OSSプロジェクト、書籍を紹介しています。'
-      : 'Products, open source projects, and books born from over 10 years as a developer and BizDev professional.'
-  const filterButtonText = lang === 'ja' ? 'フィルター' : 'Filter'
+  const isJa = lang === 'ja'
+  const title = isJa ? '制作物' : 'Work'
+  const description = isJa
+    ? '開発者・BizDevとして10年以上のキャリアから生まれたプロダクト、OSSプロジェクト、書籍を紹介しています。'
+    : 'Products, open source projects, and books born from over 10 years as a developer and BizDev professional.'
 
-  // アクティブなフィルターの数を計算
-  const activeFilterCount = useMemo(() => {
-    return filterCategory !== 'all' ? 1 : 0
-  }, [filterCategory])
+  const filterLabels: Record<FilterCategory, string> = {
+    all: isJa ? 'すべて' : 'All',
+    projects: isJa ? 'プロジェクト' : 'Projects',
+    'open-source': isJa ? 'オープンソース' : 'Open Source',
+    books: isJa ? '書籍' : 'Books',
+    'oss-contribution': isJa ? 'OSS貢献' : 'OSS Contributions',
+  }
 
-  // フィルターグループを構築
-  const filterGroups = useMemo<FilterGroup[]>(() => {
-    const filterTitle = lang === 'ja' ? 'カテゴリ' : 'Category'
-    const allText = lang === 'ja' ? 'すべて' : 'All'
-    const projectsText = lang === 'ja' ? 'プロジェクト' : 'Projects'
-    const openSourceText = lang === 'ja' ? 'オープンソース' : 'Open Source'
-    const booksText = lang === 'ja' ? '書籍' : 'Books'
-    const ossContributionText = lang === 'ja' ? 'OSS貢献' : 'OSS Contributions'
+  const categories: FilterCategory[] = [
+    'all',
+    'projects',
+    'open-source',
+    'books',
+    'oss-contribution',
+  ]
 
-    return [
-      {
-        title: filterTitle,
-        items: [
-          {
-            id: 'all',
-            label: allText,
-            active: filterCategory === 'all',
-            count: counts.all,
-            onClick: () => setFilterCategory('all'),
-          },
-          {
-            id: 'projects',
-            label: projectsText,
-            active: filterCategory === 'projects',
-            count: counts.projects,
-            onClick: () => setFilterCategory('projects'),
-          },
-          {
-            id: 'open-source',
-            label: openSourceText,
-            active: filterCategory === 'open-source',
-            count: counts['open-source'],
-            onClick: () => setFilterCategory('open-source'),
-          },
-          {
-            id: 'books',
-            label: booksText,
-            active: filterCategory === 'books',
-            count: counts.books,
-            onClick: () => setFilterCategory('books'),
-          },
-          {
-            id: 'oss-contribution',
-            label: ossContributionText,
-            active: filterCategory === 'oss-contribution',
-            count: counts['oss-contribution'],
-            onClick: () => setFilterCategory('oss-contribution'),
-          },
-        ],
-      },
-    ]
-  }, [lang, filterCategory, counts])
+  const isEmpty =
+    filteredProjects.length === 0 &&
+    filteredBooks.length === 0 &&
+    filteredOSS.length === 0 &&
+    filteredOSSContributions.length === 0
+
+  const stats = [
+    { value: mainProjects.length, label: isJa ? 'プロジェクト' : 'Projects' },
+    { value: allOSSItems.length, label: isJa ? 'OSS' : 'Open Source' },
+    { value: booksProjects.length, label: isJa ? '書籍' : 'Books' },
+    { value: npmPackages.length, label: isJa ? 'npm' : 'npm Packages' },
+  ]
 
   return (
     <>
-      {/* モバイル用フィルタードロワー */}
-      <MobileFilterDrawer
-        isOpen={isMobileFilterOpen}
-        onClose={() => setIsMobileFilterOpen(false)}
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
-        searchPlaceholder={lang === 'ja' ? '検索...' : 'Search...'}
-        filterGroups={filterGroups}
-        title={filterButtonText}
-      />
+      <section className="mx-auto max-w-[1440px] px-8 sm:px-16 pt-12 pb-20">
+        <PageHeader eyebrow="WORK" title={title} sub={description} />
 
-      {/* Heroセクション + メインコンテンツ */}
-      <section className="relative pt-12 sm:pt-16 pb-8 sm:pb-12 bg-white dark:bg-zinc-900">
-        <BackgroundDecoration variant="section" />
+        {/* Metrics */}
+        <div className="ds-metrics" style={{ marginBottom: '2rem' }}>
+          {stats.map((s) => (
+            <div key={s.label} className="ds-metric">
+              <dt className="ds-metric__label">{s.label}</dt>
+              <dd className="ds-metric__value">{s.value}</dd>
+            </div>
+          ))}
+        </div>
 
-        <Container className="relative">
-          <PageHeader title={title} description={description} />
-
-          {/* 統計バー */}
-          <StatsBar
-            projectCount={mainProjects.length}
-            ossCount={allOSSItems.length}
-            bookCount={booksProjects.length}
-            npmCount={npmPackages.length}
-            lang={lang}
+        {/* Search + filter bar */}
+        <div className="ds-filter-bar">
+          <span className="ds-filter-bar__label">{isJa ? 'カテゴリ' : 'Category'}</span>
+          {categories.map((cat) => (
+            <button
+              key={cat}
+              type="button"
+              className="ds-tag"
+              aria-pressed={filterCategory === cat ? 'true' : 'false'}
+              onClick={() => setFilterCategory(cat)}
+            >
+              {filterLabels[cat]} <small style={{ opacity: 0.6 }}>{counts[cat]}</small>
+            </button>
+          ))}
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder={isJa ? '検索...' : 'Search...'}
+            style={{
+              marginLeft: 'auto',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 'var(--text-xs)',
+              background: 'transparent',
+              border: '1px solid var(--color-line-strong)',
+              color: 'var(--color-ink)',
+              padding: '4px 10px',
+              outline: 'none',
+            }}
           />
+        </div>
 
-          {/* モバイル用検索バーとフィルターボタン */}
-          <div className="lg:hidden mb-6 space-y-4">
-            <SearchBar
-              value={searchQuery}
-              onChange={setSearchQuery}
-              placeholder={lang === 'ja' ? '検索...' : 'Search...'}
-            />
-            <MobileFilterButton
-              onClick={() => setIsMobileFilterOpen(true)}
-              activeFilterCount={activeFilterCount}
-              label={filterButtonText}
-            />
+        {/* Projects */}
+        {(filterCategory === 'all' || filterCategory === 'projects') &&
+          filteredProjects.length > 0 && (
+            <div style={{ marginBottom: '3rem' }}>
+              <SectionHeader no="01" title={isJa ? 'プロジェクト' : 'Projects'} />
+              {filteredProjects.map((p, i) => {
+                const href = isJa ? `/ja/work/${p.id}` : `/work/${p.id}`
+                const date = p.published_at ? new Date(p.published_at) : null
+                return (
+                  <Link key={p.id} href={href} className="ds-entry">
+                    <span className="ds-entry__no">{String(i + 1).padStart(3, '0')}</span>
+                    <div>
+                      <p className="ds-entry__title">{p.title}</p>
+                      {p.about && (
+                        <p className="ds-entry__meta">
+                          {p.about.replace(/<[^>]*>/g, '').substring(0, 100)}
+                          {p.about.replace(/<[^>]*>/g, '').length > 100 ? '…' : ''}
+                        </p>
+                      )}
+                      {p.tags && p.tags.length > 0 && (
+                        <p className="ds-entry__meta">{p.tags.slice(0, 3).join(' · ')}</p>
+                      )}
+                    </div>
+                    {date && (
+                      <DateDisplay
+                        date={date}
+                        lang={lang}
+                        format="short"
+                        className="ds-entry__date"
+                      />
+                    )}
+                  </Link>
+                )
+              })}
+            </div>
+          )}
+
+        {/* Books */}
+        {(filterCategory === 'all' || filterCategory === 'books') && filteredBooks.length > 0 && (
+          <div style={{ marginBottom: '3rem' }}>
+            <SectionHeader no="02" title={isJa ? '書籍' : 'Books'} />
+            {filteredBooks.map((p, i) => {
+              const href = isJa ? `/ja/work/${p.id}` : `/work/${p.id}`
+              const date = p.published_at ? new Date(p.published_at) : null
+              return (
+                <Link key={p.id} href={href} className="ds-entry">
+                  <span className="ds-entry__no">{String(i + 1).padStart(3, '0')}</span>
+                  <div>
+                    <p className="ds-entry__title">{p.title}</p>
+                    {p.about && (
+                      <p className="ds-entry__meta">
+                        {p.about.replace(/<[^>]*>/g, '').substring(0, 100)}
+                        {p.about.replace(/<[^>]*>/g, '').length > 100 ? '…' : ''}
+                      </p>
+                    )}
+                  </div>
+                  {date && (
+                    <DateDisplay
+                      date={date}
+                      lang={lang}
+                      format="short"
+                      className="ds-entry__date"
+                    />
+                  )}
+                </Link>
+              )
+            })}
           </div>
+        )}
 
-          <SidebarLayout
-            sidebar={
-              <Sidebar
-                searchQuery={searchQuery}
-                onSearchChange={setSearchQuery}
-                filterCategory={filterCategory}
-                onFilterChange={setFilterCategory}
-                counts={counts}
-                lang={lang}
-              />
-            }
+        {/* Open Source */}
+        {(filterCategory === 'all' || filterCategory === 'open-source') &&
+          filteredOSS.length > 0 && (
+            <div style={{ marginBottom: '3rem' }}>
+              <SectionHeader no="03" title={isJa ? 'オープンソース' : 'Open Source'} />
+              {filteredOSS.map((item, i) => {
+                const href = getOSSItemHref(item, lang)
+                const title = getOSSItemTitle(item)
+                const meta = getOSSItemMeta(item)
+                const date = new Date(getOSSItemDate(item))
+                const isExternal =
+                  item.type !== 'project' || !!(item.data as MicroCMSProjectsRecord).url
+                const Comp = isExternal ? 'a' : Link
+                const extraProps =
+                  item.type !== 'project' ? { target: '_blank', rel: 'noopener noreferrer' } : {}
+                return (
+                  // biome-ignore lint/a11y/useValidAnchor: dynamic element
+                  <Comp key={`${item.type}-${i}`} href={href} {...extraProps} className="ds-entry">
+                    <span className="ds-entry__no">{String(i + 1).padStart(3, '0')}</span>
+                    <div>
+                      <p className="ds-entry__title">{title}</p>
+                      {meta && <p className="ds-entry__meta">{meta}</p>}
+                    </div>
+                    <DateDisplay
+                      date={date}
+                      lang={lang}
+                      format="short"
+                      className="ds-entry__date"
+                    />
+                  </Comp>
+                )
+              })}
+            </div>
+          )}
+
+        {/* OSS Contributions */}
+        {(filterCategory === 'all' || filterCategory === 'oss-contribution') &&
+          filteredOSSContributions.length > 0 && (
+            <div style={{ marginBottom: '3rem' }}>
+              <SectionHeader no="04" title={isJa ? 'OSS貢献' : 'OSS Contributions'} />
+              {filteredOSSContributions.map((p, i) => (
+                <a
+                  key={p.id}
+                  href={p.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ds-entry"
+                >
+                  <span className="ds-entry__no">{String(i + 1).padStart(3, '0')}</span>
+                  <div>
+                    <p className="ds-entry__title">{p.title}</p>
+                    {p.about && (
+                      <p className="ds-entry__meta">
+                        {p.about.replace(/<[^>]*>/g, '').substring(0, 80)}
+                        {p.about.replace(/<[^>]*>/g, '').length > 80 ? '…' : ''}
+                      </p>
+                    )}
+                  </div>
+                  <span className="ds-entry__date">GitHub →</span>
+                </a>
+              ))}
+            </div>
+          )}
+
+        {isEmpty && (
+          <p
+            style={{
+              color: 'var(--color-muted)',
+              padding: '3rem 0',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 'var(--text-sm)',
+            }}
           >
-            {/* プロジェクトセクション */}
-            {(filterCategory === 'all' || filterCategory === 'projects') &&
-              filteredProjects.length > 0 && (
-                <div className="mb-12">
-                  <h2 className="mb-6 text-2xl font-bold text-slate-900 dark:text-white">
-                    {lang === 'ja' ? 'プロジェクト' : 'Projects'}
-                  </h2>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
-                    {filteredProjects.map((project) => (
-                      <UnifiedProjectCard key={project.id} project={project} lang={lang} />
-                    ))}
-                  </div>
-                </div>
-              )}
-
-            {/* 書籍セクション */}
-            {(filterCategory === 'all' || filterCategory === 'books') &&
-              filteredBooks.length > 0 && (
-                <div className="mb-12">
-                  <h2 className="mb-6 text-2xl font-bold text-slate-900 dark:text-white">
-                    {lang === 'ja' ? '書籍' : 'Books'}
-                  </h2>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
-                    {filteredBooks.map((project) => (
-                      <UnifiedProjectCard key={project.id} project={project} lang={lang} />
-                    ))}
-                  </div>
-                </div>
-              )}
-
-            {/* オープンソースセクション */}
-            {(filterCategory === 'all' || filterCategory === 'open-source') &&
-              filteredOSS.length > 0 && (
-                <div className="mb-12">
-                  <h2 className="mb-6 text-2xl font-bold text-slate-900 dark:text-white">
-                    {lang === 'ja' ? 'オープンソース' : 'Open Source'}
-                  </h2>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
-                    {filteredOSS.map((item, _index) => {
-                      if (item.type === 'project') {
-                        return (
-                          <UnifiedProjectCard
-                            key={item.data.id}
-                            project={item.data as MicroCMSProjectsRecord}
-                            lang={lang}
-                          />
-                        )
-                      } else if (item.type === 'npm') {
-                        return (
-                          <UnifiedOSSCard
-                            key={`npm-${(item.data as NPMRegistrySearchResult).package.name}`}
-                            item={{ type: 'npm', data: item.data as NPMRegistrySearchResult }}
-                            lang={lang}
-                          />
-                        )
-                      } else {
-                        return (
-                          <UnifiedOSSCard
-                            key={`wp-${(item.data as WordPressPluginDetail).slug}`}
-                            item={{ type: 'wordpress', data: item.data as WordPressPluginDetail }}
-                            lang={lang}
-                          />
-                        )
-                      }
-                    })}
-                  </div>
-                </div>
-              )}
-
-            {/* OSS Contributionセクション */}
-            {(filterCategory === 'all' || filterCategory === 'oss-contribution') &&
-              filteredOSSContributions.length > 0 && (
-                <div>
-                  <h2 className="mb-6 text-2xl font-bold text-slate-900 dark:text-white">
-                    {lang === 'ja' ? 'OSS貢献' : 'OSS Contributions'}
-                  </h2>
-                  <div className="space-y-3">
-                    {filteredOSSContributions.map((project) => (
-                      <OSSContributionLink key={project.id} project={project} />
-                    ))}
-                  </div>
-                </div>
-              )}
-
-            {/* 結果なし */}
-            {filteredProjects.length === 0 &&
-              filteredBooks.length === 0 &&
-              filteredOSS.length === 0 &&
-              filteredOSSContributions.length === 0 && (
-                <div className="py-12 text-center">
-                  <p className="text-slate-600 dark:text-slate-400">
-                    {lang === 'ja' ? '該当する項目が見つかりませんでした。' : 'No items found.'}
-                  </p>
-                </div>
-              )}
-          </SidebarLayout>
-        </Container>
+            {isJa ? '該当する項目が見つかりませんでした。' : 'No items found.'}
+          </p>
+        )}
       </section>
 
-      {/* CTA セクション */}
-      <WorkCTA lang={lang} />
+      {/* CTA */}
+      <div className="mx-auto max-w-[1440px] px-8 sm:px-16">
+        <div className="ds-cta-block">
+          <span className="ds-cta-block__pre">{isJa ? 'お問い合わせ' : 'Collaboration'}</span>
+          <h2 className="ds-cta-block__title">
+            {isJa ? (
+              <>
+                一緒にプロジェクトを
+                <br />
+                <em>始めませんか？</em>
+              </>
+            ) : (
+              <>
+                Interested in working
+                <br />
+                <em>together?</em>
+              </>
+            )}
+          </h2>
+          <div className="ds-cta-block__actions">
+            <a href="mailto:hello@hidetaka.dev" className="ds-btn ds-btn--primary ds-btn--lg">
+              {isJa ? 'お問い合わせ' : 'Get in touch'}
+            </a>
+            <Link
+              href={SITE_CONFIG.social.twitter.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ds-btn ds-btn--secondary ds-btn--lg"
+            >
+              Twitter / X
+            </Link>
+          </div>
+        </div>
+      </div>
     </>
   )
 }

--- a/src/components/containers/pages/WritingPage.tsx
+++ b/src/components/containers/pages/WritingPage.tsx
@@ -1,206 +1,49 @@
 'use client'
 
-import Image from 'next/image'
+import Link from 'next/link'
 import { useCallback, useMemo, useState } from 'react'
 import Container from '@/components/tailwindui/Container'
-import DateDisplay from '@/components/ui/DateDisplay'
-import FilterItem from '@/components/ui/FilterItem'
-import MobileFilterButton from '@/components/ui/MobileFilterButton'
-import MobileFilterDrawer, { type FilterGroup } from '@/components/ui/MobileFilterDrawer'
 import PageHeader from '@/components/ui/PageHeader'
-import SearchBar from '@/components/ui/SearchBar'
-import SidebarLayout from '@/components/ui/SidebarLayout'
-import Tag from '@/components/ui/Tag'
 import type { FeedItem } from '@/libs/dataSources/types'
 import { removeHtmlTags } from '@/libs/sanitize'
 
 type WritingItem = FeedItem
 type FilterDataSource = string | null
 
-// 統一されたWritingカードコンポーネント
-function UnifiedWritingCard({ item, lang }: { item: WritingItem; lang: string }) {
+function WritingEntryRow({ item, index }: { item: WritingItem; index: number }) {
   const href = item.href
-  const title = item.title
-  const description = removeHtmlTags(item.description)
-  const datetime = item.datetime
-  const date = new Date(datetime)
-  const imageUrl = item.image
+  const date = new Date(item.datetime)
+  const dateStr = `${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`
+  const source = item.dataSource?.name ?? ''
+  const isExternal = !href.startsWith('/')
 
-  // サイト内リンクかどうかを判定
-  const isInternalLink = (() => {
-    // 相対パス（/で始まる）は常にサイト内リンク
-    if (href.startsWith('/')) return true
-
-    try {
-      // URLをパースしてホスト名をチェック
-      const url = new URL(href)
-      return url.hostname === 'hidetaka.dev' || url.hostname === 'www.hidetaka.dev'
-    } catch {
-      // パースに失敗した場合（相対パスの可能性）はサイト内リンクとして扱う
-      return true
-    }
-  })()
-
-  const CardContent = (
-    <article className="relative overflow-hidden rounded-2xl border border-zinc-200 bg-white transition-all hover:border-indigo-300 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-700">
-      {/* Image - Top (if available) */}
-      {imageUrl && (
-        <div className="relative aspect-[4/3] w-full overflow-hidden">
-          <Image
-            src={imageUrl}
-            alt={title}
-            fill
-            className="object-cover transition-transform duration-500 group-hover:scale-110"
-            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-          />
-        </div>
-      )}
-
-      {/* Content */}
-      <div className={`p-5 lg:p-6 ${imageUrl ? '' : 'pt-6'}`}>
-        <div className="flex flex-col gap-3">
-          {/* Date and DataSource */}
-          <div className="flex items-center gap-3 flex-wrap">
-            <DateDisplay
-              date={date}
-              lang={lang}
-              format="short"
-              className="text-xs font-semibold text-slate-500 dark:text-slate-400"
-            />
-            {item.dataSource && (
-              <Tag variant="purple" size="sm">
-                {item.dataSource.name}
-              </Tag>
-            )}
-          </div>
-
-          {/* Title */}
-          <h3 className="text-lg font-bold leading-tight text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">
-            {title}
-          </h3>
-
-          {/* Description */}
-          {description && (
-            <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400 line-clamp-3">
-              {description}
-              {description.length >= 150 ? '...' : ''}
-            </p>
-          )}
-
-          {/* Read more indicator */}
-          <div className="flex items-center text-sm font-medium text-indigo-600 dark:text-indigo-400 mt-1">
-            {lang === 'ja' ? '記事を読む' : 'Read article'}
-            <svg className="ml-1 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </article>
-  )
-
-  // サイト内リンクの場合は同じタブで開き、外部リンクは別タブで開く
-  return isInternalLink ? (
-    <a href={href} className="group block">
-      {CardContent}
-    </a>
-  ) : (
-    <a href={href} target="_blank" rel="noopener noreferrer" className="group block">
-      {CardContent}
-    </a>
-  )
-}
-
-// サイドバーコンポーネント（デスクトップ用）
-function Sidebar({
-  searchQuery,
-  onSearchChange,
-  filterDataSource,
-  onFilterDataSourceChange,
-  availableDataSources,
-  dataSourceMap,
-  counts,
-  lang,
-}: {
-  searchQuery: string
-  onSearchChange: (value: string) => void
-  filterDataSource: FilterDataSource
-  onFilterDataSourceChange: (source: FilterDataSource) => void
-  availableDataSources: string[]
-  dataSourceMap: Map<string, string>
-  counts: {
-    all: number
-    external: number
-    byDataSource: Record<string, number>
-  }
-  lang: string
-}) {
-  const searchPlaceholder = lang === 'ja' ? '検索...' : 'Search...'
-  const sourceTitle = lang === 'ja' ? 'データソース' : 'Source'
-  const allText = lang === 'ja' ? 'すべて' : 'All'
-
-  return (
-    <div className="hidden lg:block space-y-6">
-      {/* 検索バー */}
+  const content = (
+    <div className="ds-entry">
+      <span className="ds-entry__no">{String(index + 1).padStart(3, '0')}</span>
       <div>
-        <SearchBar value={searchQuery} onChange={onSearchChange} placeholder={searchPlaceholder} />
+        <p className="ds-entry__title">{item.title}</p>
+        {source && <div className="ds-entry__meta">{source.toUpperCase()}</div>}
       </div>
-
-      {/* データソースフィルター */}
-      {availableDataSources.length > 0 && (
-        <div>
-          <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-slate-900 dark:text-white">
-            {sourceTitle}
-          </h3>
-          <nav className="space-y-1">
-            <FilterItem
-              active={filterDataSource === null}
-              onClick={() => onFilterDataSourceChange(null)}
-              count={counts.all}
-            >
-              {allText}
-            </FilterItem>
-            {availableDataSources.map((source) => {
-              const sourceHref = dataSourceMap.get(source) || '#'
-              return (
-                <div key={source} className="space-y-1">
-                  <FilterItem
-                    active={filterDataSource === source}
-                    onClick={() => onFilterDataSourceChange(source)}
-                    count={counts.byDataSource[source] || 0}
-                  >
-                    {source}
-                  </FilterItem>
-                  {filterDataSource === source && (
-                    <a
-                      href={sourceHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="ml-4 text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 flex items-center gap-1"
-                    >
-                      {lang === 'ja' ? '元のサイトで見る' : 'View on original site'}
-                      <svg
-                        className="h-3 w-3"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                        />
-                      </svg>
-                    </a>
-                  )}
-                </div>
-              )
-            })}
-          </nav>
-        </div>
-      )}
+      <span className="ds-entry__date">{dateStr}</span>
     </div>
+  )
+
+  if (isExternal) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ display: 'block', color: 'inherit', textDecoration: 'none' }}
+      >
+        {content}
+      </a>
+    )
+  }
+  return (
+    <Link href={href} style={{ display: 'block', color: 'inherit', textDecoration: 'none' }}>
+      {content}
+    </Link>
   )
 }
 
@@ -215,7 +58,6 @@ export default function WritingPageContent({
 }) {
   const [searchQuery, setSearchQuery] = useState('')
   const [filterDataSource, setFilterDataSource] = useState<FilterDataSource>(null)
-  const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false)
 
   // 全記事を統合
   const allItems: WritingItem[] = externalArticles
@@ -291,7 +133,6 @@ export default function WritingPageContent({
 
     return {
       all: allItems.length,
-      external: externalArticles.length,
       byDataSource,
     }
   }, [allItems, externalArticles, availableDataSources, hasMoreBySource])
@@ -302,160 +143,123 @@ export default function WritingPageContent({
     lang === 'ja'
       ? '技術記事、ブログ投稿、ニュースなどの執筆活動を紹介しています。'
       : "A collection of technical articles, blog posts, news, and other writing I've published."
-  const filterButtonText = lang === 'ja' ? 'フィルター' : 'Filter'
 
-  // アクティブなフィルターの数を計算
-  const activeFilterCount = useMemo(() => {
-    let count = 0
-    if (filterDataSource !== null) count++
-    return count
-  }, [filterDataSource])
-
-  // フィルターグループを構築
-  const filterGroups = useMemo<FilterGroup[]>(() => {
-    const allText = lang === 'ja' ? 'すべて' : 'All'
-    const sourceTitle = lang === 'ja' ? 'データソース' : 'Source'
-
-    const groups: FilterGroup[] = []
-
-    // データソースフィルター
-    if (availableDataSources.length > 0) {
-      groups.push({
-        title: sourceTitle,
-        items: [
-          {
-            id: 'source-all',
-            label: allText,
-            active: filterDataSource === null,
-            count: counts.all,
-            onClick: () => setFilterDataSource(null),
-          },
-          ...availableDataSources.map((source) => ({
-            id: `source-${source}`,
-            label: source,
-            active: filterDataSource === source,
-            count: counts.byDataSource[source] || 0,
-            onClick: () => setFilterDataSource(source),
-            externalLink: dataSourceMap.get(source),
-          })),
-        ],
-      })
-    }
-
-    return groups
-  }, [lang, filterDataSource, availableDataSources, counts, dataSourceMap.get])
+  const allText = lang === 'ja' ? 'すべて' : 'All'
 
   return (
-    <>
-      {/* モバイル用フィルタードロワー */}
-      <MobileFilterDrawer
-        isOpen={isMobileFilterOpen}
-        onClose={() => setIsMobileFilterOpen(false)}
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
-        searchPlaceholder={lang === 'ja' ? '検索...' : 'Search...'}
-        filterGroups={filterGroups}
-        title={filterButtonText}
-        lang={lang}
+    <Container>
+      <PageHeader
+        title={title}
+        eyebrow={lang === 'ja' ? '§ Writing / 執筆' : '§ Writing / Articles'}
+        description={description}
       />
 
-      {/* Heroセクション + メインコンテンツ */}
-      <section className="pt-12 sm:pt-16 pb-8 sm:pb-12 bg-white dark:bg-zinc-900">
-        <Container>
-          <PageHeader title={title} description={description} />
+      {/* Filter bar */}
+      <div className="ds-filter-bar">
+        <span className="ds-filter-bar__label">{lang === 'ja' ? 'ソース' : 'Source'}</span>
+        <button
+          type="button"
+          className="ds-tag"
+          aria-pressed={filterDataSource === null}
+          onClick={() => setFilterDataSource(null)}
+        >
+          {allText} ({counts.all})
+        </button>
+        {availableDataSources.map((source) => (
+          <button
+            key={source}
+            type="button"
+            className="ds-tag"
+            aria-pressed={filterDataSource === source}
+            onClick={() => setFilterDataSource(filterDataSource === source ? null : source)}
+          >
+            {source} ({counts.byDataSource[source] || 0}
+            {hasMoreBySource[source] ? '+' : ''})
+          </button>
+        ))}
+        {/* Search */}
+        <input
+          type="search"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder={lang === 'ja' ? '検索...' : 'Search...'}
+          style={{
+            marginLeft: 'auto',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 'var(--text-xs)',
+            letterSpacing: 'var(--tracking-wide)',
+            background: 'transparent',
+            border: '1px solid var(--color-line-strong)',
+            color: 'var(--color-ink)',
+            padding: 'var(--space-2) var(--space-4)',
+            outline: 'none',
+            width: '200px',
+          }}
+        />
+      </div>
 
-          {/* モバイル用検索バーとフィルターボタン */}
-          <div className="lg:hidden mb-6 space-y-4">
-            <SearchBar
-              value={searchQuery}
-              onChange={setSearchQuery}
-              placeholder={lang === 'ja' ? '検索...' : 'Search...'}
-            />
-            <MobileFilterButton
-              onClick={() => setIsMobileFilterOpen(true)}
-              activeFilterCount={activeFilterCount}
-              label={filterButtonText}
-            />
+      {/* Article list */}
+      {filteredItems.length > 0 ? (
+        <>
+          <div>
+            {filteredItems.map((item, index) => (
+              <WritingEntryRow key={item.href} item={item} index={index} />
+            ))}
           </div>
 
-          <SidebarLayout
-            sidebar={
-              <Sidebar
-                searchQuery={searchQuery}
-                onSearchChange={setSearchQuery}
-                filterDataSource={filterDataSource}
-                onFilterDataSourceChange={setFilterDataSource}
-                availableDataSources={availableDataSources}
-                dataSourceMap={dataSourceMap}
-                counts={counts}
-                lang={lang}
-              />
-            }
-          >
-            {/* 記事グリッド */}
-            {filteredItems.length > 0 ? (
-              <>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
-                  {filteredItems.map((item) => (
-                    <UnifiedWritingCard key={item.href} item={item} lang={lang} />
-                  ))}
-                </div>
-
-                {/* 外部動線セクション */}
-                {availableDataSources.length > 0 && (
-                  <div className="mt-16 pt-16 border-t border-zinc-200 dark:border-zinc-800">
-                    <div className="text-center">
-                      <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
-                        {lang === 'ja' ? 'もっと記事を見る' : 'View More Articles'}
-                      </h3>
-                      <p className="text-sm text-slate-600 dark:text-slate-400 mb-6">
-                        {lang === 'ja'
-                          ? '最新20件を表示しています。それ以前の記事は各サイトでご覧ください。'
-                          : 'Showing the latest 20 articles. View older articles on each site.'}
-                      </p>
-                      <div className="flex flex-wrap justify-center gap-4">
-                        {availableDataSources.map((source) => {
-                          const sourceHref = dataSourceMap.get(source) || '#'
-                          return (
-                            <a
-                              key={source}
-                              href={sourceHref}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-slate-700 dark:text-slate-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 hover:border-indigo-400 dark:hover:border-indigo-600 transition-colors"
-                            >
-                              <span className="font-medium">{source}</span>
-                              <svg
-                                className="h-4 w-4"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  strokeWidth={2}
-                                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                                />
-                              </svg>
-                            </a>
-                          )
-                        })}
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </>
-            ) : (
-              <div className="py-12 text-center">
-                <p className="text-slate-600 dark:text-slate-400">
-                  {lang === 'ja' ? '該当する記事が見つかりませんでした。' : 'No articles found.'}
-                </p>
+          {/* External links section */}
+          {availableDataSources.length > 0 && (
+            <div
+              style={{
+                marginTop: 'var(--space-10)',
+                paddingTop: 'var(--space-9)',
+                borderTop: '1px solid var(--color-line-strong)',
+              }}
+            >
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 'var(--text-xs)',
+                  letterSpacing: 'var(--tracking-widest)',
+                  textTransform: 'uppercase',
+                  color: 'var(--color-muted)',
+                  marginBottom: 'var(--space-5)',
+                }}
+              >
+                {lang === 'ja' ? 'もっと見る — 各サイト' : 'View More — External Sources'}
               </div>
-            )}
-          </SidebarLayout>
-        </Container>
-      </section>
-    </>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-3)' }}>
+                {availableDataSources.map((source) => {
+                  const sourceHref = dataSourceMap.get(source) || '#'
+                  return (
+                    <a
+                      key={source}
+                      href={sourceHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ds-btn ds-btn--ghost ds-btn--sm"
+                    >
+                      {source}
+                    </a>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+        </>
+      ) : (
+        <div
+          style={{
+            padding: 'var(--space-12) 0',
+            textAlign: 'center',
+            color: 'var(--color-muted)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 'var(--text-xs)',
+          }}
+        >
+          {lang === 'ja' ? '該当する記事が見つかりませんでした。' : 'No articles found.'}
+        </div>
+      )}
+    </Container>
   )
 }

--- a/src/components/home/Capabilities.tsx
+++ b/src/components/home/Capabilities.tsx
@@ -1,121 +1,178 @@
-import Container from '@/components/tailwindui/Container'
-import SectionHeader from '@/components/ui/SectionHeader'
-
-type Capability = {
+type Service = {
+  no: string
+  category: string
+  categoryLabel: string
   title: string
+  titleAccent: string
   description: string
-  highlights: string[]
-}
-
-function CapabilityCard({ capability }: { capability: Capability }) {
-  return (
-    <article className="group relative flex h-full flex-col rounded-2xl border border-zinc-200 bg-white p-10 transition-all hover:shadow-lg hover:border-indigo-200 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-800">
-      <h3 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-white">
-        {capability.title}
-      </h3>
-      <p className="mt-6 text-base leading-relaxed text-slate-700 dark:text-slate-400">
-        {capability.description}
-      </p>
-      <ul className="mt-8 space-y-4 text-sm leading-6 text-slate-600 dark:text-slate-400">
-        {capability.highlights.map((highlight) => (
-          <li key={highlight} className="flex items-start gap-4">
-            <span className="mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-indigo-600 dark:bg-indigo-400" />
-            <span>{highlight}</span>
-          </li>
-        ))}
-      </ul>
-    </article>
-  )
+  bullets: string[]
 }
 
 export default function Capabilities({ lang }: { lang: string }) {
-  const sectionTitle =
-    lang === 'ja'
-      ? 'SaaSグロースのためのフルスタックエンジニアリング'
-      : 'Full-stack engineering for SaaS growth'
-  const sectionDescription =
-    lang === 'ja'
-      ? 'Stripeの決済導線設計からAWS/Lambdaによるサーバーレス構築、WordPressによるメディア・マーケティング基盤まで。プロダクトの継続的な収益化と高速な実験を支援します。'
-      : 'From Stripe monetization flows to AWS serverless architecture and WordPress-powered marketing platforms. I help teams unlock recurring revenue and ship experiments faster.'
+  const isJa = lang.startsWith('ja')
 
-  const capabilities: Capability[] =
-    lang === 'ja'
-      ? [
-          {
-            title: 'Stripeで収益を最大化',
-            description:
-              'プロダクトのLTV向上に向けて料金プランや請求オートメーションを設計。Billing・Connect・Radarを活用し、SaaS/マーケットプレイスの成長を伴走します。',
-            highlights: [
-              '従量課金・年額契約など柔軟なプライシング設計',
-              'SaaS指標を可視化するダッシュボードと分析環境',
-              'Revenue Recognitionや自動請求オペレーションの整備',
-            ],
-          },
-          {
-            title: 'AWS Serverless × Cloudflareでスケール',
-            description:
-              'Lambda、Step Functions、Cloudflare Workersを組み合わせ、負荷に応じてシームレスにスケールするバックエンドを構築。グローバルユーザーにも高速な体験を提供します。',
-            highlights: [
-              'マルチリージョン対応のAPIとジョブパイプライン',
-              'IaC・CI/CDを用いた運用負担の最小化',
-              'Observabilityとセキュリティベストプラクティスの実装',
-            ],
-          },
-          {
-            title: 'WordPressでマーケ&コンテンツを加速',
-            description:
-              'WordPressサイトやHeadlessサイトを設計。リード獲得やコミュニティ施策と連携し、開発とマーケが並走できる仕組みを整えます。',
-            highlights: [
-              'WordPress / Headless WordPress / Cloudflare Pagesの運用',
-              'MicroCMSや外部SaaSとのハイブリッドな連携',
-              '編集体験と高速表示を両立するユーザー体験',
-            ],
-          },
-        ]
-      : [
-          {
-            title: 'Monetize with Stripe confidence',
-            description:
-              'Design pricing strategies, billing automation, and compliant payment flows that increase LTV. I partner with founders to implement Billing, Connect, and Radar for SaaS and marketplaces.',
-            highlights: [
-              'Flexible pricing with usage-based or annual plans',
-              'Growth dashboards to illuminate core SaaS metrics',
-              'Revenue Recognition and automated billing operations',
-            ],
-          },
-          {
-            title: 'Scale on AWS Serverless & Cloudflare',
-            description:
-              'Combine Lambda, Step Functions, and Cloudflare Workers to deliver resilient, globally distributed backend experiences. Built for cost efficiency, observability, and rapid experimentation.',
-            highlights: [
-              'Multi-region APIs and asynchronous job pipelines',
-              'Infrastructure-as-code with frictionless CI/CD',
-              'Embedded security and runtime insights by default',
-            ],
-          },
-          {
-            title: 'Accelerate content with WordPress',
-            description:
-              'Design WordPress sites and headless sites. Integrate with lead generation and community initiatives, enabling development and marketing to work in parallel.',
-            highlights: [
-              'WordPress / Headless WordPress / Cloudflare Pages operations',
-              'Hybrid integrations with MicroCMS and existing SaaS',
-              'User experience balancing editing UX and speed',
-            ],
-          },
-        ]
+  const sectionNo = '§01 / SERVICES'
+  const sectionTitle = isJa ? '何ができるか' : 'What I can do'
+  const sectionSub = 'FOUR DISCIPLINES'
+  const sectionDesc = isJa
+    ? 'すべて単独の案件として、あるいは既存チームへのエンジニアリングパートナーとして。長期運用を前提に、現場の言葉と IaC で設計します。'
+    : 'As a standalone engagement or as an engineering partner embedded in your team — designed for long-term operations.'
+
+  const services: Service[] = isJa
+    ? [
+        {
+          no: '01 / Stripe',
+          category: 'Stripe',
+          categoryLabel: 'Monetize',
+          title: '決済を、',
+          titleAccent: '収益の武器',
+          description:
+            '従量・年額・トライアル。複雑化する課金体系を、Billing / Connect / Radar で運用に耐える形にする。Revenue Recognition まで見据えた請求自動化。',
+          bullets: ['従量・年額プランの設計', 'SaaS メトリクス可視化', 'Revenue Recognition 運用'],
+        },
+        {
+          no: '02 / AWS · CF',
+          category: 'AWS · CF',
+          categoryLabel: 'Scale',
+          title: '境界なき',
+          titleAccent: 'サーバーレス基盤',
+          description:
+            'Lambda・Step Functions と Cloudflare Workers を組み合わせ、マルチリージョン API と非同期ジョブパイプラインを構築。観測性・セキュリティは標準装備。',
+          bullets: [
+            'マルチリージョン API 設計',
+            'IaC による CI/CD',
+            'ランタイム監視・アラート設計',
+          ],
+        },
+        {
+          no: '03 / WordPress',
+          category: 'WordPress',
+          categoryLabel: 'Publish',
+          title: '編集を、',
+          titleAccent: '開発と並走',
+          description:
+            'WordPress / Headless WP / Cloudflare Pages の運用。MicroCMS や既存 SaaS とのハイブリッドで、編集 UX と速度を両立します。',
+          bullets: ['Headless 構成への移行支援', '編集フロー・権限設計', 'リード獲得と計測基盤'],
+        },
+        {
+          no: '04 / Arch.',
+          category: 'Architecture',
+          categoryLabel: 'Design',
+          title: '長く育つ',
+          titleAccent: 'システム設計',
+          description:
+            'マイクロサービス、イベント駆動、データベース最適化、フェイルオーバー戦略。成長に追従する設計を、チームに根付く形で渡します。',
+          bullets: ['サービス分割・境界設計', 'イベント駆動と整合性', '障害復旧の運用設計'],
+        },
+      ]
+    : [
+        {
+          no: '01 / Stripe',
+          category: 'Stripe',
+          categoryLabel: 'Monetize',
+          title: 'Turn payments into',
+          titleAccent: 'revenue weapons',
+          description:
+            'Usage-based, annual, and trial billing. Tame complex billing with Billing / Connect / Radar — built to last. Billing automation through Revenue Recognition.',
+          bullets: [
+            'Usage-based & annual plan design',
+            'SaaS metrics dashboards',
+            'Revenue Recognition operations',
+          ],
+        },
+        {
+          no: '02 / AWS · CF',
+          category: 'AWS · CF',
+          categoryLabel: 'Scale',
+          title: 'Boundless',
+          titleAccent: 'serverless infra',
+          description:
+            'Combine Lambda, Step Functions, and Cloudflare Workers to build multi-region APIs and async pipelines. Observability and security built-in.',
+          bullets: ['Multi-region API design', 'IaC-driven CI/CD', 'Runtime monitoring & alerting'],
+        },
+        {
+          no: '03 / WordPress',
+          category: 'WordPress',
+          categoryLabel: 'Publish',
+          title: 'Let editing',
+          titleAccent: 'keep pace with dev',
+          description:
+            'WordPress / Headless WP / Cloudflare Pages. Hybrid integrations with MicroCMS and existing SaaS — editorial UX and performance in balance.',
+          bullets: [
+            'Migration to headless architecture',
+            'Editorial flow & permission design',
+            'Lead gen & analytics foundation',
+          ],
+        },
+        {
+          no: '04 / Arch.',
+          category: 'Architecture',
+          categoryLabel: 'Design',
+          title: 'Systems designed',
+          titleAccent: 'to grow with you',
+          description:
+            'Microservices, event-driven architecture, database optimization, failover strategies. Scalable design handed to your team to own.',
+          bullets: [
+            'Service boundary design',
+            'Event-driven & data consistency',
+            'Failure recovery & operations',
+          ],
+        },
+      ]
 
   return (
-    <section className="relative py-24 sm:py-32">
-      <Container>
-        <SectionHeader title={sectionTitle} description={sectionDescription} align="center" />
-
-        <div className="mt-20 grid gap-10 lg:grid-cols-3 lg:gap-12">
-          {capabilities.map((capability) => (
-            <CapabilityCard key={capability.title} capability={capability} />
-          ))}
+    <section className="pt-24 pb-0 mx-auto max-w-[1440px] px-16">
+      {/* Section header */}
+      <header className="grid grid-cols-12 gap-6 pb-5 border-b-2 border-stone-900/20 dark:border-stone-100/20 mb-10 items-baseline">
+        <div className="col-span-2 font-mono text-[11px] tracking-[0.2em] uppercase text-stone-500">
+          {sectionNo}
         </div>
-      </Container>
+        <div className="col-span-6">
+          <h2 className="font-sans font-black text-[48px] tracking-[-0.02em] leading-none text-stone-950 dark:text-stone-50">
+            {sectionTitle}
+            <small className="block font-mono text-[12px] tracking-[0.24em] uppercase text-stone-500 font-normal mt-2.5">
+              {sectionSub}
+            </small>
+          </h2>
+        </div>
+        <p className="col-span-4 text-[13px] leading-[1.8] text-stone-500 dark:text-stone-400">
+          {sectionDesc}
+        </p>
+      </header>
+
+      {/* 2x2 grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-px bg-stone-900/20 dark:bg-stone-100/20 border border-stone-900/20 dark:border-stone-100/20">
+        {services.map((svc) => (
+          <article
+            key={svc.no}
+            className="bg-[#f4f2ee] dark:bg-[#0d0c0b] p-9 grid grid-rows-[auto_auto_1fr_auto] gap-4 min-h-[300px]"
+          >
+            <div className="flex justify-between font-mono text-[10px] tracking-[0.16em] uppercase text-stone-500">
+              <span>{svc.no}</span>
+              <span>{svc.categoryLabel}</span>
+            </div>
+            <h3 className="font-sans font-bold text-[28px] leading-[1.2] tracking-[-0.01em] text-stone-950 dark:text-stone-50">
+              {svc.title}
+              <em className="not-italic text-vermilion">{svc.titleAccent}</em>
+              {isJa ? 'にする。' : '.'}
+            </h3>
+            <p className="text-[13px] leading-[1.85] text-stone-700 dark:text-stone-300 max-w-[32em]">
+              {svc.description}
+            </p>
+            <ul className="flex flex-col gap-1.5 pt-4 border-t border-stone-900/10 dark:border-stone-100/10">
+              {svc.bullets.map((b) => (
+                <li
+                  key={b}
+                  className="font-mono text-[11px] tracking-[0.04em] text-stone-500 grid grid-cols-[20px_1fr] gap-2"
+                >
+                  <span className="text-vermilion">&#8594;</span>
+                  <span>{b}</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
     </section>
   )
 }

--- a/src/components/home/HomeCTA.tsx
+++ b/src/components/home/HomeCTA.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link'
+
+export default function HomeCTA({ lang }: { lang: string }) {
+  const isJa = lang.startsWith('ja')
+
+  return (
+    <section className="mt-35 mx-auto max-w-[1440px] px-16 py-30 text-center border-t-2 border-b border-stone-900/20 dark:border-stone-100/20">
+      <div className="font-mono text-[11px] tracking-[0.3em] uppercase text-stone-500 mb-6">
+        § 04 / CONTACT · Q2 2026 · 2 SLOTS
+      </div>
+      <h2 className="font-sans font-black text-[clamp(44px,5.2vw,72px)] leading-[1.15] max-w-[22ch] mx-auto tracking-[-0.02em] text-stone-950 dark:text-stone-50">
+        {isJa ? (
+          <>
+            貴社の <em className="not-italic text-vermilion">収益導線</em>、<br />
+            一緒に設計しませんか。
+          </>
+        ) : (
+          <>
+            Ready to design your <em className="not-italic text-vermilion">revenue experience</em>{' '}
+            together?
+          </>
+        )}
+      </h2>
+      <div className="mt-12 flex gap-4 justify-center flex-wrap">
+        <a
+          href="mailto:hello@hidetaka.dev"
+          className="inline-flex items-center gap-3 px-8 py-5 bg-stone-950 dark:bg-stone-50 text-stone-50 dark:text-stone-950 font-sans font-bold text-[14px] tracking-[0.04em] after:content-['→']"
+        >
+          {isJa ? '相談する · hello@hidetaka.dev' : 'Get in touch · hello@hidetaka.dev'}
+        </a>
+        <Link
+          href={isJa ? '/ja/work' : '/work'}
+          className="inline-flex items-center gap-3 px-8 py-5 border border-stone-900 dark:border-stone-100 bg-transparent text-stone-900 dark:text-stone-100 font-sans font-bold text-[14px] tracking-[0.04em]"
+        >
+          {isJa ? 'プロジェクトを見る' : 'View projects'}
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/src/components/home/SpeakingSection.tsx
+++ b/src/components/home/SpeakingSection.tsx
@@ -1,0 +1,78 @@
+import Link from 'next/link'
+
+type Talk = {
+  label: string
+  labelType: string
+  title: string
+  event: string
+  date: string
+}
+
+export default function SpeakingSection({ lang }: { lang: string }) {
+  const isJa = lang.startsWith('ja')
+
+  const talks: Talk[] = [
+    {
+      label: 'KEYNOTE',
+      labelType: 'KEYNOTE',
+      title: isJa
+        ? 'Stripe Billing で月額から従量へ — AI 時代の課金設計'
+        : 'From subscription to usage-based — billing design for the AI era',
+      event: 'Stripe Tour Tokyo 2026',
+      date: '2026.05.23',
+    },
+    {
+      label: isJa ? 'SESSION · 40min' : 'SESSION · 40min',
+      labelType: 'SESSION',
+      title: isJa
+        ? 'サーバーレスで LINE Bot を最小コストで運用する'
+        : 'Running LINE bots serverless at minimal cost',
+      event: 'JAWS DAYS 2026',
+      date: '2026.03.11',
+    },
+    {
+      label: 'WORKSHOP',
+      labelType: 'WORKSHOP',
+      title: isJa
+        ? 'Headless WordPress で編集と開発を分離する勘所'
+        : 'Decoupling editing from dev with Headless WordPress',
+      event: 'WordCamp Asia 2025',
+      date: '2025.11.28',
+    },
+  ]
+
+  return (
+    <section className="mt-30 mx-auto max-w-[1440px] px-16 pt-14 border-t-2 border-stone-900/20 dark:border-stone-100/20">
+      <div className="flex justify-between items-baseline mb-8">
+        <h2 className="font-sans font-black text-[48px] tracking-[-0.02em] leading-none text-stone-950 dark:text-stone-50">
+          {isJa ? '登壇' : 'Speaking'}
+          <small className="block font-mono text-[12px] tracking-[0.22em] uppercase text-stone-500 font-normal mt-2.5">
+            §03 / 2025–2026 HIGHLIGHTS
+          </small>
+        </h2>
+        <Link
+          href={isJa ? '/ja/speaking' : '/speaking'}
+          className="font-mono text-[11px] tracking-[0.14em] uppercase text-stone-400 hover:text-vermilion transition-colors"
+        >
+          {isJa ? '全登壇 →' : 'All talks →'}
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-px bg-stone-900/20 dark:bg-stone-100/20 border border-stone-900/20 dark:border-stone-100/20">
+        {talks.map((talk) => (
+          <div key={talk.title} className="bg-[#f4f2ee] dark:bg-[#0d0c0b] p-6">
+            <span className="inline-block bg-vermilion text-white font-mono text-[10px] px-1.5 py-0.5 tracking-[0.14em] uppercase mb-3">
+              {talk.label}
+            </span>
+            <h3 className="font-sans font-bold text-[18px] leading-[1.35] text-stone-950 dark:text-stone-50 mb-3">
+              {talk.title}
+            </h3>
+            <p className="font-mono text-[11px] tracking-[0.1em] text-stone-500">
+              {talk.event} · {talk.date}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/home/StackShowcase.tsx
+++ b/src/components/home/StackShowcase.tsx
@@ -1,69 +1,66 @@
-import Container from '@/components/tailwindui/Container'
-import SectionHeader from '@/components/ui/SectionHeader'
-import StackItemCard from '@/components/ui/StackItemCard'
-
-type StackItem = {
-  name: string
-  description: string
-  gradient: string
-}
-
 export default function StackShowcase({ lang }: { lang: string }) {
-  const items: StackItem[] = [
+  const isJa = lang.startsWith('ja')
+
+  const sectionNo = '§02 / STACK'
+  const sectionTitle = isJa ? '選ぶ道具' : 'Trusted stack'
+  const sectionSub = 'TRUSTED PLATFORM STACK'
+  const sectionDesc = isJa
+    ? '実戦で枯れているものだけ。新しい API や機能はまず自分の手で動かし、本番に出すまでに失敗を終わらせます。'
+    : 'Proven in production. New APIs are battle-tested personally before shipping to clients.'
+
+  const items = [
     {
+      no: '01 · Primary',
       name: 'Stripe',
-      description: lang === 'ja' ? 'Billing / Connect / Radar' : 'Billing · Connect · Radar',
-      gradient: 'from-[#635bff] via-[#7f7bff] to-[#35b5ff]',
+      desc: 'Billing · Connect · Radar · Meter Events · V2 API',
     },
-    {
-      name: 'AWS Serverless',
-      description:
-        lang === 'ja' ? 'Lambda / Step Functions / DynamoDB' : 'Lambda · Step Functions · DynamoDB',
-      gradient: 'from-[#fbbf24] via-[#f97316] to-[#ef4444]',
-    },
-    {
-      name: 'Cloudflare',
-      description: lang === 'ja' ? 'Workers / Pages / Zero Trust' : 'Workers · Pages · Zero Trust',
-      gradient: 'from-[#f97316] via-[#fb923c] to-[#facc15]',
-    },
-    {
-      name: 'WordPress',
-      description: lang === 'ja' ? 'Enterprise / Headless / VIP' : 'Enterprise · Headless · VIP',
-      gradient: 'from-[#21759b] via-[#2dd4bf] to-[#60a5fa]',
-    },
-    {
-      name: 'Next.js',
-      description: lang === 'ja' ? 'App Router / ISR / Edge' : 'App Router · ISR · Edge',
-      gradient: 'from-[#6366f1] via-[#14b8a6] to-[#06b6d4]',
-    },
+    { no: '02 · Infra', name: 'AWS', desc: 'Lambda · Step Functions · DynamoDB · CDK · S3' },
+    { no: '03 · Edge', name: 'Cloudflare', desc: 'Workers · Pages · Zero Trust · R2 · D1' },
+    { no: '04 · CMS', name: 'WordPress', desc: 'Enterprise · Headless · VIP · MicroCMS' },
+    { no: '05 · Front', name: 'Next.js', desc: 'App Router · ISR · Edge · Vercel AI SDK' },
   ]
 
-  const title =
-    lang === 'ja'
-      ? '信頼するスタックで、事業のスピードを最大化'
-      : 'Move faster on a trusted platform stack'
-  const subtitle =
-    lang === 'ja'
-      ? 'パートナー企業との共創やエコシステム構築を前提に、開発から運用までをシームレスに繋ぎます。'
-      : 'Built for collaborative ecosystems—seamless from development to operations.'
-
   return (
-    <section className="relative py-24 sm:py-32">
-      <Container>
-        <SectionHeader title={title} description={subtitle} align="center" />
-
-        <div className="mt-20 grid gap-6 sm:grid-cols-2 lg:grid-cols-5">
-          {items.map((item) => (
-            <StackItemCard
-              key={item.name}
-              name={item.name}
-              description={item.description}
-              gradient={item.gradient}
-              focusLabel={lang === 'ja' ? '専門領域' : 'Focus'}
-            />
-          ))}
+    <section className="mt-30 mx-auto max-w-[1440px] px-16">
+      {/* Section header */}
+      <header className="grid grid-cols-12 gap-6 pb-5 border-b-2 border-stone-900/20 dark:border-stone-100/20 mb-6 items-baseline">
+        <div className="col-span-2 font-mono text-[11px] tracking-[0.2em] uppercase text-stone-500">
+          {sectionNo}
         </div>
-      </Container>
+        <div className="col-span-6">
+          <h2 className="font-sans font-black text-[48px] tracking-[-0.02em] leading-none text-stone-950 dark:text-stone-50">
+            {sectionTitle}
+            <small className="block font-mono text-[12px] tracking-[0.24em] uppercase text-stone-500 font-normal mt-2.5">
+              {sectionSub}
+            </small>
+          </h2>
+        </div>
+        <p className="col-span-4 text-[13px] leading-[1.8] text-stone-500 dark:text-stone-400">
+          {sectionDesc}
+        </p>
+      </header>
+
+      {/* 5-col row */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-px bg-stone-900/20 dark:bg-stone-100/20 border border-stone-900/20 dark:border-stone-100/20">
+        {items.map((item) => (
+          <div
+            key={item.name}
+            className="bg-[#f4f2ee] dark:bg-[#0d0c0b] p-5 flex flex-col justify-between min-h-[140px]"
+          >
+            <div>
+              <div className="font-mono text-[9px] tracking-[0.2em] uppercase text-stone-500 mb-2">
+                {item.no}
+              </div>
+              <h3 className="font-sans font-bold text-[18px] text-stone-950 dark:text-stone-50">
+                {item.name}
+              </h3>
+            </div>
+            <p className="font-mono text-[10px] tracking-[0.08em] text-stone-500 leading-[1.7] mt-2">
+              {item.desc}
+            </p>
+          </div>
+        ))}
+      </div>
     </section>
   )
 }

--- a/src/components/tailwindui/Footer.tsx
+++ b/src/components/tailwindui/Footer.tsx
@@ -8,166 +8,104 @@ import {
   getLanguageFromURL,
   getPathnameWithLangType,
 } from '@/libs/urlUtils/lang.util'
-import GitHubIcon from './SocialIcons/GitHub'
-import LinkedInIcon from './SocialIcons/LinkedIn'
-import TwitterIcon from './SocialIcons/Twitter'
-
-/**
- * Renders a styled navigation link used in the footer navigation.
- *
- * @param href - Destination URL or path for the link
- * @param children - Visible label or content for the link
- * @returns A Next.js `Link` element styled for footer navigation
- */
-function NavLink({ href, children }: { href: string; children: React.ReactNode }) {
-  return (
-    <Link
-      href={href}
-      className="text-sm font-medium text-slate-700 dark:text-slate-300 transition-colors hover:text-indigo-600 dark:hover:text-indigo-400"
-    >
-      {children}
-    </Link>
-  )
-}
-
-function InnerContainer({
-  children,
-  className = '',
-}: {
-  children: React.ReactNode
-  className?: string
-}) {
-  return (
-    <div className={`relative px-4 sm:px-8 lg:px-12 ${className}`}>
-      <div className="mx-auto max-w-2xl lg:max-w-5xl">{children}</div>
-    </div>
-  )
-}
-
-function OuterContainer({
-  children,
-  className = '',
-}: {
-  children: React.ReactNode
-  className?: string
-}) {
-  return (
-    <div className={`sm:px-8 ${className}`}>
-      <div className="mx-auto max-w-7xl lg:px-8">{children}</div>
-    </div>
-  )
-}
 
 export default function Footer() {
   const pathname = usePathname()
   const lang = getLanguageFromURL(pathname)
+  const isJa = lang === 'ja'
 
   return (
-    <footer className="relative mt-32 overflow-hidden">
-      {/* Background decoration */}
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute bottom-0 left-0 h-64 w-64 rounded-full bg-indigo-200/20 blur-3xl dark:bg-indigo-900/10" />
-        <div className="absolute bottom-0 right-1/4 h-48 w-48 rounded-full bg-purple-200/15 blur-3xl dark:bg-purple-900/10" />
-      </div>
-
-      <OuterContainer>
-        <div className="relative border-t border-zinc-200 dark:border-zinc-800 pt-16 pb-20">
-          <InnerContainer>
-            <div className="flex flex-col gap-12">
-              {/* Top section: Navigation and Social Links */}
-              <div className="flex flex-col gap-8 sm:flex-row sm:items-start sm:justify-between">
-                {/* Navigation */}
-                <div className="flex flex-col gap-6">
-                  <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-900 dark:text-white">
-                    Navigation
-                  </h3>
-                  <nav className="flex flex-col gap-4">
-                    <NavLink href={getPathnameWithLangType('about', lang)}>
-                      {lang === 'ja' ? '概要' : 'About'}
-                    </NavLink>
-                    <NavLink href={getPathnameWithLangType('work', lang)}>
-                      {lang === 'ja' ? '制作物' : 'Work'}
-                    </NavLink>
-                    <NavLink href={getPathnameWithLangType('writing', lang)}>
-                      {lang === 'ja' ? '執筆' : 'Writing'}
-                    </NavLink>
-                    <NavLink href={getPathnameWithLangType('blog', lang)}>
-                      {lang === 'ja' ? 'ブログ' : 'Blog'}
-                    </NavLink>
-                    <NavLink href={getPathnameWithLangType('speaking', lang)}>
-                      {lang === 'ja' ? '登壇' : 'Speaking'}
-                    </NavLink>
-                    <NavLink href={getPathnameWithLangType('privacy', lang)}>
-                      {lang === 'ja' ? 'プライバシーポリシー' : 'Privacy Policy'}
-                    </NavLink>
-                  </nav>
-                </div>
-
-                {/* Language Switcher */}
-                <div className="flex flex-col gap-6">
-                  <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-900 dark:text-white">
-                    Language
-                  </h3>
-                  <nav className="flex flex-col gap-4">
-                    <NavLink href={changeLanguageURL(pathname, 'ja')}>
-                      {lang === 'ja' ? '日本語' : 'Japanese'}
-                    </NavLink>
-                    <NavLink href={changeLanguageURL(pathname, 'en')}>
-                      {lang === 'ja' ? '英語' : 'English'}
-                    </NavLink>
-                  </nav>
-                </div>
-
-                {/* Social Links */}
-                <div className="flex flex-col gap-6">
-                  <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-900 dark:text-white">
-                    Connect
-                  </h3>
-                  <ul className="flex flex-col gap-4">
-                    <li>
-                      <a
-                        href={SITE_CONFIG.social.twitter.url}
-                        aria-label={SITE_CONFIG.social.twitter.ariaLabel}
-                        className="group flex items-center gap-3 text-sm font-medium text-slate-700 dark:text-slate-300 transition-colors hover:text-indigo-600 dark:hover:text-indigo-400"
-                      >
-                        <TwitterIcon className="h-5 w-5 flex-none fill-slate-500 transition-colors group-hover:fill-indigo-600 dark:fill-slate-400 dark:group-hover:fill-indigo-400" />
-                        <span>{SITE_CONFIG.social.twitter.label}</span>
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        href={SITE_CONFIG.social.github.url}
-                        aria-label={SITE_CONFIG.social.github.ariaLabel}
-                        className="group flex items-center gap-3 text-sm font-medium text-slate-700 dark:text-slate-300 transition-colors hover:text-indigo-600 dark:hover:text-indigo-400"
-                      >
-                        <GitHubIcon className="h-5 w-5 flex-none fill-slate-500 transition-colors group-hover:fill-indigo-600 dark:fill-slate-400 dark:group-hover:fill-indigo-400" />
-                        <span>{SITE_CONFIG.social.github.label}</span>
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        href={SITE_CONFIG.social.linkedin.url}
-                        aria-label={SITE_CONFIG.social.linkedin.ariaLabel}
-                        className="group flex items-center gap-3 text-sm font-medium text-slate-700 dark:text-slate-300 transition-colors hover:text-indigo-600 dark:hover:text-indigo-400"
-                      >
-                        <LinkedInIcon className="h-5 w-5 flex-none fill-slate-500 transition-colors group-hover:fill-indigo-600 dark:fill-slate-400 dark:group-hover:fill-indigo-400" />
-                        <span>{SITE_CONFIG.social.linkedin.label}</span>
-                      </a>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-
-              {/* Bottom section: Copyright */}
-              <div className="border-t border-zinc-200 dark:border-zinc-800 pt-8">
-                <p className="text-sm text-slate-600 dark:text-slate-400 text-center sm:text-left">
-                  &copy; {new Date().getFullYear()} {SITE_CONFIG.author.name}. All rights reserved.
-                </p>
-              </div>
-            </div>
-          </InnerContainer>
+    <footer className="ds-site-footer">
+      <div className="ds-site-footer__inner">
+        {/* Brand */}
+        <div>
+          <div className="ds-site-footer__brand">HIDETAKA.DEV</div>
+          <div className="ds-site-footer__copy">
+            Engineering partner for SaaS &amp; commerce.
+            <br />
+            Based in Kyoto, Japan.
+          </div>
+          <div className="ds-site-footer__copy" style={{ marginTop: '16px' }}>
+            &copy; {new Date().getFullYear()} Hidetaka Okamoto
+          </div>
         </div>
-      </OuterContainer>
+
+        {/* Pages nav */}
+        <nav>
+          <div className="ds-site-footer__nav-title">{isJa ? 'ページ' : 'Pages'}</div>
+          <Link
+            href={getPathnameWithLangType('writing', lang)}
+            className="ds-site-footer__nav-link"
+          >
+            {isJa ? '執筆' : 'Writing'}
+          </Link>
+          <Link href={getPathnameWithLangType('work', lang)} className="ds-site-footer__nav-link">
+            {isJa ? '制作物' : 'Work'}
+          </Link>
+          <Link
+            href={getPathnameWithLangType('speaking', lang)}
+            className="ds-site-footer__nav-link"
+          >
+            {isJa ? '登壇' : 'Speaking'}
+          </Link>
+          <Link href={getPathnameWithLangType('about', lang)} className="ds-site-footer__nav-link">
+            {isJa ? '概要' : 'About'}
+          </Link>
+          <Link
+            href={getPathnameWithLangType('privacy', lang)}
+            className="ds-site-footer__nav-link"
+          >
+            {isJa ? 'プライバシー' : 'Privacy'}
+          </Link>
+        </nav>
+
+        {/* Connect nav */}
+        <nav>
+          <div className="ds-site-footer__nav-title">{isJa ? 'リンク' : 'Connect'}</div>
+          <a
+            href={SITE_CONFIG.social.twitter.url}
+            className="ds-site-footer__nav-link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Twitter / X
+          </a>
+          <a
+            href={SITE_CONFIG.social.github.url}
+            className="ds-site-footer__nav-link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub
+          </a>
+          <a
+            href={SITE_CONFIG.social.linkedin.url}
+            className="ds-site-footer__nav-link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            LinkedIn
+          </a>
+          <Link
+            href={changeLanguageURL(pathname, lang === 'ja' ? 'en' : 'ja')}
+            className="ds-site-footer__nav-link"
+          >
+            {lang === 'ja' ? 'English' : '日本語'}
+          </Link>
+        </nav>
+
+        {/* Status */}
+        <div className="ds-site-footer__status">
+          <div style={{ marginBottom: '12px' }}>
+            <span className="ds-site-footer__status-dot" />
+            <span className="ds-site-footer__status-label">{isJa ? '受付中' : 'Available'}</span>
+          </div>
+          <div className="ds-site-footer__copy" style={{ textAlign: 'right' }}>
+            Q2 2026
+            <br />2 slots remaining
+          </div>
+        </div>
+      </div>
     </footer>
   )
 }

--- a/src/components/tailwindui/Header.tsx
+++ b/src/components/tailwindui/Header.tsx
@@ -2,342 +2,124 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import {
   changeLanguageURL,
   getLanguageFromURL,
   getPathnameWithLangType,
 } from '@/libs/urlUtils/lang.util'
-import Container from './Container'
 import ModeToggle from './Headers/ModeToggle'
 
-/**
- * Render a menu icon that switches between hamburger and close states.
- *
- * @param isOpen - When `true`, displays the close ("X") icon; when `false`, displays the hamburger menu icon.
- * @returns The SVG element representing the current menu icon state.
- */
-function MenuIcon({ isOpen }: { isOpen: boolean }) {
-  return (
-    <svg
-      className="h-6 w-6"
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth="1.5"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      {isOpen ? (
-        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-      ) : (
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
-        />
-      )}
-    </svg>
-  )
-}
-
-function MobileNavItem({
-  href,
-  children,
-  isActive,
-  onClick,
-}: {
-  href: string
-  children: React.ReactNode
-  isActive?: boolean
-  onClick?: () => void
-}) {
-  return (
-    <Link
-      href={href}
-      onClick={onClick}
-      className={`block px-4 py-3 text-base font-medium rounded-lg transition-all ${
-        isActive
-          ? 'text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-500/10'
-          : 'text-slate-700 dark:text-slate-300 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-indigo-50/50 dark:hover:bg-indigo-500/5'
-      }`}
-    >
-      {children}
-    </Link>
-  )
-}
-
-function DesktopNavItem({
-  href,
-  children,
-  isActive,
-}: {
-  href: string
-  children: React.ReactNode
-  isActive?: boolean
-}) {
-  return (
-    <Link
-      href={href}
-      className={`relative px-4 py-2 text-sm font-medium rounded-lg transition-all ${
-        isActive
-          ? 'text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-500/10'
-          : 'text-slate-700 dark:text-slate-300 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-indigo-50/50 dark:hover:bg-indigo-500/5'
-      }`}
-    >
-      {children}
-      {isActive && (
-        <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 h-0.5 w-6 bg-indigo-600 dark:bg-indigo-400 rounded-full" />
-      )}
-    </Link>
-  )
-}
-
-/**
- * Render the mobile slide-in navigation panel and backdrop when the mobile menu is open.
- *
- * Disables background scrolling while open and restores it when closed or on unmount. The menu
- * displays localized navigation links and a language switcher derived from the current URL.
- *
- * @param isOpen - Whether the mobile menu is visible
- * @param onClose - Callback invoked to request closing the menu (called by backdrop, close buttons, and nav item clicks)
- * @returns The mobile menu JSX when `isOpen` is true, `null` otherwise
- */
-function MobileMenu({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+function NavLinks({ onClose }: { onClose?: () => void }) {
   const pathname = usePathname()
   const lang = getLanguageFromURL(pathname)
-  const currentLang = lang
 
   const navItems = [
-    { path: 'about', label: lang === 'ja' ? '概要' : 'About' },
-    { path: 'work', label: lang === 'ja' ? '制作物' : 'Work' },
     { path: 'writing', label: lang === 'ja' ? '執筆' : 'Writing' },
-    { path: 'blog', label: lang === 'ja' ? 'ブログ' : 'Blog' },
-    { path: 'news', label: lang === 'ja' ? 'ニュース' : 'News' },
+    { path: 'work', label: lang === 'ja' ? '制作物' : 'Work' },
     { path: 'speaking', label: lang === 'ja' ? '登壇' : 'Speaking' },
+    { path: 'about', label: lang === 'ja' ? '概要' : 'About' },
   ]
-
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = ''
-    }
-    return () => {
-      document.body.style.overflow = ''
-    }
-  }, [isOpen])
-
-  if (!isOpen) return null
 
   return (
     <>
-      {/* Backdrop */}
-      <button
-        type="button"
-        className="fixed inset-0 bg-black/20 backdrop-blur-sm z-40 lg:hidden"
-        onClick={onClose}
-        aria-label="Close menu"
-      />
-
-      {/* Menu Panel */}
-      <div className="fixed inset-y-0 right-0 z-50 w-full max-w-sm bg-white/95 backdrop-blur-md shadow-2xl ring-1 ring-zinc-900/5 dark:bg-zinc-900/95 dark:ring-white/10 lg:hidden">
-        <div className="flex flex-col h-full">
-          {/* Header */}
-          <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-200 dark:border-zinc-800">
-            <h2 className="text-lg font-bold text-slate-900 dark:text-white">Menu</h2>
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-lg p-2 text-slate-700 dark:text-slate-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
-              aria-label="Close menu"
-            >
-              <MenuIcon isOpen={true} />
-            </button>
-          </div>
-
-          {/* Navigation */}
-          <nav className="flex-1 overflow-y-auto px-6 py-6">
-            <div className="space-y-2">
-              {navItems.map((item) => {
-                const itemPath = getPathnameWithLangType(item.path, lang)
-                const isActive = pathname === itemPath || pathname.startsWith(`${itemPath}/`)
-                return (
-                  <MobileNavItem
-                    key={item.path}
-                    href={itemPath}
-                    isActive={isActive}
-                    onClick={onClose}
-                  >
-                    {item.label}
-                  </MobileNavItem>
-                )
-              })}
-            </div>
-
-            {/* Language Switcher */}
-            <div className="mt-8 pt-8 border-t border-zinc-200 dark:border-zinc-800">
-              <h3 className="px-4 mb-4 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
-                Language
-              </h3>
-              <div className="space-y-2">
-                <MobileNavItem
-                  href={changeLanguageURL(pathname, 'ja')}
-                  isActive={currentLang === 'ja'}
-                  onClick={onClose}
-                >
-                  日本語
-                </MobileNavItem>
-                <MobileNavItem
-                  href={changeLanguageURL(pathname, 'en')}
-                  isActive={currentLang === 'en'}
-                  onClick={onClose}
-                >
-                  English
-                </MobileNavItem>
-              </div>
-            </div>
-          </nav>
-
-          {/* Footer */}
-          <div className="px-6 py-4 border-t border-zinc-200 dark:border-zinc-800">
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-slate-600 dark:text-slate-400">Theme</span>
-              <ModeToggle />
-            </div>
-          </div>
-        </div>
-      </div>
+      {navItems.map((item) => {
+        const href = getPathnameWithLangType(item.path, lang)
+        const isActive = pathname === href || pathname.startsWith(`${href}/`)
+        return (
+          <Link
+            key={item.path}
+            href={href}
+            onClick={onClose}
+            className="ds-site-nav__link"
+            aria-current={isActive ? 'page' : undefined}
+          >
+            {item.label}
+          </Link>
+        )
+      })}
     </>
   )
 }
 
-function DesktopNavigation() {
+export default function Header() {
   const pathname = usePathname()
   const lang = getLanguageFromURL(pathname)
-
-  const navItems = [
-    { path: 'about', label: lang === 'ja' ? '概要' : 'About' },
-    { path: 'work', label: lang === 'ja' ? '制作物' : 'Work' },
-    { path: 'writing', label: lang === 'ja' ? '執筆' : 'Writing' },
-    { path: 'blog', label: lang === 'ja' ? 'ブログ' : 'Blog' },
-    { path: 'news', label: lang === 'ja' ? 'ニュース' : 'News' },
-    { path: 'speaking', label: lang === 'ja' ? '登壇' : 'Speaking' },
-  ]
-
-  return (
-    <nav className="hidden lg:flex items-center gap-1">
-      {navItems.map((item) => {
-        const itemPath = getPathnameWithLangType(item.path, lang)
-        const isActive = pathname === itemPath || pathname.startsWith(`${itemPath}/`)
-        return (
-          <DesktopNavItem key={item.path} href={itemPath} isActive={isActive}>
-            {item.label}
-          </DesktopNavItem>
-        )
-      })}
-    </nav>
-  )
-}
-
-function DesktopLangSwitcher() {
-  const pathname = usePathname()
-  const currentLang = getLanguageFromURL(pathname)
-
-  return (
-    <div className="hidden lg:flex items-center gap-1 rounded-lg bg-white/80 backdrop-blur-md px-2 py-1.5 shadow-sm ring-1 ring-zinc-900/5 dark:bg-zinc-800/80 dark:ring-white/10">
-      <Link
-        href={changeLanguageURL(pathname, 'ja')}
-        className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all ${
-          currentLang === 'ja'
-            ? 'text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-500/10'
-            : 'text-slate-700 dark:text-slate-300 hover:text-indigo-600 dark:hover:text-indigo-400'
-        }`}
-      >
-        JA
-      </Link>
-      <Link
-        href={changeLanguageURL(pathname, 'en')}
-        className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all ${
-          currentLang === 'en'
-            ? 'text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-500/10'
-            : 'text-slate-700 dark:text-slate-300 hover:text-indigo-600 dark:hover:text-indigo-400'
-        }`}
-      >
-        EN
-      </Link>
-    </div>
-  )
-}
-
-export default function Header() {
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const [mobileOpen, setMobileOpen] = useState(false)
 
   return (
     <>
-      <header
-        className="relative z-50 bg-white dark:bg-zinc-900"
-        style={{
-          height: 'var(--header-height)',
-          marginBottom: 'var(--header-mb)',
-        }}
-      >
-        {/* Background decoration - subtle and minimal */}
-        <div className="absolute inset-0 overflow-hidden pointer-events-none">
-          <div className="absolute top-0 right-0 h-40 w-40 rounded-full bg-indigo-200/20 blur-3xl dark:bg-indigo-900/10" />
-          <div className="absolute top-0 left-1/4 h-32 w-32 rounded-full bg-purple-200/15 blur-3xl dark:bg-purple-900/10" />
-        </div>
+      <nav className="ds-site-nav">
+        <div className="ds-site-nav__inner">
+          {/* Logo */}
+          <Link href={lang === 'ja' ? '/ja' : '/'} className="ds-site-nav__logo">
+            <strong>HIDETAKA</strong>.DEV
+          </Link>
 
-        <div
-          className="relative top-0 z-10 h-20 pt-6"
-          style={{ position: 'var(--header-position)' } as unknown as React.CSSProperties}
-        >
-          <Container
-            className="top-[var(--header-top,theme(spacing.6))] w-full"
-            style={{ position: 'var(--header-inner-position)' } as unknown as React.CSSProperties}
+          {/* Desktop links */}
+          <div className="ds-site-nav__links hidden sm:flex">
+            <NavLinks />
+            {/* Language switcher */}
+            <Link
+              href={changeLanguageURL(pathname, lang === 'ja' ? 'en' : 'ja')}
+              className="ds-site-nav__link"
+            >
+              {lang === 'ja' ? 'EN' : 'JA'}
+            </Link>
+            <ModeToggle />
+          </div>
+
+          {/* Mobile toggle */}
+          <button
+            type="button"
+            className="sm:hidden ds-theme-btn ml-auto"
+            onClick={() => setMobileOpen(!mobileOpen)}
+            aria-label="Toggle menu"
           >
-            <div className="flex items-center justify-between gap-4">
-              {/* Logo */}
-              <Link href="/" className="group relative flex-shrink-0">
-                <span className="sr-only">Hidetaka.dev</span>
-                <div className="relative">
-                  <h1 className="text-xl sm:text-2xl font-extrabold tracking-tight text-slate-900 dark:text-white transition-colors group-hover:text-indigo-600 dark:group-hover:text-indigo-400">
-                    Hidetaka.dev
-                  </h1>
-                  <div className="absolute -bottom-1 left-0 h-0.5 w-0 bg-indigo-600 transition-all duration-300 group-hover:w-full dark:bg-indigo-400" />
-                </div>
-              </Link>
-
-              {/* Desktop Navigation */}
-              <div className="hidden lg:flex items-center gap-6 flex-1 justify-center">
-                <DesktopNavigation />
-              </div>
-
-              {/* Right side: Language Switcher & Dark Mode Toggle */}
-              <div className="flex items-center gap-3 flex-shrink-0">
-                <DesktopLangSwitcher />
-
-                <div className="hidden lg:block">
-                  <ModeToggle />
-                </div>
-
-                {/* Mobile Menu Button */}
-                <button
-                  type="button"
-                  onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-                  className="lg:hidden rounded-lg p-2 text-slate-700 dark:text-slate-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
-                  aria-label="Toggle menu"
-                  aria-expanded={mobileMenuOpen}
-                >
-                  <MenuIcon isOpen={mobileMenuOpen} />
-                </button>
-              </div>
-            </div>
-          </Container>
+            {mobileOpen ? '✕' : '≡'}
+          </button>
         </div>
-      </header>
+      </nav>
 
-      {/* Mobile Menu */}
-      <MobileMenu isOpen={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
+      {/* Mobile drawer */}
+      {mobileOpen && (
+        <>
+          <button
+            type="button"
+            className="fixed inset-0 z-40 bg-[var(--color-ink)]/20"
+            onClick={() => setMobileOpen(false)}
+            aria-label="Close menu"
+          />
+          <div className="fixed inset-y-0 right-0 z-50 w-72 bg-[var(--color-bg)] border-l border-[var(--color-line-strong)] flex flex-col">
+            <div className="flex items-center justify-between px-6 py-4 border-b border-[var(--color-line)]">
+              <span className="ds-site-nav__logo">
+                <strong>HIDETAKA</strong>.DEV
+              </span>
+              <button
+                type="button"
+                className="ds-theme-btn"
+                onClick={() => setMobileOpen(false)}
+                aria-label="Close"
+              >
+                ✕
+              </button>
+            </div>
+            <nav className="flex flex-col gap-0 px-6 py-6 flex-1">
+              <NavLinks onClose={() => setMobileOpen(false)} />
+              <Link
+                href={changeLanguageURL(pathname, lang === 'ja' ? 'en' : 'ja')}
+                className="ds-site-nav__link mt-4 pt-4 border-t border-[var(--color-line)]"
+                onClick={() => setMobileOpen(false)}
+              >
+                {lang === 'ja' ? 'English' : '日本語'}
+              </Link>
+            </nav>
+            <div className="px-6 py-4 border-t border-[var(--color-line)]">
+              <ModeToggle />
+            </div>
+          </div>
+        </>
+      )}
     </>
   )
 }

--- a/src/components/tailwindui/Headers/ModeToggle.tsx
+++ b/src/components/tailwindui/Headers/ModeToggle.tsx
@@ -1,80 +1,34 @@
 'use client'
-
 import { useEffect, useState } from 'react'
 
-function SunIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-      className={className}
-    >
-      <path d="M8 12.25A4.25 4.25 0 0 1 12.25 8v0a4.25 4.25 0 0 1 4.25 4.25v0a4.25 4.25 0 0 1-4.25 4.25v0A4.25 4.25 0 0 1 8 12.25v0Z" />
-      <path
-        d="M12.25 3v1.5M21.5 12.25H20M18.791 18.791l-1.06-1.06M18.791 5.709l-1.06 1.06M12.25 20v1.5M4.5 12.25H3M6.77 6.77 5.709 5.709M6.77 17.73l-1.061 1.061"
-        fill="none"
-      />
-    </svg>
-  )
-}
-
-function MoonIcon({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" className={className}>
-      <path
-        d="M17.25 16.22a6.937 6.937 0 0 1-9.47-9.47 7.451 7.451 0 1 0 9.47 9.47ZM12.75 7C17 7 17 2.75 17 2.75S17 7 21.25 7C17 7 17 11.25 17 11.25S17 7 12.75 7Z"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
-}
-
 export default function ModeToggle() {
+  const [isDark, setIsDark] = useState(false)
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
     setMounted(true)
+    setIsDark(document.documentElement.classList.contains('dark'))
   }, [])
 
-  function disableTransitionsTemporarily() {
-    document.documentElement.classList.add('[&_*]:!transition-none')
-    window.setTimeout(() => {
-      document.documentElement.classList.remove('[&_*]:!transition-none')
-    }, 0)
-  }
-
-  function toggleMode() {
-    disableTransitionsTemporarily()
-
-    const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-    const isSystemDarkMode = darkModeMediaQuery.matches
-    const isDarkMode = document.documentElement.classList.toggle('dark')
-
-    if (isDarkMode === isSystemDarkMode) {
-      delete window.localStorage.isDarkMode
+  function toggle() {
+    const next = !document.documentElement.classList.contains('dark')
+    if (next) {
+      document.documentElement.classList.add('dark')
+      document.documentElement.dataset.theme = 'dark'
+      window.localStorage.isDarkMode = 'true'
     } else {
-      window.localStorage.isDarkMode = isDarkMode
+      document.documentElement.classList.remove('dark')
+      document.documentElement.dataset.theme = 'light'
+      window.localStorage.isDarkMode = 'false'
     }
+    setIsDark(next)
   }
 
-  if (!mounted) {
-    return null
-  }
+  if (!mounted) return null
 
   return (
-    <button
-      type="button"
-      aria-label="Toggle dark mode"
-      className="group rounded-full bg-white/90 px-3 py-2 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur transition dark:bg-zinc-800/90 dark:ring-white/10 dark:hover:ring-white/20"
-      onClick={toggleMode}
-    >
-      <SunIcon className="h-6 w-6 fill-zinc-100 stroke-zinc-500 transition group-hover:fill-zinc-200 group-hover:stroke-indigo-600 dark:hidden [@media(prefers-color-scheme:dark)]:fill-indigo-50 [@media(prefers-color-scheme:dark)]:stroke-indigo-500 [@media(prefers-color-scheme:dark)]:group-hover:fill-indigo-50 [@media(prefers-color-scheme:dark)]:group-hover:stroke-indigo-600" />
-      <MoonIcon className="hidden h-6 w-6 fill-zinc-700 stroke-zinc-500 transition dark:block [@media(prefers-color-scheme:dark)]:group-hover:stroke-indigo-400 [@media_not_(prefers-color-scheme:dark)]:fill-indigo-400/10 [@media_not_(prefers-color-scheme:dark)]:stroke-indigo-500" />
+    <button type="button" onClick={toggle} className="ds-theme-btn" aria-label="Toggle dark mode">
+      {isDark ? 'Light' : 'Dark'}
     </button>
   )
 }

--- a/src/components/ui/ArticleCTA.tsx
+++ b/src/components/ui/ArticleCTA.tsx
@@ -44,20 +44,19 @@ export default function ArticleCTA({
   // 言語の正規化（無効な値は'en'にフォールバック）
   const normalizedLang = normalizeLang(lang)
 
-  // カスタムCTAデータの検証(一度だけ実行)
-  const isCustomDataValid = ctaData && isValidCTAData(ctaData)
-
   // CTAデータの選択: カスタムデータが有効な場合は優先、そうでなければパターンから選択
-  const selectedCTAData: CTAData = isCustomDataValid
-    ? ctaData
-    : CTA_PATTERNS[normalizedArticleType][normalizedLang]
-
-  // 無効なカスタムデータが提供された場合は警告をログ
-  if (ctaData && !isCustomDataValid) {
-    console.warn('[ArticleCTA] Invalid ctaData provided, falling back to pattern:', {
-      articleType: normalizedArticleType,
-      lang: normalizedLang,
-    })
+  let selectedCTAData: CTAData
+  if (ctaData && isValidCTAData(ctaData)) {
+    selectedCTAData = ctaData
+  } else {
+    selectedCTAData = CTA_PATTERNS[normalizedArticleType][normalizedLang]
+    // 無効なカスタムデータが提供された場合は警告をログ
+    if (ctaData) {
+      console.warn('[ArticleCTA] Invalid ctaData provided, falling back to pattern:', {
+        articleType: normalizedArticleType,
+        lang: normalizedLang,
+      })
+    }
   }
 
   return (

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -1,32 +1,59 @@
 type PageHeaderProps = {
   title: string
+  eyebrow?: string
+  sub?: string
+  meta?: string[]
   description?: string
   className?: string
-  titleClassName?: string
-  descriptionClassName?: string
+  children?: React.ReactNode
 }
 
 export default function PageHeader({
   title,
+  eyebrow,
+  sub,
+  meta,
   description,
   className = '',
-  titleClassName = '',
-  descriptionClassName = '',
+  children,
 }: PageHeaderProps) {
   return (
-    <header className={`max-w-3xl mb-8 ${className}`}>
-      <h1
-        className={`text-4xl font-bold tracking-tight text-slate-900 dark:text-white sm:text-5xl ${titleClassName}`}
+    <header className={`ds-page-header ${className}`}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: children ? '1fr auto' : '1fr',
+          gap: '40px',
+          alignItems: 'end',
+        }}
       >
-        {title}
-      </h1>
-      {description && (
-        <p
-          className={`mt-3 text-lg leading-relaxed text-slate-600 dark:text-slate-400 ${descriptionClassName}`}
-        >
-          {description}
-        </p>
-      )}
+        <div>
+          {eyebrow && <div className="ds-page-header__eyebrow">{eyebrow}</div>}
+          <h1 className="ds-page-header__title">{title}</h1>
+          {sub && <p className="ds-page-header__sub">{sub}</p>}
+          {description && (
+            <p
+              style={{
+                marginTop: '16px',
+                fontSize: 'var(--text-sm)',
+                color: 'var(--color-ink-2)',
+                lineHeight: 'var(--leading-loose)',
+                maxWidth: '56ch',
+              }}
+            >
+              {description}
+            </p>
+          )}
+          {meta && meta.length > 0 && (
+            <div className="ds-page-header__meta">
+              {meta.map((m) => (
+                <span key={m}>{m}</span>
+              ))}
+            </div>
+          )}
+        </div>
+        {children && <div>{children}</div>}
+      </div>
     </header>
   )
 }

--- a/src/components/ui/Pagination.tsx
+++ b/src/components/ui/Pagination.tsx
@@ -30,70 +30,32 @@ export default function Pagination({ currentPage, totalPages, basePath, lang }: 
   const pageText = getPaginationText(lang, 'page')
 
   return (
-    <nav
-      className="flex items-center justify-between border-t border-zinc-200 dark:border-zinc-800 px-4 py-3 sm:px-6 mt-12"
-      aria-label="Pagination"
-    >
-      <div className="flex flex-1 justify-between sm:justify-start">
+    <nav className="ds-pagination" aria-label="Pagination">
+      <div>
         {prevPage ? (
-          <Link
-            href={prevHref}
-            className="relative inline-flex items-center rounded-md border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
-          >
-            <svg className="mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
-            {prevText}
+          <Link href={prevHref} className="ds-btn ds-btn--ghost ds-btn--sm">
+            ← {prevText}
           </Link>
         ) : (
-          <div className="relative inline-flex items-center rounded-md border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-400 dark:text-zinc-600 cursor-not-allowed">
-            <svg className="mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
-            {prevText}
-          </div>
+          <span className="ds-btn ds-btn--ghost ds-btn--sm" style={{ opacity: 0.4 }}>
+            ← {prevText}
+          </span>
         )}
       </div>
 
-      <div className="hidden sm:flex sm:flex-1 sm:items-center sm:justify-center">
-        <div>
-          <p className="text-sm text-zinc-700 dark:text-zinc-300">
-            <span className="font-medium">{currentPage}</span>
-            <span className="mx-1">/</span>
-            <span className="font-medium">{totalPages}</span>
-            <span className="ml-1">{pageText}</span>
-          </p>
-        </div>
-      </div>
+      <span>
+        {currentPage} / {totalPages} {pageText}
+      </span>
 
-      <div className="flex flex-1 justify-end">
+      <div>
         {nextPage ? (
-          <Link
-            href={nextHref}
-            className="relative inline-flex items-center rounded-md border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
-          >
-            {nextText}
-            <svg className="ml-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
+          <Link href={nextHref} className="ds-btn ds-btn--ghost ds-btn--sm">
+            {nextText} →
           </Link>
         ) : (
-          <div className="relative inline-flex items-center rounded-md border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-400 dark:text-zinc-600 cursor-not-allowed">
-            {nextText}
-            <svg className="ml-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </div>
+          <span className="ds-btn ds-btn--ghost ds-btn--sm" style={{ opacity: 0.4 }}>
+            {nextText} →
+          </span>
         )}
       </div>
     </nav>

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -1,30 +1,28 @@
-import { getSectionHeaderAlignStyles, type SectionHeaderAlign } from '@/libs/componentStyles.utils'
-
 type SectionHeaderProps = {
+  no?: string
   title: string
+  titleSub?: string
+  action?: React.ReactNode
   description?: string
-  align?: SectionHeaderAlign
+  align?: 'left' | 'center' | 'right'
   className?: string
 }
 
 export default function SectionHeader({
+  no,
   title,
-  description,
-  align = 'center',
+  titleSub,
+  action,
   className = '',
 }: SectionHeaderProps) {
-  const alignStyles = getSectionHeaderAlignStyles(align)
-
   return (
-    <div className={`mx-auto max-w-3xl ${alignStyles} ${className}`}>
-      <h2 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white sm:text-4xl">
+    <header className={`ds-sec-header ${className}`}>
+      {no && <div className="ds-sec-header__no">{no}</div>}
+      <h2 className="ds-sec-header__title">
         {title}
+        {titleSub && <small>{titleSub}</small>}
       </h2>
-      {description && (
-        <p className="mt-6 text-lg leading-relaxed text-slate-700 dark:text-slate-400">
-          {description}
-        </p>
-      )}
-    </div>
+      {action && <div className="ds-sec-header__action">{action}</div>}
+    </header>
   )
 }

--- a/src/libs/ctaValidation.test.ts
+++ b/src/libs/ctaValidation.test.ts
@@ -401,7 +401,10 @@ describe('ctaValidation', () => {
             heading: fc.string(),
             description: fc.string(),
             buttons: fc.array(
-              fc.record({ text: fc.string(), href: fc.constant('data:text/html,<script>alert("XSS")</script>') }),
+              fc.record({
+                text: fc.string(),
+                href: fc.constant('data:text/html,<script>alert("XSS")</script>'),
+              }),
               { minLength: 1, maxLength: 3 },
             ),
           }),

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,3 +2,8 @@
 @import "tailwindcss/components";
 /*@import './prism.css';*/
 @import "tailwindcss/utilities";
+
+body {
+  font-feature-settings: "palt";
+  -webkit-font-smoothing: antialiased;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -9,6 +9,9 @@ module.exports = {
 	theme: {
 		extend: {
 			fontFamily: {
+				sans: ['var(--font-zen-kaku)', 'var(--font-inter-tight)', 'system-ui', 'sans-serif'],
+				serif: ['var(--font-shippori)', 'var(--font-inter-tight)', 'Georgia', 'serif'],
+				mono: ['var(--font-jetbrains)', 'ui-monospace', 'monospace'],
 				japanese: [
 					'"Noto Sans JP"',
 					'"Hiragino Kaku Gothic ProN"',
@@ -17,6 +20,9 @@ module.exports = {
 					'Arial',
 					'sans-serif',
 				],
+			},
+			colors: {
+				vermilion: '#ff5b29',
 			},
 		},
 	},


### PR DESCRIPTION
## 概要

`renewal` ブランチの全変更をmainへ取り込むPR。
元のタイトル（`isValidCTAData` の修正）は最終コミットの内容に過ぎず、このPRはサイト全体のUI大規模リニューアルを含む。

## 変更規模

+2,400 / -3,062 行、32ファイル変更

## 主な変更内容

### デザインシステムの刷新
- `src/app/globals.css` に `ds-*` カスタムCSSクラスとデザイントークン（CSS変数）を全面導入
- Tailwind utility classベースのスタイルを `ds-*` クラスベースに移行
- フォント変更: Zen Kaku Gothic / Shippori Mincho / JetBrains Mono 追加
- カラーパレット変更: indigo/slate系 → 石・ヴァーミリオン（#ff5b29）系

### コンポーネント刷新
- `Header.tsx` / `Footer.tsx`: ナビゲーション構造を全面刷新
- `Hero.tsx`: 新デザインシステムに移行
- `WorkPage.tsx` / `WritingPage.tsx` / `BlogPage.tsx` / `SpeakingPage.tsx` / `AboutPage.tsx`: 各ページコンテナを刷新
- `FeaturedContent.tsx`: 大幅リニューアル
- `PageHeader.tsx` / `SectionHeader.tsx` / `Pagination.tsx`: UI部品を `ds-*` クラスへ移行
- ホームページ: `HomeCTA.tsx` / `SpeakingSection.tsx` 新規追加

### その他
- `ArticleCTA.tsx` の `isValidCTAData` ロジック整理（if/else化）

## 現在の課題（要対応）

CodeRabbitが CHANGES_REQUESTED（13件）:

- `<html lang="en">` のハードコード → `/ja/*` でも `lang="en"` になりSEOに影響
- `WorkPage` の `isExternal` ロジックバグ → 全プロジェクトが外部リンク扱いになる
- `PageHeader` / `SectionHeader` のprops破壊的変更 → 既存コールサイトで型エラー
- モバイルドロワーのARIA欠如（`aria-expanded`, `role="dialog"` 等）
- `.ds-theme-btn` の `all: unset` によるフォーカスリング消失
- `Georgia` → `georgia`（stylelint規約違反）
- 検索inputへの `aria-label` 欠如
- レスポンシブ未対応のグリッド複数箇所

また mainブランチとのコンフリクト（DIRTY）があり、リベースが必要。

## 対応方針

1. mainにリベースしてコンフリクト解消
2. 上記13件のCodeRabbit指摘を修正
3. 理想はPRを機能単位で分割（デザインシステム基盤 / コンポーネント移行 / ページコンテナ移行）