### PR TITLE
[CLOSED] feat: wordpress-skills を Work ページに追加 + LP への直リンク対応

### DIFF
--- a/docs/microcms/wordpress-skills.md
+++ b/docs/microcms/wordpress-skills.md
@@ -1,0 +1,142 @@
+# microCMS 投稿原稿: wordpress-skills
+
+このドキュメントは microCMS の `projects` エンドポイントに投稿するコンテンツ原稿です。
+
+> **重要**: content ID は microCMS が自動生成するランダム値を使用してください。
+> `wordpress-skills` という ID は使用しないこと。
+> LP は Cloudflare Worker として `hidetaka.dev/work/wordpress-skills` で独立稼働しており、
+> Next.js の `/work/[slug]` との slug 衝突を避けるため。
+
+---
+
+## フィールド一覧
+
+| フィールド | 値 |
+|---|---|
+| **title** | `wordpress-skills` |
+| **url** | `https://hidetaka.dev/work/wordpress-skills` |
+| **published_at** | `2026-06-02` |
+| **project_type** | `owned_oss` |
+| **lang** | `English` |
+| **is_solo** | `true` |
+| **status** | `active` |
+| **tags** | `WordPress`, `AI`, `Claude Code`, `Agent Skills`, `Cloudflare Workers`, `Python` |
+
+---
+
+## about（英語）
+
+```
+Agent Skills that give AI coding agents primary-source grounding for WordPress development. Instead of generating code from memory, the agent searches and reads official WordPress Developer Handbooks at request time — so answers about plugins, themes, the Block Editor, the REST API, and coding standards come from the docs, not from a guess.
+```
+
+---
+
+## background（英語・HTML）
+
+```html
+<p>Official and semi-official skills (e.g. WordPress/agent-skills, Automattic/wordpress-agent-skills) are great at <strong>generating</strong> WordPress code. But generation relies on the model's training data, which goes stale and occasionally invents APIs that never existed.</p>
+
+<p><code>wordpress-skills</code> is the <strong>grounding layer</strong>: it fetches the relevant Handbook pages at request time, so your agent has the current, official source in front of it.</p>
+
+<p>Included skill: <strong>wordpress-handbook</strong> — searches the seven official WordPress Developer Handbooks (Plugin / Theme / Block Editor / REST API / Common APIs / Coding Standards / Advanced Administration) and fetches full article content on demand.</p>
+
+<p>Compatible with Claude Code, Cursor, GitHub Copilot, Codex, Gemini CLI, and any agent that supports the open <a href="https://agentskills.io">SKILL.md</a> standard.</p>
+```
+
+---
+
+## architecture（英語・HTML）
+
+```html
+<p>Built as a monorepo with two packages:</p>
+
+<ul>
+  <li><strong>skills/wordpress-handbook</strong> — Python-based skill scripts that query <code>developer.wordpress.org</code> search and fetch Handbook article content over HTTPS.</li>
+  <li><strong>site/</strong> — Astro landing page deployed as a standalone Cloudflare Worker, mounted at <code>hidetaka.dev/work/wordpress-skills</code> via Cloudflare route matching.</li>
+</ul>
+
+<p>Install via GitHub CLI:</p>
+<pre><code>gh skill install hideokamoto/wordpress-skills wordpress-handbook</code></pre>
+
+<p>Or via Vercel skills CLI:</p>
+<pre><code>npx skills add hideokamoto/wordpress-skills --skill wordpress-handbook</code></pre>
+```
+
+---
+
+## 日本語版フィールド
+
+| フィールド | 値 |
+|---|---|
+| **title** | `wordpress-skills` |
+| **url** | `https://hidetaka.dev/work/wordpress-skills` |
+| **published_at** | `2026-06-02` |
+| **project_type** | `owned_oss` |
+| **lang** | `Japanese` |
+| **is_solo** | `true` |
+| **status** | `active` |
+| **tags** | `WordPress`, `AI`, `Claude Code`, `Agent Skills`, `Cloudflare Workers`, `Python` |
+
+## about（日本語）
+
+```
+AI コーディングエージェントに WordPress 開発の一次情報グラウンディングを与える Agent Skills です。記憶からコードを生成するのではなく、リクエスト時に developer.wordpress.org の公式ハンドブックを検索・取得します。プラグイン・テーマ・ブロックエディター・REST API・コーディング規約に関する回答が、"うろ覚え"ではなく公式ドキュメント由来になります。
+```
+
+## background（日本語・HTML）
+
+```html
+<p>公式・準公式のスキル（WordPress/agent-skills、Automattic/wordpress-agent-skills など）は WordPress コードの<strong>生成</strong>に強みがあります。ただし生成はモデルの学習データに依存するため、情報が古くなったり、存在しない API を作り出してしまうことがあります。</p>
+
+<p><code>wordpress-skills</code> は<strong>グラウンディング層</strong>です。リクエスト時に該当するハンドブックのページを取得し、最新かつ公式の情報をエージェントの手元に置きます。</p>
+
+<p>収録スキル: <strong>wordpress-handbook</strong> — 公式 7 ハンドブック（プラグイン / テーマ / ブロックエディター / REST API / 共通 API / コーディング規約 / 高度な管理）を検索し、必要に応じて記事本文を取得します。</p>
+
+<p>Claude Code・Cursor・GitHub Copilot・Codex・Gemini CLI など、オープンな <a href="https://agentskills.io">SKILL.md</a> 標準に対応したエージェントで動作します。</p>
+```
+
+## architecture（日本語・HTML）
+
+```html
+<p>2 パッケージのモノレポ構成:</p>
+
+<ul>
+  <li><strong>skills/wordpress-handbook</strong> — <code>developer.wordpress.org</code> の検索とハンドブック記事取得を行う Python 製スキルスクリプト。</li>
+  <li><strong>site/</strong> — Astro 製ランディングページ。独立した Cloudflare Worker としてデプロイされ、Cloudflare のルートマッチングにより <code>hidetaka.dev/work/wordpress-skills</code> にマウントされます。</li>
+</ul>
+
+<p>GitHub CLI でインストール:</p>
+<pre><code>gh skill install hideokamoto/wordpress-skills wordpress-handbook</code></pre>
+
+<p>Vercel skills CLI でインストール:</p>
+<pre><code>npx skills add hideokamoto/wordpress-skills --skill wordpress-handbook</code></pre>
+```
+
+---
+
+## LP パス設計について
+
+### 現在の構成
+
+```
+hidetaka.dev/work/wordpress-skills  →  Astro LP (Cloudflare Worker)
+hidetaka.dev/work/[slug]            →  Next.js 詳細ページ (microCMS content)
+```
+
+Cloudflare Workers のルートマッチングがエッジで先に処理されるため、
+`/work/wordpress-skills` へのリクエストは Next.js に届かず LP Worker が応答します。
+
+### slug 衝突の回避
+
+microCMS の content ID は自動生成のランダム値（例: `abc123xyz`）のため、
+`/work/wordpress-skills` という静的ページは Next.js により生成されません。
+**content ID として `wordpress-skills` を手動設定しないこと。**
+
+### 日本語 LP
+
+Astro サイトの `/work/wordpress-skills/ja/` が日本語 LP として機能します
+（Cloudflare Worker ルート `hidetaka.dev/work/wordpress-skills/*` でカバー）。
+
+hidetaka.dev の Work ページで日本語ユーザーがカードをクリックした場合も、
+英語 LP (`/work/wordpress-skills`) にリンクし、LP 内で言語切り替えします。

--- a/src/components/containers/pages/WorkPage.tsx
+++ b/src/components/containers/pages/WorkPage.tsx
@@ -92,7 +92,13 @@ function getOSSItemDate(item: OSSItem): string {
 
 // 統一されたWorkカードコンポーネント（プロジェクト用）
 function UnifiedProjectCard({ project, lang }: { project: MicroCMSProjectsRecord; lang: string }) {
-  const href = lang === 'ja' ? `/ja/work/${project.id}` : `/work/${project.id}`
+  // url が hidetaka.dev 上の専用 LP を指す場合はそちらへ直リンク（Next.js 詳細ページをスキップ）
+  const isInternalLP = project.url.startsWith('https://hidetaka.dev/')
+  const href = isInternalLP
+    ? project.url
+    : lang === 'ja'
+      ? `/ja/work/${project.id}`
+      : `/work/${project.id}`
   const date = project.published_at ? new Date(project.published_at) : null
   const status = getMicroCMSProjectStatus(project.status)
   const statusVariant = getStatusBadgeVariant(status)

--- a/src/components/containers/pages/WorkPage.tsx
+++ b/src/components/containers/pages/WorkPage.tsx
@@ -92,10 +92,12 @@ function getOSSItemDate(item: OSSItem): string {
 
 // 統一されたWorkカードコンポーネント（プロジェクト用）
 function UnifiedProjectCard({ project, lang }: { project: MicroCMSProjectsRecord; lang: string }) {
-  // url が hidetaka.dev 上の専用 LP を指す場合はそちらへ直リンク（Next.js 詳細ページをスキップ）
-  const isInternalLP = project.url.startsWith('https://hidetaka.dev/')
+  // url が hidetaka.dev/work/ 配下の専用 LP を指す場合はそちらへ直リンク（Next.js 詳細ページをスキップ）
+  const isInternalLP = project.url.startsWith('https://hidetaka.dev/work/')
   const href = isInternalLP
-    ? project.url
+    ? lang === 'ja'
+      ? project.url.replace(/\/$/, '') + '/ja/'
+      : project.url
     : lang === 'ja'
       ? `/ja/work/${project.id}`
       : `/work/${project.id}`

--- a/src/libs/microCMS/apis.ts
+++ b/src/libs/microCMS/apis.ts
@@ -1,6 +1,8 @@
-import { MICROCMS_MOCK_BOOKs } from './mocks'
+import { MICROCMS_MOCK_BOOKs, MICROCMS_MOCK_OSS_PROJECTS } from './mocks'
 import type { MicroCMSClient, MicroCMSProjectsRecord } from './types'
 import { handleMicroCMSRequest } from './utils'
+
+const MICROCMS_MOCK_ALL_PROJECTS = [...MICROCMS_MOCK_BOOKs, ...MICROCMS_MOCK_OSS_PROJECTS]
 
 export class MicroCMSAPI {
   private readonly client: MicroCMSClient
@@ -29,7 +31,7 @@ export class MicroCMSAPI {
   public async listAllProjects(): Promise<MicroCMSProjectsRecord[]> {
     return handleMicroCMSRequest(
       this.client,
-      MICROCMS_MOCK_BOOKs,
+      MICROCMS_MOCK_ALL_PROJECTS,
       async () => {
         return await this.client!.getAllContents({
           endpoint: 'projects',

--- a/src/libs/microCMS/mocks.ts
+++ b/src/libs/microCMS/mocks.ts
@@ -1,5 +1,25 @@
 import type { MicroCMSProjectsRecord } from './types'
 
+export const MICROCMS_MOCK_OSS_PROJECTS: MicroCMSProjectsRecord[] = [
+  {
+    id: 'wordpress-skills-oss',
+    createdAt: '2026-06-02T00:00:00.000Z',
+    updatedAt: '2026-06-02T00:00:00.000Z',
+    publishedAt: '2026-06-02T00:00:00.000Z',
+    revisedAt: '2026-06-02T00:00:00.000Z',
+    title: 'wordpress-skills',
+    url: 'https://hidetaka.dev/work/wordpress-skills',
+    published_at: '2026-06-02T00:00:00.000Z',
+    tags: ['WordPress', 'AI', 'Claude Code', 'Agent Skills', 'Cloudflare Workers', 'Python'],
+    project_type: ['owned_oss'],
+    lang: ['English'],
+    is_solo: true,
+    status: 'active',
+    about:
+      'Agent Skills that give AI coding agents primary-source grounding for WordPress development. Instead of generating code from memory, the agent searches and reads official WordPress Developer Handbooks at request time.',
+  },
+]
+
 export const MICROCMS_MOCK_BOOKs: MicroCMSProjectsRecord[] = [
   {
     id: '48xxv5o8vt8j',


### PR DESCRIPTION
## Summary

- **microCMS 側に概要情報を保存**し、**LP は独立した Cloudflare Worker として稼働**させる設計で実装
- Work ページのカードが LP へ直リンクするよう `UnifiedProjectCard` のリンクロジックを変更
- 開発用モックデータ (`MICROCMS_MOCK_OSS_PROJECTS`) に wordpress-skills エントリを追加
- microCMS 投稿原稿（英語・日本語）を `docs/microcms/wordpress-skills.md` に作成

## Changes

### `src/components/containers/pages/WorkPage.tsx`

`UnifiedProjectCard` のリンク先を変更:

```
変更前: 常に /work/[cms-id] (Next.js 詳細ページ) へ
変更後: url が https://hidetaka.dev/ から始まる場合 → LP へ直リンク
        それ以外 → 従来通り /work/[cms-id]
```

これにより `Work ページカード → LP` が 1 クリックで到達可能になる。

### `src/libs/microCMS/mocks.ts`

`MICROCMS_MOCK_OSS_PROJECTS` を新設し wordpress-skills エントリを追加:

- `id: 'wordpress-skills-oss'` (LP slug `wordpress-skills` との衝突を回避)
- `url: 'https://hidetaka.dev/work/wordpress-skills'` (LP への直リンク)
- `project_type: ['owned_oss']`、`status: 'active'`

### `src/libs/microCMS/apis.ts`

`listAllProjects()` のモックデータを `[...books, ...oss_projects]` に拡張。

### `docs/microcms/wordpress-skills.md` (新規)

microCMS `projects` エンドポイントへの投稿原稿。英語・日本語両バージョンの全フィールド値を記載。

## LP パス設計について

### 現在の構成（変更不要）

```
hidetaka.dev/work/wordpress-skills     → Astro LP (Cloudflare Worker)
hidetaka.dev/work/[slug]               → Next.js 詳細ページ (microCMS)
```

Cloudflare Workers のルートマッチングがエッジで優先されるため、`/work/wordpress-skills` は常に LP Worker が応答する。Next.js の `/work/[slug]` との実害はない。

### slug 衝突回避ルール

microCMS の content ID は自動生成のランダム値（例: `abc123xyz`）なので、`/work/wordpress-skills` という静的 Next.js ページが生成される心配はない。**手動で `wordpress-skills` という ID を設定しないこと。**

### 日本語 LP

- Astro サイトは `/work/wordpress-skills/ja/` に日本語ページを持つ
- Cloudflare Worker ルート `hidetaka.dev/work/wordpress-skills/*` でカバー済み
- hidetaka.dev 側の日本語カードは英語 LP URL (`/work/wordpress-skills`) にリンクし、LP 内で言語切り替え

## Test plan

- [ ] `pnpm test` — 全テスト通過 (670 tests)
- [ ] `pnpm lint:check` — lint 通過
- [ ] `pnpm build` — TypeScript ビルド通過
- [ ] `MICROCMS_API_MODE=mock pnpm dev` で Work ページを開き、wordpress-skills カードが表示されることを確認
- [ ] カードクリックで `https://hidetaka.dev/work/wordpress-skills` に遷移することを確認
- [ ] 他の microCMS プロジェクト（books など）のカードが従来通り `/work/[id]` 詳細ページに遷移することを確認
- [ ] microCMS に原稿を投稿（`docs/microcms/wordpress-skills.md` を参照）

https://claude.ai/code/session_01APz7Cux6fwLjJz5qaxVDL4

---
_Generated by [Claude Code](https://claude.ai/code/session_01APz7Cux6fwLjJz5qaxVDL4)_