### PR TITLE
chore: add OTEL_RESOURCE_ATTRIBUTES to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,5 +24,8 @@
         ]
       }
     ]
+  },
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "project.name=hidetaka.dev.2023"
   }
 }


### PR DESCRIPTION
## Summary

- `.claude/settings.json` に `env` ブロックを追加し `OTEL_RESOURCE_ATTRIBUTES` を設定
- 既存の `hooks` 設定（SessionStart / PreToolUse）は保持

## 変更内容

```json
{
  "env": {
    "OTEL_RESOURCE_ATTRIBUTES": "project.name=hidetaka.dev.2023"
  }
}
```

---
_Generated by [Claude Code](https://claude.ai/code/session_015o4RkTp1SX5y2VTTsGKpGZ)_