### PR TITLE
fix: sitemapからリダイレクト対象/重複URLを除外しSEOシグナル分散を解消

### DIFF
--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SITE_CONFIG } from '@/config'
+import { createRedirectRules } from '@/libs/middleware/redirectRules'
+
+// 外部データ取得をモック化し、静的ルートとプロジェクトパス生成の検証に集中する
+vi.mock('@/libs/dataSources/thoughts', () => ({
+  loadAllThoughts: vi.fn().mockResolvedValue([]),
+}))
+vi.mock('@/libs/dataSources/products', () => ({
+  loadAllProducts: vi.fn().mockResolvedValue([]),
+}))
+vi.mock('@/libs/dataSources/devnotes', () => ({
+  loadAllDevNotes: vi.fn().mockResolvedValue([]),
+}))
+vi.mock('@/libs/microCMS/client', () => ({
+  createMicroCMSClient: vi.fn().mockReturnValue({}),
+}))
+vi.mock('@/libs/microCMS/apis', () => ({
+  MicroCMSAPI: class {
+    listAllProjects() {
+      return Promise.resolve([{ id: 'sample-project', updatedAt: '2025-01-01T00:00:00.000Z' }])
+    }
+  },
+}))
+
+import sitemap from './sitemap'
+
+describe('sitemap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('リダイレクト対象のレガシーURLを含まない', async () => {
+    const entries = await sitemap()
+    const pathnames = entries.map((entry) => entry.url.replace(SITE_CONFIG.url, ''))
+
+    const forbidden = ['/articles', '/oss', '/projects', '/ja/articles', '/ja/oss', '/ja/projects']
+    for (const path of forbidden) {
+      expect(pathnames).not.toContain(path)
+      // 配下のパス（例: /projects/xxx）も含まないこと
+      expect(pathnames.some((p) => p === path || p.startsWith(`${path}/`))).toBe(false)
+    }
+  })
+
+  it('sitemapが返す全URLがどのリダイレクトルールにもマッチしない', async () => {
+    const entries = await sitemap()
+    const rules = createRedirectRules()
+
+    const matched = entries
+      .map((entry) => entry.url.replace(SITE_CONFIG.url, ''))
+      .filter((pathname) => rules.some((rule) => rule.shouldRedirect(pathname)))
+
+    expect(matched).toEqual([])
+  })
+
+  it('リダイレクトされない正規の静的URLは維持する', async () => {
+    const entries = await sitemap()
+    const pathnames = entries.map((entry) => entry.url.replace(SITE_CONFIG.url, ''))
+
+    const expected = [
+      '',
+      '/about',
+      '/blog',
+      '/news',
+      '/speaking',
+      '/work',
+      '/writing',
+      '/ja',
+      '/ja/about',
+      '/ja/blog',
+      '/ja/news',
+      '/ja/speaking',
+      '/ja/work',
+      '/ja/writing',
+    ]
+    for (const path of expected) {
+      expect(pathnames).toContain(path)
+    }
+  })
+
+  it('プロジェクトページは /work と /ja/work のみに生成される', async () => {
+    const entries = await sitemap()
+    const pathnames = entries.map((entry) => entry.url.replace(SITE_CONFIG.url, ''))
+
+    expect(pathnames).toContain('/work/sample-project')
+    expect(pathnames).toContain('/ja/work/sample-project')
+    expect(pathnames).not.toContain('/projects/sample-project')
+    expect(pathnames).not.toContain('/ja/projects/sample-project')
+  })
+})

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -36,28 +36,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const microCMS = new MicroCMSAPI(createMicroCMSClient())
 
   // 静的ページ（英語版）
-  const staticRoutes = [
-    '',
-    '/about',
-    '/articles',
-    '/blog',
-    '/news',
-    '/oss',
-    '/projects',
-    '/speaking',
-    '/work',
-    '/writing',
-  ]
+  // /articles, /oss, /projects は middleware でリダイレクトされるため除外
+  const staticRoutes = ['', '/about', '/blog', '/news', '/speaking', '/work', '/writing']
 
   // 静的ページ（日本語版）
+  // /ja/articles, /ja/oss, /ja/projects は middleware でリダイレクトされるため除外
   const jaStaticRoutes = [
     '/ja',
     '/ja/about',
-    '/ja/articles',
     '/ja/blog',
     '/ja/news',
-    '/ja/oss',
-    '/ja/projects',
     '/ja/speaking',
     '/ja/work',
     '/ja/writing',
@@ -100,13 +88,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const projects = await microCMS.listAllProjects()
     projectPages = projects.flatMap((project) => {
       const lastModified = project.updatedAt ? new Date(project.updatedAt) : undefined
-      return createEntriesForPaths(
-        ['/projects', '/ja/projects', '/work', '/ja/work'],
-        project.id,
-        lastModified,
-        'monthly',
-        0.7,
-      )
+      // /projects, /ja/projects は /work系へリダイレクトされる重複のため除外
+      return createEntriesForPaths(['/work', '/ja/work'], project.id, lastModified, 'monthly', 0.7)
     })
   } catch (error) {
     logger.error('Failed to load projects for sitemap', {


### PR DESCRIPTION
## 背景（SEOレポート分析より）

`src/app/sitemap.ts` が、middleware（`createRedirectRules()`）で **リダイレクトされるレガシーURL** や **同一コンテンツの重複URL** を出力しており、SEOシグナル（リンク評価）が分散していた。`/projects`→`/work`、`/oss`→`/work`、`/articles`→`/writing` はリダイレクト対象であり、sitemapに載せるべきではない。

## 変更内容（`src/app/sitemap.ts` のみ）

除外したURL:
- 静的（英語）: `/articles`, `/oss`, `/projects`
- 静的（日本語）: `/ja/articles`, `/ja/oss`, `/ja/projects`
- プロジェクト動的: `createEntriesForPaths` のベースパスを `['/projects', '/ja/projects', '/work', '/ja/work']` → **`['/work', '/ja/work']`** に変更（`/projects/{id}`・`/ja/projects/{id}` の重複を除外）

維持: blog / news（`/news`, `/ja/news`）/ dev-notes / `/about` / `/blog` / `/speaking` / `/work` / `/writing` 等の正規URL。

## テスト（TDD）

`src/app/sitemap.test.ts` を新規作成（外部データソースは `vi.mock`、4ケース）:
1. リダイレクト対象のレガシーURLを含まない
2. **`createRedirectRules()` を import し、sitemapの全URLがどのリダイレクトルールにもマッチしない**（リグレッション防止に堅牢）
3. リダイレクトされない正規の静的URLが維持される
4. プロジェクトページが `/work`・`/ja/work` のみに生成される

実装前は 3/4 レッド → 実装後 4/4 グリーン。

## 検証

- `pnpm lint:check` ✅
- `pnpm test` ✅（674テスト全通過）
- `pnpm build` ✅（`/sitemap.xml` 正常生成）

https://claude.ai/code/session_01BYtdQhtvugEJdzASEQnEA2

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYtdQhtvugEJdzASEQnEA2)_