### PR TITLE
feat: work詳細ページにgenerateMetadataを実装しtitle/description/OGPを生成

### DIFF
--- a/src/app/ja/work/[slug]/page.tsx
+++ b/src/app/ja/work/[slug]/page.tsx
@@ -1,5 +1,7 @@
+import type { Metadata } from 'next'
 import Image from 'next/image'
 import Container from '@/components/tailwindui/Container'
+import { generateProjectMetadata } from '@/libs/metadata'
 import { MicroCMSAPI } from '@/libs/microCMS/apis'
 import { createMicroCMSClient } from '@/libs/microCMS/client'
 
@@ -9,6 +11,24 @@ export async function generateStaticParams() {
   return projects.map((project) => ({
     slug: project.id,
   }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  const { slug } = await params
+  const microCMS = new MicroCMSAPI(createMicroCMSClient())
+  const project = await microCMS
+    .listAllProjects()
+    .then((projects) => projects.find((p) => p.id === slug))
+
+  if (!project) {
+    return { title: 'Work | Hidetaka.dev' }
+  }
+
+  return generateProjectMetadata(project, 'ja')
 }
 
 export default async function ProjectDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -1,5 +1,7 @@
+import type { Metadata } from 'next'
 import Image from 'next/image'
 import Container from '@/components/tailwindui/Container'
+import { generateProjectMetadata } from '@/libs/metadata'
 import { MicroCMSAPI } from '@/libs/microCMS/apis'
 import { createMicroCMSClient } from '@/libs/microCMS/client'
 
@@ -9,6 +11,24 @@ export async function generateStaticParams() {
   return projects.map((project) => ({
     slug: project.id,
   }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  const { slug } = await params
+  const microCMS = new MicroCMSAPI(createMicroCMSClient())
+  const project = await microCMS
+    .listAllProjects()
+    .then((projects) => projects.find((p) => p.id === slug))
+
+  if (!project) {
+    return { title: 'Work | Hidetaka.dev' }
+  }
+
+  return generateProjectMetadata(project, 'en')
 }
 
 export default async function ProjectDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/libs/metadata.test.ts
+++ b/src/libs/metadata.test.ts
@@ -1,6 +1,29 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { WPThought } from './dataSources/types'
-import { generateBlogPostMetadata, generateDevNoteMetadata } from './metadata'
+import {
+  generateBlogPostMetadata,
+  generateDevNoteMetadata,
+  generateProjectMetadata,
+} from './metadata'
+import type { MicroCMSProjectsRecord } from './microCMS/types'
+
+// プロジェクト用のモックデータファクトリ
+const createMockProject = (
+  overrides: Partial<MicroCMSProjectsRecord> = {},
+): MicroCMSProjectsRecord => ({
+  id: 'project-1',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  publishedAt: '2024-01-01T00:00:00.000Z',
+  title: 'Test Project',
+  url: 'https://example.com/project',
+  tags: ['typescript'],
+  project_type: ['owned_oss'],
+  lang: ['English'],
+  is_solo: true,
+  about: '<p>A great project about testing.</p>',
+  ...overrides,
+})
 
 // テスト用のモックデータファクトリ
 const createMockWPThought = (overrides: Partial<WPThought> = {}): WPThought => ({
@@ -213,5 +236,95 @@ describe('generateBlogPostMetadata', () => {
 
     expect(result1.openGraph?.images?.[0]?.url).toContain('/thoughts/1')
     expect(result2.openGraph?.images?.[0]?.url).toContain('/thoughts/2')
+  })
+})
+
+describe('generateProjectMetadata', () => {
+  it('should use project title as the metadata title', () => {
+    const project = createMockProject({ title: 'My OSS Tool' })
+
+    const result = generateProjectMetadata(project, 'en')
+
+    expect(result.title).toBe('My OSS Tool')
+    expect(result.openGraph?.title).toBe('My OSS Tool')
+    expect(result.twitter?.title).toBe('My OSS Tool')
+  })
+
+  it('should strip HTML tags from about to build the description', () => {
+    const project = createMockProject({
+      about: '<p>A <strong>great</strong> project.</p>',
+    })
+
+    const result = generateProjectMetadata(project, 'en')
+
+    expect(result.description).toBe('A great project.')
+    expect(result.description).not.toContain('<')
+    expect(result.openGraph?.description).toBe('A great project.')
+    expect(result.twitter?.description).toBe('A great project.')
+  })
+
+  it('should normalize whitespace in the description', () => {
+    const project = createMockProject({
+      about: '<p>Line one.</p>\n   <p>Line two.</p>',
+    })
+
+    const result = generateProjectMetadata(project, 'en')
+
+    expect(result.description).toBe('Line one. Line two.')
+  })
+
+  it('should truncate long descriptions to about 120 characters', () => {
+    const longText = 'あ'.repeat(300)
+    const project = createMockProject({ about: `<p>${longText}</p>` })
+
+    const result = generateProjectMetadata(project, 'ja')
+
+    expect(result.description).toBeDefined()
+    expect((result.description as string).length).toBeLessThanOrEqual(121)
+  })
+
+  it('should fall back to title when about is missing', () => {
+    const project = createMockProject({ title: 'No About Project', about: undefined })
+
+    const result = generateProjectMetadata(project, 'en')
+
+    expect(result.description).toBe('No About Project')
+    expect(result.openGraph?.description).toBe('No About Project')
+  })
+
+  it('should set openGraph type to website', () => {
+    const project = createMockProject()
+
+    const result = generateProjectMetadata(project, 'en')
+
+    expect(result.openGraph?.type).toBe('website')
+  })
+
+  it('should set twitter card to summary_large_image', () => {
+    const project = createMockProject()
+
+    const result = generateProjectMetadata(project, 'en')
+
+    expect(result.twitter?.card).toBe('summary_large_image')
+  })
+
+  it('should include the project image in openGraph when present', () => {
+    const project = createMockProject({
+      image: { url: 'https://images.microcms-assets.io/test.png', width: 1200, height: 630 },
+    })
+
+    const result = generateProjectMetadata(project, 'en')
+
+    expect(result.openGraph?.images).toBeDefined()
+    expect(result.openGraph?.images).toHaveLength(1)
+    expect(result.openGraph?.images?.[0]?.url).toBe('https://images.microcms-assets.io/test.png')
+  })
+
+  it('should omit openGraph images when the project has no image', () => {
+    const project = createMockProject({ image: undefined })
+
+    const result = generateProjectMetadata(project, 'en')
+
+    expect(result.openGraph?.images).toBeUndefined()
   })
 })

--- a/src/libs/metadata.ts
+++ b/src/libs/metadata.ts
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import type { WPThought } from './dataSources/types'
+import type { MicroCMSProjectsRecord } from './microCMS/types'
 
 export function generateDevNoteMetadata(note: WPThought): Metadata {
   const ogImageUrl = new URL(
@@ -57,6 +58,55 @@ export function generateBlogPostMetadata(thought: WPThought): Metadata {
       card: 'summary_large_image',
       title: thought.title.rendered,
       images: [ogImageUrl.toString()],
+    },
+  }
+}
+
+const PROJECT_DESCRIPTION_MAX_LENGTH = 120
+
+export function generateProjectMetadata(
+  project: MicroCMSProjectsRecord,
+  _lang: 'ja' | 'en',
+): Metadata {
+  // aboutからHTMLタグを除去し、空白を正規化して説明文を生成する
+  // aboutが無ければtitleをフォールバックとして使用する
+  const rawDescription = project.about
+    ? project.about
+        .replace(/<[^>]*>/g, '')
+        .replace(/\s+/g, ' ')
+        .trim()
+    : ''
+  const baseDescription = rawDescription.length > 0 ? rawDescription : project.title
+  const description =
+    baseDescription.length > PROJECT_DESCRIPTION_MAX_LENGTH
+      ? baseDescription.slice(0, PROJECT_DESCRIPTION_MAX_LENGTH)
+      : baseDescription
+
+  return {
+    title: project.title,
+    description,
+    openGraph: {
+      title: project.title,
+      description,
+      type: 'website',
+      ...(project.image
+        ? {
+            images: [
+              {
+                url: project.image.url,
+                width: project.image.width,
+                height: project.image.height,
+                alt: project.title,
+              },
+            ],
+          }
+        : {}),
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: project.title,
+      description,
+      ...(project.image ? { images: [project.image.url] } : {}),
     },
   }
 }


### PR DESCRIPTION
## 背景（SEOレポート分析より）

`/ja/work/bq-cle0v37t` は **4,475 impression / 平均順位8.25 と露出は高いのに CTR 2.17%** と低く、機会損失が大きかった。コードを調査したところ、`src/app/work/[slug]/page.tsx` と `src/app/ja/work/[slug]/page.tsx` には **`generateMetadata` が存在せず**、title / description / OGP が生成されていなかった（news ページには実装あり）。識別子そのままの slug でメタ情報が空のため、検索スニペットがクリックを誘発できていなかった。

CTR 2.17% → 5% への改善で **+約127クリック** が見込める。

## 変更内容

- `src/libs/metadata.ts` に **`generateProjectMetadata(project, lang)`** を新規追加
  - `title`: `project.title`
  - `description`: `project.about` からHTMLタグ除去 + 空白正規化 + 120文字切り詰め。about が無ければ title をフォールバック
  - `openGraph`: `type: 'website'` + title/description、`project.image` があれば images
  - `twitter`: `summary_large_image` + title/description
- `src/app/work/[slug]/page.tsx`（`'en'`）/ `src/app/ja/work/[slug]/page.tsx`（`'ja'`）に `generateMetadata` を実装
  - `listAllProjects()` から `slug === project.id` で検索、見つからなければ `{ title: 'Work | Hidetaka.dev' }` フォールバック
- `generateStaticParams` とページ描画は不変更

## テスト（TDD）

- `src/libs/metadata.test.ts` に `generateProjectMetadata` の8ケースを追加（title反映 / about→description＆HTMLタグ除去 / 空白正規化 / 120文字切り詰め / about無しのtitleフォールバック / og type / twitter card / image有無でのimages）
- 実装前レッド → 実装後グリーン

## 検証

- `pnpm lint:check` ✅
- `pnpm test` ✅（679テスト全通過）
- `pnpm build` ✅（`/work/[slug]`・`/ja/work/[slug]` SSG生成成功）

> 注: `metadata.ts` を触る #metadata-description PR とマージ時に軽微な競合の可能性あり。後勝ちブランチをリベースで解消します。

https://claude.ai/code/session_01BYtdQhtvugEJdzASEQnEA2

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYtdQhtvugEJdzASEQnEA2)_