### PR TITLE
fix: ダークモード表示崩れとメタデータの即効バグを修正(フェーズ1)

### DIFF
--- a/public/favicons/browserconfig.xml
+++ b/public/favicons/browserconfig.xml
@@ -2,8 +2,8 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/mstile-150x150.png"/>
-            <TileColor>#da532c</TileColor>
+            <square150x150logo src="/favicons/mstile-150x150.png"/>
+            <TileColor>#4f46e5</TileColor>
         </tile>
     </msapplication>
 </browserconfig>

--- a/public/favicons/site.webmanifest
+++ b/public/favicons/site.webmanifest
@@ -1,19 +1,19 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Hidetaka.dev",
+    "short_name": "Hidetaka",
     "icons": [
         {
-            "src": "/android-chrome-192x192.png",
+            "src": "/favicons/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-512x512.png",
+            "src": "/favicons/android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
+    "theme_color": "#4f46e5",
     "background_color": "#ffffff",
     "display": "standalone"
 }

--- a/src/app/ja/projects/[slug]/page.tsx
+++ b/src/app/ja/projects/[slug]/page.tsx
@@ -149,7 +149,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50 dark:focus:ring-offset-zinc-900"
                 >
                   Visit application
                 </a>

--- a/src/app/ja/projects/[slug]/page.tsx
+++ b/src/app/ja/projects/[slug]/page.tsx
@@ -24,7 +24,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
 
   return (
     <Container className="mt-8 sm:mt-16">
-      <div className="bg-white">
+      <div className="bg-white dark:bg-zinc-900">
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:grid lg:max-w-7xl lg:grid-cols-2 lg:gap-x-8 lg:px-8">
           <div className="lg:max-w-lg lg:self-end">
             <nav aria-label="Breadcrumb">
@@ -33,7 +33,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   <div className="flex items-center text-sm">
                     <a
                       href="/ja/projects"
-                      className="font-medium text-gray-500 hover:text-gray-900"
+                      className="font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"
                     >
                       Projects
                     </a>
@@ -41,7 +41,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                       viewBox="0 0 20 20"
                       fill="currentColor"
                       aria-hidden="true"
-                      className="ml-2 size-5 shrink-0 text-gray-300"
+                      className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                     >
                       <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                     </svg>
@@ -50,12 +50,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 {project.project_type.map((type) => (
                   <li key={type}>
                     <div className="flex items-center text-sm">
-                      <span className="font-medium text-gray-500">{type}</span>
+                      <span className="font-medium text-zinc-500 dark:text-zinc-400">{type}</span>
                       <svg
                         viewBox="0 0 20 20"
                         fill="currentColor"
                         aria-hidden="true"
-                        className="ml-2 size-5 shrink-0 text-gray-300"
+                        className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                       >
                         <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                       </svg>
@@ -65,7 +65,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </ol>
             </nav>
             <div className="mt-4">
-              <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+              <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-4xl">
                 {project.title}
               </h1>
             </div>
@@ -74,12 +74,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 Product information
               </h2>
               <div className="flex items-center">
-                <p className="text-lg text-gray-900 sm:text-xl">Free to use</p>
+                <p className="text-lg text-zinc-900 dark:text-white sm:text-xl">Free to use</p>
                 {project.published_at && (
-                  <div className="ml-4 border-l border-gray-300 pl-4">
+                  <div className="ml-4 border-l border-zinc-300 dark:border-zinc-600 pl-4">
                     <h2 className="sr-only">Release date</h2>
                     <div className="flex items-center">
-                      <p className="ml-2 text-sm text-gray-500">
+                      <p className="ml-2 text-sm text-zinc-500 dark:text-zinc-400">
                         Released at{' '}
                         {new Date(project.published_at).toLocaleDateString('ja-JP', {
                           day: 'numeric',
@@ -94,7 +94,9 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </div>
               {project.about && (
                 <div className="mt-4 space-y-6">
-                  <p className="text-base text-gray-500">{project.about.replace(/<[^>]*>/g, '')}</p>
+                  <p className="text-base text-zinc-500 dark:text-zinc-400">
+                    {project.about.replace(/<[^>]*>/g, '')}
+                  </p>
                 </div>
               )}
             </section>
@@ -129,7 +131,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </h2>
               <div className="mt-8">
                 <div className="flex items-center justify-between">
-                  <h2 className="text-sm font-medium text-gray-900">tools</h2>
+                  <h2 className="text-sm font-medium text-zinc-900 dark:text-white">tools</h2>
                 </div>
                 <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
                   {project.tags.map((tag) => (
@@ -147,7 +149,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
                 >
                   Visit application
                 </a>
@@ -158,10 +160,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       </div>
       {project.background && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Background
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:
@@ -174,10 +177,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       )}
       {project.architecture && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Architecture
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:

--- a/src/app/ja/test-sentry/page.tsx
+++ b/src/app/ja/test-sentry/page.tsx
@@ -5,13 +5,18 @@
  * 開発モードでのみアクセス可能です。
  */
 
+import type { Metadata } from 'next'
 import SentryTestClient from '@/components/sentry/SentryTestClient.ja'
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
 
 export default async function TestSentryPage() {
   // 開発モードかどうかを確認
   if (process.env.NODE_ENV !== 'development') {
     return (
-      <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="flex min-h-dvh items-center justify-center px-4">
         <div className="text-center max-w-md">
           <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-4">
             本番環境では利用できません

--- a/src/app/ja/work/[slug]/page.tsx
+++ b/src/app/ja/work/[slug]/page.tsx
@@ -169,7 +169,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50 dark:focus:ring-offset-zinc-900"
                 >
                   Visit application
                 </a>

--- a/src/app/ja/work/[slug]/page.tsx
+++ b/src/app/ja/work/[slug]/page.tsx
@@ -44,21 +44,24 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
 
   return (
     <Container className="mt-8 sm:mt-16">
-      <div className="bg-white">
+      <div className="bg-white dark:bg-zinc-900">
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:grid lg:max-w-7xl lg:grid-cols-2 lg:gap-x-8 lg:px-8">
           <div className="lg:max-w-lg lg:self-end">
             <nav aria-label="Breadcrumb">
               <ol className="flex items-center space-x-2">
                 <li>
                   <div className="flex items-center text-sm">
-                    <a href="/ja/work" className="font-medium text-gray-500 hover:text-gray-900">
+                    <a
+                      href="/ja/work"
+                      className="font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"
+                    >
                       Work
                     </a>
                     <svg
                       viewBox="0 0 20 20"
                       fill="currentColor"
                       aria-hidden="true"
-                      className="ml-2 size-5 shrink-0 text-gray-300"
+                      className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                     >
                       <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                     </svg>
@@ -67,12 +70,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 {project.project_type.map((type) => (
                   <li key={type}>
                     <div className="flex items-center text-sm">
-                      <span className="font-medium text-gray-500">{type}</span>
+                      <span className="font-medium text-zinc-500 dark:text-zinc-400">{type}</span>
                       <svg
                         viewBox="0 0 20 20"
                         fill="currentColor"
                         aria-hidden="true"
-                        className="ml-2 size-5 shrink-0 text-gray-300"
+                        className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                       >
                         <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                       </svg>
@@ -82,7 +85,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </ol>
             </nav>
             <div className="mt-4">
-              <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+              <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-4xl">
                 {project.title}
               </h1>
             </div>
@@ -91,12 +94,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 Product information
               </h2>
               <div className="flex items-center">
-                <p className="text-lg text-gray-900 sm:text-xl">Free to use</p>
+                <p className="text-lg text-zinc-900 dark:text-white sm:text-xl">Free to use</p>
                 {project.published_at && (
-                  <div className="ml-4 border-l border-gray-300 pl-4">
+                  <div className="ml-4 border-l border-zinc-300 dark:border-zinc-600 pl-4">
                     <h2 className="sr-only">Release date</h2>
                     <div className="flex items-center">
-                      <p className="ml-2 text-sm text-gray-500">
+                      <p className="ml-2 text-sm text-zinc-500 dark:text-zinc-400">
                         Released at{' '}
                         {new Date(project.published_at).toLocaleDateString('ja-JP', {
                           day: 'numeric',
@@ -111,7 +114,9 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </div>
               {project.about && (
                 <div className="mt-4 space-y-6">
-                  <p className="text-base text-gray-500">{project.about.replace(/<[^>]*>/g, '')}</p>
+                  <p className="text-base text-zinc-500 dark:text-zinc-400">
+                    {project.about.replace(/<[^>]*>/g, '')}
+                  </p>
                 </div>
               )}
             </section>
@@ -146,7 +151,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </h2>
               <div className="mt-8">
                 <div className="flex items-center justify-between">
-                  <h2 className="text-sm font-medium text-gray-900">tools</h2>
+                  <h2 className="text-sm font-medium text-zinc-900 dark:text-white">tools</h2>
                 </div>
                 <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
                   {project.tags.map((tag) => (
@@ -164,7 +169,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
                 >
                   Visit application
                 </a>
@@ -175,10 +180,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       </div>
       {project.background && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Background
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:
@@ -191,10 +197,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       )}
       {project.architecture && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Architecture
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,7 +53,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <JsonLd data={generatePersonJsonLd()} />
       </head>
       <body className="flex h-full flex-col bg-zinc-50 dark:bg-black">
-        <JsonLd data={generatePersonJsonLd()} />
         <SentryProvider>
           <GoogleAnalytics gaId="G-RV8PYHHYHN" />
           <DarkModeScript />

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -149,7 +149,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50 dark:focus:ring-offset-zinc-900"
                 >
                   Visit application
                 </a>

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -24,21 +24,24 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
 
   return (
     <Container className="mt-8 sm:mt-16">
-      <div className="bg-white">
+      <div className="bg-white dark:bg-zinc-900">
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:grid lg:max-w-7xl lg:grid-cols-2 lg:gap-x-8 lg:px-8">
           <div className="lg:max-w-lg lg:self-end">
             <nav aria-label="Breadcrumb">
               <ol className="flex items-center space-x-2">
                 <li>
                   <div className="flex items-center text-sm">
-                    <a href="/projects" className="font-medium text-gray-500 hover:text-gray-900">
+                    <a
+                      href="/projects"
+                      className="font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"
+                    >
                       Projects
                     </a>
                     <svg
                       viewBox="0 0 20 20"
                       fill="currentColor"
                       aria-hidden="true"
-                      className="ml-2 size-5 shrink-0 text-gray-300"
+                      className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                     >
                       <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                     </svg>
@@ -47,12 +50,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 {project.project_type.map((type) => (
                   <li key={type}>
                     <div className="flex items-center text-sm">
-                      <span className="font-medium text-gray-500">{type}</span>
+                      <span className="font-medium text-zinc-500 dark:text-zinc-400">{type}</span>
                       <svg
                         viewBox="0 0 20 20"
                         fill="currentColor"
                         aria-hidden="true"
-                        className="ml-2 size-5 shrink-0 text-gray-300"
+                        className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                       >
                         <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                       </svg>
@@ -62,7 +65,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </ol>
             </nav>
             <div className="mt-4">
-              <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+              <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-4xl">
                 {project.title}
               </h1>
             </div>
@@ -71,12 +74,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 Product information
               </h2>
               <div className="flex items-center">
-                <p className="text-lg text-gray-900 sm:text-xl">Free to use</p>
+                <p className="text-lg text-zinc-900 dark:text-white sm:text-xl">Free to use</p>
                 {project.published_at && (
-                  <div className="ml-4 border-l border-gray-300 pl-4">
+                  <div className="ml-4 border-l border-zinc-300 dark:border-zinc-600 pl-4">
                     <h2 className="sr-only">Release date</h2>
                     <div className="flex items-center">
-                      <p className="ml-2 text-sm text-gray-500">
+                      <p className="ml-2 text-sm text-zinc-500 dark:text-zinc-400">
                         Released at{' '}
                         {new Date(project.published_at).toLocaleDateString('en-US', {
                           day: 'numeric',
@@ -91,7 +94,9 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </div>
               {project.about && (
                 <div className="mt-4 space-y-6">
-                  <p className="text-base text-gray-500">{project.about.replace(/<[^>]*>/g, '')}</p>
+                  <p className="text-base text-zinc-500 dark:text-zinc-400">
+                    {project.about.replace(/<[^>]*>/g, '')}
+                  </p>
                 </div>
               )}
             </section>
@@ -126,7 +131,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </h2>
               <div className="mt-8">
                 <div className="flex items-center justify-between">
-                  <h2 className="text-sm font-medium text-gray-900">tools</h2>
+                  <h2 className="text-sm font-medium text-zinc-900 dark:text-white">tools</h2>
                 </div>
                 <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
                   {project.tags.map((tag) => (
@@ -144,7 +149,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
                 >
                   Visit application
                 </a>
@@ -155,10 +160,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       </div>
       {project.background && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Background
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:
@@ -171,10 +177,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       )}
       {project.architecture && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Architecture
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
-      disallow: '/private/',
+      disallow: ['/private/', '/sentry-test', '/test-sentry'],
     },
     sitemap: `${SITE_CONFIG.url}/sitemap.xml`,
   }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
-      disallow: ['/private/', '/sentry-test', '/test-sentry'],
+      disallow: ['/private/', '/sentry-test', '/test-sentry', '/ja/test-sentry'],
     },
     sitemap: `${SITE_CONFIG.url}/sitemap.xml`,
   }

--- a/src/app/sentry-test/layout.tsx
+++ b/src/app/sentry-test/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
+
+export default function SentryTestLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/src/app/test-sentry/page.tsx
+++ b/src/app/test-sentry/page.tsx
@@ -5,13 +5,18 @@
  * Only accessible in development mode.
  */
 
+import type { Metadata } from 'next'
 import SentryTestClient from '@/components/sentry/SentryTestClient'
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
 
 export default async function TestSentryPage() {
   // Check if we're in development mode
   if (process.env.NODE_ENV !== 'development') {
     return (
-      <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="flex min-h-dvh items-center justify-center px-4">
         <div className="text-center max-w-md">
           <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-4">
             Not Available in Production

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -169,7 +169,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50 dark:focus:ring-offset-zinc-900"
                 >
                   Visit application
                 </a>

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -44,21 +44,24 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
 
   return (
     <Container className="mt-8 sm:mt-16">
-      <div className="bg-white">
+      <div className="bg-white dark:bg-zinc-900">
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:grid lg:max-w-7xl lg:grid-cols-2 lg:gap-x-8 lg:px-8">
           <div className="lg:max-w-lg lg:self-end">
             <nav aria-label="Breadcrumb">
               <ol className="flex items-center space-x-2">
                 <li>
                   <div className="flex items-center text-sm">
-                    <a href="/work" className="font-medium text-gray-500 hover:text-gray-900">
+                    <a
+                      href="/work"
+                      className="font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"
+                    >
                       Work
                     </a>
                     <svg
                       viewBox="0 0 20 20"
                       fill="currentColor"
                       aria-hidden="true"
-                      className="ml-2 size-5 shrink-0 text-gray-300"
+                      className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                     >
                       <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                     </svg>
@@ -67,12 +70,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 {project.project_type.map((type) => (
                   <li key={type}>
                     <div className="flex items-center text-sm">
-                      <span className="font-medium text-gray-500">{type}</span>
+                      <span className="font-medium text-zinc-500 dark:text-zinc-400">{type}</span>
                       <svg
                         viewBox="0 0 20 20"
                         fill="currentColor"
                         aria-hidden="true"
-                        className="ml-2 size-5 shrink-0 text-gray-300"
+                        className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                       >
                         <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                       </svg>
@@ -82,7 +85,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </ol>
             </nav>
             <div className="mt-4">
-              <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+              <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-4xl">
                 {project.title}
               </h1>
             </div>
@@ -91,12 +94,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 Product information
               </h2>
               <div className="flex items-center">
-                <p className="text-lg text-gray-900 sm:text-xl">Free to use</p>
+                <p className="text-lg text-zinc-900 dark:text-white sm:text-xl">Free to use</p>
                 {project.published_at && (
-                  <div className="ml-4 border-l border-gray-300 pl-4">
+                  <div className="ml-4 border-l border-zinc-300 dark:border-zinc-600 pl-4">
                     <h2 className="sr-only">Release date</h2>
                     <div className="flex items-center">
-                      <p className="ml-2 text-sm text-gray-500">
+                      <p className="ml-2 text-sm text-zinc-500 dark:text-zinc-400">
                         Released at{' '}
                         {new Date(project.published_at).toLocaleDateString('en-US', {
                           day: 'numeric',
@@ -111,7 +114,9 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </div>
               {project.about && (
                 <div className="mt-4 space-y-6">
-                  <p className="text-base text-gray-500">{project.about.replace(/<[^>]*>/g, '')}</p>
+                  <p className="text-base text-zinc-500 dark:text-zinc-400">
+                    {project.about.replace(/<[^>]*>/g, '')}
+                  </p>
                 </div>
               )}
             </section>
@@ -146,7 +151,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </h2>
               <div className="mt-8">
                 <div className="flex items-center justify-between">
-                  <h2 className="text-sm font-medium text-gray-900">tools</h2>
+                  <h2 className="text-sm font-medium text-zinc-900 dark:text-white">tools</h2>
                 </div>
                 <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
                   {project.tags.map((tag) => (
@@ -164,7 +169,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
                 >
                   Visit application
                 </a>
@@ -175,10 +180,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       </div>
       {project.background && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Background
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:
@@ -191,10 +197,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       )}
       {project.architecture && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Architecture
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:

--- a/src/components/sentry/SentryTestClient.ja.tsx
+++ b/src/components/sentry/SentryTestClient.ja.tsx
@@ -103,7 +103,7 @@ export default function SentryTestClient() {
   }
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black py-12 px-4">
+    <div className="min-h-dvh bg-zinc-50 dark:bg-black py-12 px-4">
       <div className="max-w-4xl mx-auto">
         <div className="bg-white dark:bg-zinc-900 rounded-lg shadow-lg p-8">
           <h1 className="text-4xl font-bold text-slate-900 dark:text-white mb-4">

--- a/src/components/sentry/SentryTestClient.tsx
+++ b/src/components/sentry/SentryTestClient.tsx
@@ -97,7 +97,7 @@ export default function SentryTestClient() {
   }
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black py-12 px-4">
+    <div className="min-h-dvh bg-zinc-50 dark:bg-black py-12 px-4">
       <div className="max-w-4xl mx-auto">
         <div className="bg-white dark:bg-zinc-900 rounded-lg shadow-lg p-8">
           <h1 className="text-4xl font-bold text-slate-900 dark:text-white mb-4">

--- a/src/components/ui/ErrorUI.tsx
+++ b/src/components/ui/ErrorUI.tsx
@@ -22,7 +22,7 @@ export default function ErrorUI({
   return (
     <main
       className={cn(
-        'flex min-h-screen items-center justify-center px-4 bg-zinc-50 dark:bg-black',
+        'flex min-h-dvh items-center justify-center px-4 bg-zinc-50 dark:bg-black',
         className,
       )}
       role="alert"


### PR DESCRIPTION
デザイン・UIスキル8観点での並列レビューで検出した即効性の高いバグ修正です(フェーズ1/3)。

## 変更内容

- **Person JSON-LDの二重出力を削除**: `src/app/layout.tsx` で head/body 両方にレンダリングされていた重複を解消
- **ダークモード不可視バグ修正**: `work/[slug]`・`projects/[slug]` 詳細ページ(日英4ファイル)で `dark:` バリアントが欠落し、Background/Architecture 見出しと本文がダーク背景で不可視だった問題を修正(gray→zinc 統一含む)
- **site.webmanifest 修正**: 空だった `name`/`short_name` を設定、icon の 404 パスを `/favicons/` 配下に修正、`theme_color` をブランド色 `#4f46e5` に
- **browserconfig.xml 修正**: デフォルトの `#da532c` をブランド色に、mstile パス修正
- **`min-h-screen` → `min-h-dvh`**(5箇所): モバイルブラウザのURLバー表示時のレイアウトずれ対策
- **テストページの noindex**: `/sentry-test`・`/test-sentry` 系に `robots: { index: false }` を追加し、`robots.ts` の disallow にも追加

## 検証

- ✅ `pnpm lint:check` / `pnpm test` / `pnpm build` すべて合格

関連: フェーズ2(SEO基盤)・フェーズ3(a11y基盤)のPRと独立してマージ可能です。

https://claude.ai/code/session_016RMVPFpo2HeNJ7bDhBmwFK

---
_Generated by [Claude Code](https://claude.ai/code/session_016RMVPFpo2HeNJ7bDhBmwFK)_