### PR TITLE
feat: dev-notes/blog詳細ページにmeta descriptionを追加してCTRを改善

### DIFF
--- a/src/libs/metadata.test.ts
+++ b/src/libs/metadata.test.ts
@@ -133,6 +133,88 @@ describe('generateDevNoteMetadata', () => {
     expect(result.twitter?.images).toHaveLength(1)
     expect(result.twitter?.images?.[0]).toBe('https://hidetaka.dev/api/thumbnail/dev-notes/123')
   })
+
+  describe('description', () => {
+    it('should generate a description from the excerpt', () => {
+      const note = createMockWPThought({
+        excerpt: { rendered: '<p>This is a useful summary of the note.</p>' },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBe('This is a useful summary of the note.')
+      expect(result.openGraph?.description).toBe('This is a useful summary of the note.')
+      expect(result.twitter?.description).toBe('This is a useful summary of the note.')
+    })
+
+    it('should strip HTML tags from the description', () => {
+      const note = createMockWPThought({
+        excerpt: { rendered: '<p>Hello <strong>world</strong> from <a href="#">here</a>.</p>' },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBe('Hello world from here.')
+      expect(result.description).not.toMatch(/<[^>]*>/)
+    })
+
+    it('should normalize whitespace in the description', () => {
+      const note = createMockWPThought({
+        excerpt: { rendered: '<p>Multiple   spaces\n\nand newlines</p>' },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBe('Multiple spaces and newlines')
+    })
+
+    it('should truncate the description to roughly 120 characters', () => {
+      const longText = 'A'.repeat(300)
+      const note = createMockWPThought({
+        excerpt: { rendered: `<p>${longText}</p>` },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBeDefined()
+      expect((result.description as string).length).toBeLessThanOrEqual(123)
+    })
+
+    it('should fall back to content when the excerpt is empty', () => {
+      const note = createMockWPThought({
+        excerpt: { rendered: '' },
+        content: { rendered: '<p>Fallback content body.</p>' },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBe('Fallback content body.')
+    })
+
+    it('should fall back to the title when excerpt and content are empty', () => {
+      const note = createMockWPThought({
+        title: { rendered: 'Only Title Available' },
+        excerpt: { rendered: '' },
+        content: { rendered: '' },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBe('Only Title Available')
+    })
+
+    it('should never produce an empty string description', () => {
+      const note = createMockWPThought({
+        title: { rendered: 'Some Title' },
+        excerpt: { rendered: '<p>   </p>' },
+        content: { rendered: '<p></p>' },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBeTruthy()
+    })
+  })
 })
 
 describe('generateBlogPostMetadata', () => {
@@ -236,6 +318,88 @@ describe('generateBlogPostMetadata', () => {
 
     expect(result1.openGraph?.images?.[0]?.url).toContain('/thoughts/1')
     expect(result2.openGraph?.images?.[0]?.url).toContain('/thoughts/2')
+  })
+
+  describe('description', () => {
+    it('should generate a description from the excerpt', () => {
+      const thought = createMockWPThought({
+        excerpt: { rendered: '<p>This is a useful summary of the post.</p>' },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBe('This is a useful summary of the post.')
+      expect(result.openGraph?.description).toBe('This is a useful summary of the post.')
+      expect(result.twitter?.description).toBe('This is a useful summary of the post.')
+    })
+
+    it('should strip HTML tags from the description', () => {
+      const thought = createMockWPThought({
+        excerpt: { rendered: '<p>Hello <strong>world</strong> from <a href="#">here</a>.</p>' },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBe('Hello world from here.')
+      expect(result.description).not.toMatch(/<[^>]*>/)
+    })
+
+    it('should normalize whitespace in the description', () => {
+      const thought = createMockWPThought({
+        excerpt: { rendered: '<p>Multiple   spaces\n\nand newlines</p>' },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBe('Multiple spaces and newlines')
+    })
+
+    it('should truncate the description to roughly 120 characters', () => {
+      const longText = 'A'.repeat(300)
+      const thought = createMockWPThought({
+        excerpt: { rendered: `<p>${longText}</p>` },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBeDefined()
+      expect((result.description as string).length).toBeLessThanOrEqual(123)
+    })
+
+    it('should fall back to content when the excerpt is empty', () => {
+      const thought = createMockWPThought({
+        excerpt: { rendered: '' },
+        content: { rendered: '<p>Fallback content body.</p>' },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBe('Fallback content body.')
+    })
+
+    it('should fall back to the title when excerpt and content are empty', () => {
+      const thought = createMockWPThought({
+        title: { rendered: 'Only Title Available' },
+        excerpt: { rendered: '' },
+        content: { rendered: '' },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBe('Only Title Available')
+    })
+
+    it('should never produce an empty string description', () => {
+      const thought = createMockWPThought({
+        title: { rendered: 'Some Title' },
+        excerpt: { rendered: '<p>   </p>' },
+        content: { rendered: '<p></p>' },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBeTruthy()
+    })
   })
 })
 

--- a/src/libs/metadata.ts
+++ b/src/libs/metadata.ts
@@ -1,6 +1,30 @@
 import type { Metadata } from 'next'
 import type { WPThought } from './dataSources/types'
 import type { MicroCMSProjectsRecord } from './microCMS/types'
+import { removeHtmlTags } from './sanitize'
+
+const MAX_DESCRIPTION_LENGTH = 120
+
+/**
+ * WordPressのexcerpt/contentからmeta description用のプレーンテキストを生成する。
+ * HTMLタグを除去し、空白を正規化したうえで最大120文字程度に切り詰める。
+ * excerpt・contentが空の場合はtitleにフォールバックし、空文字を返さない。
+ */
+function buildDescription(thought: WPThought): string {
+  const candidates = [thought.excerpt?.rendered, thought.content?.rendered, thought.title.rendered]
+
+  for (const candidate of candidates) {
+    const text = (removeHtmlTags(candidate ?? '') ?? '').replace(/\s+/g, ' ').trim()
+    if (!text) continue
+
+    if (text.length <= MAX_DESCRIPTION_LENGTH) {
+      return text
+    }
+    return `${text.slice(0, MAX_DESCRIPTION_LENGTH).trimEnd()}...`
+  }
+
+  return thought.title.rendered
+}
 
 export function generateDevNoteMetadata(note: WPThought): Metadata {
   const ogImageUrl = new URL(
@@ -8,10 +32,14 @@ export function generateDevNoteMetadata(note: WPThought): Metadata {
     process.env.NEXT_PUBLIC_SITE_URL || 'https://hidetaka.dev',
   )
 
+  const description = buildDescription(note)
+
   return {
     title: note.title.rendered,
+    description,
     openGraph: {
       title: note.title.rendered,
+      description,
       type: 'article',
       publishedTime: note.date,
       images: [
@@ -26,6 +54,7 @@ export function generateDevNoteMetadata(note: WPThought): Metadata {
     twitter: {
       card: 'summary_large_image',
       title: note.title.rendered,
+      description,
       images: [ogImageUrl.toString()],
     },
   }
@@ -39,10 +68,14 @@ export function generateBlogPostMetadata(thought: WPThought): Metadata {
     process.env.NEXT_PUBLIC_SITE_URL || 'https://hidetaka.dev',
   )
 
+  const description = buildDescription(thought)
+
   return {
     title: thought.title.rendered,
+    description,
     openGraph: {
       title: thought.title.rendered,
+      description,
       type: 'article',
       publishedTime: thought.date,
       images: [
@@ -57,6 +90,7 @@ export function generateBlogPostMetadata(thought: WPThought): Metadata {
     twitter: {
       card: 'summary_large_image',
       title: thought.title.rendered,
+      description,
       images: [ogImageUrl.toString()],
     },
   }


### PR DESCRIPTION
## 背景（SEOレポート分析より）

過去6ヶ月のSearch Console分析で、`hidetaka.dev` 本体は impression は伸びているのに **CTR が構造的に低い（平均2.87%）** ことが判明。原因をコードで裏取りしたところ、`src/libs/metadata.ts` の `generateDevNoteMetadata` / `generateBlogPostMetadata` が **`description` を一切出力していない** ことが分かった。流入の中核である dev-notes / blog 詳細ページ全件で、検索スニペットが Google の本文自動生成依存になっており、CTR をコントロールできていなかった。

## 変更内容

- `buildDescription` ヘルパーを追加（`src/libs/sanitize.ts` の `removeHtmlTags` を踏襲）
- `generateDevNoteMetadata` / `generateBlogPostMetadata` の戻り値に以下を追加:
  - トップレベル `description`
  - `openGraph.description`
  - `twitter.description`
- 候補の優先順位: `excerpt.rendered` → `content.rendered` → `title.rendered`（フォールバック）
- 空白正規化 + `trim()` + 最大120文字（超過時は `...` 付与）。空文字は返さず最終フォールバックは title
- 既存の title / openGraph / twitter / images の挙動は不変更

## テスト（TDD）

- `src/libs/metadata.test.ts` に両関数分 計14ケースを追加（excerptからの生成 / HTMLタグ除去 / 空白正規化 / 120文字切り詰め / content・titleへのフォールバック / 空文字を返さない）
- 実装前はレッド、実装後グリーンを確認

## 検証

- `pnpm lint:check` ✅
- `pnpm test` ✅（684テスト全通過）
- `pnpm build` ✅

> 注: `metadata.ts` を触る #work-generateMetadata PR とマージ時に軽微な競合の可能性あり。後勝ちブランチをリベースで解消します。

https://claude.ai/code/session_01BYtdQhtvugEJdzASEQnEA2

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYtdQhtvugEJdzASEQnEA2)_