### PR TITLE
feat: canonical/hreflangとtitleテンプレートを導入しSEO基盤を整備(フェーズ2)

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,7 +1,9 @@
 import AboutPageContent from '@/components/containers/pages/AboutPage'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
-  title: 'About Hidetaka Okamoto',
+  alternates: buildAlternates('/about'),
+  title: 'About',
 }
 
 export default function AboutPage() {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     }
   }
 
-  return generateBlogPostMetadata(thought)
+  return generateBlogPostMetadata(thought, `/blog/${slug}`)
 }
 
 export default async function BlogDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,8 +3,10 @@ import BlogPageContent from '@/components/containers/pages/BlogPage'
 import JsonLd from '@/components/JsonLd'
 import { loadAllCategories, loadThoughts } from '@/libs/dataSources/thoughts'
 import { generateBlogListJsonLd } from '@/libs/jsonLd'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
+  alternates: buildAlternates('/blog'),
   title: 'Blog',
 }
 

--- a/src/app/ja/about/page.tsx
+++ b/src/app/ja/about/page.tsx
@@ -1,7 +1,9 @@
 import AboutPageContent from '@/components/containers/pages/AboutPage'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
-  title: 'About Hidetaka Okamoto',
+  alternates: buildAlternates('/ja/about'),
+  title: 'About',
 }
 
 export default function AboutPage() {

--- a/src/app/ja/blog/[slug]/page.tsx
+++ b/src/app/ja/blog/[slug]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     }
   }
 
-  return generateBlogPostMetadata(thought)
+  return generateBlogPostMetadata(thought, `/ja/blog/${slug}`)
 }
 
 export default async function BlogDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/ja/blog/page.tsx
+++ b/src/app/ja/blog/page.tsx
@@ -3,8 +3,10 @@ import BlogPageContent from '@/components/containers/pages/BlogPage'
 import JsonLd from '@/components/JsonLd'
 import { loadAllCategories, loadThoughts } from '@/libs/dataSources/thoughts'
 import { generateBlogListJsonLd } from '@/libs/jsonLd'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
+  alternates: buildAlternates('/ja/blog'),
   title: 'ブログ',
 }
 

--- a/src/app/ja/events/[slug]/page.tsx
+++ b/src/app/ja/events/[slug]/page.tsx
@@ -37,7 +37,10 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   // WPEventをWPThought形式に変換してメタデータを生成
   const thought = eventToThought(event)
 
-  return generateBlogPostMetadata(thought)
+  // イベントページは日本語版のみ存在するため、hreflangは日本語のみ出力する
+  return generateBlogPostMetadata(thought, `/ja/events/${slug}`, {
+    availableLanguages: ['ja'],
+  })
 }
 
 export default async function EventDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/ja/layout.tsx
+++ b/src/app/ja/layout.tsx
@@ -2,7 +2,10 @@ import type { Metadata } from 'next'
 import { SITE_DESCRIPTION_JA, SITE_TITLE_JA } from '@/consts'
 
 export const metadata: Metadata = {
-  title: SITE_TITLE_JA,
+  title: {
+    default: SITE_TITLE_JA,
+    template: '%s | 岡本 秀高',
+  },
   description: SITE_DESCRIPTION_JA,
   metadataBase: new URL('https://hidetaka.dev'),
   openGraph: {

--- a/src/app/ja/news/[slug]/page.tsx
+++ b/src/app/ja/news/[slug]/page.tsx
@@ -50,7 +50,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   // WPProductをWPThought形式に変換してメタデータを生成
   const thought = productToThought(product)
 
-  return generateBlogPostMetadata(thought)
+  return generateBlogPostMetadata(thought, `/ja/news/${slug}`)
 }
 
 export default async function NewsDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/ja/news/page.tsx
+++ b/src/app/ja/news/page.tsx
@@ -1,7 +1,9 @@
 import NewsPageContent from '@/components/containers/pages/NewsPage'
 import { loadProducts } from '@/libs/dataSources/products'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
+  alternates: buildAlternates('/ja/news'),
   title: 'News',
 }
 

--- a/src/app/ja/page.tsx
+++ b/src/app/ja/page.tsx
@@ -1,7 +1,13 @@
+import type { Metadata } from 'next'
 import FeaturedContent from '@/components/containers/FeaturedContent'
 import Hero from '@/components/Hero/Hero'
 import Capabilities from '@/components/home/Capabilities'
 import StackShowcase from '@/components/home/StackShowcase'
+import { buildAlternates } from '@/libs/metadata'
+
+export const metadata: Metadata = {
+  alternates: buildAlternates('/ja'),
+}
 
 export default async function HomePage() {
   const lang = 'ja'

--- a/src/app/ja/speaking/page.tsx
+++ b/src/app/ja/speaking/page.tsx
@@ -1,7 +1,9 @@
 import SpeakingPageContent from '@/components/containers/pages/SpeakingPage'
 import { loadWPEvents } from '@/libs/dataSources/events'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
+  alternates: buildAlternates('/ja/speaking'),
   title: '登壇・講演',
 }
 

--- a/src/app/ja/work/[slug]/page.tsx
+++ b/src/app/ja/work/[slug]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({
     .then((projects) => projects.find((p) => p.id === slug))
 
   if (!project) {
-    return { title: 'Work | Hidetaka.dev' }
+    return { title: 'Work' }
   }
 
   return generateProjectMetadata(project, 'ja')

--- a/src/app/ja/work/page.tsx
+++ b/src/app/ja/work/page.tsx
@@ -1,10 +1,12 @@
 import WorkPageContent from '@/components/containers/pages/WorkPage'
 import { listMyNPMPackages } from '@/libs/dataSources/npmjs'
 import { listMyWordPressPlugins } from '@/libs/dataSources/wporg'
+import { buildAlternates } from '@/libs/metadata'
 import { MicroCMSAPI } from '@/libs/microCMS/apis'
 import { createMicroCMSClient } from '@/libs/microCMS/client'
 
 export const metadata = {
+  alternates: buildAlternates('/ja/work'),
   title: 'Work',
 }
 

--- a/src/app/ja/writing/dev-notes/[slug]/page.tsx
+++ b/src/app/ja/writing/dev-notes/[slug]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     }
   }
 
-  return generateDevNoteMetadata(note)
+  return generateDevNoteMetadata(note, `/ja/writing/dev-notes/${slug}`)
 }
 
 export default async function DevNoteDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/ja/writing/dev-notes/page.tsx
+++ b/src/app/ja/writing/dev-notes/page.tsx
@@ -3,19 +3,22 @@ import DevNotesArchivePage from '@/components/containers/pages/DevNotesArchivePa
 import JsonLd from '@/components/JsonLd'
 import { loadDevNotes } from '@/libs/dataSources/devnotes'
 import { generateBlogListJsonLd } from '@/libs/jsonLd'
+import { buildAlternates } from '@/libs/metadata'
 
-const title = '開発メモ | Hidetaka.dev'
+const title = '開発メモ'
 const description = '日々の開発で気づいたことや学んだことを記録しています。'
 
 export const metadata: Metadata = {
   title,
   description,
+  alternates: buildAlternates('/ja/writing/dev-notes'),
   openGraph: {
     title,
     description,
     type: 'website',
     url: 'https://hidetaka.dev/ja/writing/dev-notes',
     siteName: 'Hidetaka.dev',
+    locale: 'ja_JP',
   },
   twitter: {
     card: 'summary_large_image',

--- a/src/app/ja/writing/page.tsx
+++ b/src/app/ja/writing/page.tsx
@@ -1,9 +1,11 @@
 import WritingPageContent from '@/components/containers/pages/WritingPage'
 import StatsSection from '@/components/ui/stats/StatsSection'
 import { loadBlogPosts } from '@/libs/dataSources/blogs'
+import { buildAlternates } from '@/libs/metadata'
 import { loadStatsPosts } from '@/libs/stats/loadStatsPosts'
 
 export const metadata = {
+  alternates: buildAlternates('/ja/writing'),
   title: 'Writing',
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,10 @@ import Header from '@/components/tailwindui/Header'
 import { generatePersonJsonLd } from '@/libs/jsonLd'
 
 export const metadata: Metadata = {
-  title: SITE_TITLE,
+  title: {
+    default: SITE_TITLE,
+    template: '%s | Hidetaka Okamoto',
+  },
   description: SITE_DESCRIPTION,
   metadataBase: new URL('https://hidetaka.dev'),
   openGraph: {

--- a/src/app/news/[slug]/page.tsx
+++ b/src/app/news/[slug]/page.tsx
@@ -50,7 +50,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   // WPProductをWPThought形式に変換してメタデータを生成
   const thought = productToThought(product)
 
-  return generateBlogPostMetadata(thought)
+  return generateBlogPostMetadata(thought, `/news/${slug}`)
 }
 
 export default async function NewsDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,7 +1,9 @@
 import NewsPageContent from '@/components/containers/pages/NewsPage'
 import { loadProducts } from '@/libs/dataSources/products'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
+  alternates: buildAlternates('/news'),
   title: 'News',
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,13 @@
+import type { Metadata } from 'next'
 import FeaturedContent from '@/components/containers/FeaturedContent'
 import Hero from '@/components/Hero/Hero'
 import Capabilities from '@/components/home/Capabilities'
 import StackShowcase from '@/components/home/StackShowcase'
+import { buildAlternates } from '@/libs/metadata'
+
+export const metadata: Metadata = {
+  alternates: buildAlternates('/'),
+}
 
 export default async function HomePage() {
   const lang = 'en'

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -117,26 +117,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     })
   }
 
-  // Dev Notes（WordPress API、日本語版と英語版）
+  // Dev Notes（WordPress API）
+  // en/jaで同一コンテンツを返すため、canonicalである日本語版URLのみ登録する
+  // （英語版URLはhreflang/canonicalで日本語版へ正規化される）
   let devNotesPages: MetadataRoute.Sitemap = []
   try {
-    const [allDevNotesJa, allDevNotesEn] = await Promise.all([
-      loadAllDevNotes('ja'),
-      loadAllDevNotes('en'),
-    ])
-    const jaPages = allDevNotesJa.map((item) => ({
+    const allDevNotesJa = await loadAllDevNotes('ja')
+    devNotesPages = allDevNotesJa.map((item) => ({
       url: `${SITE_CONFIG.url}${item.href}`,
       lastModified: new Date(item.datetime),
       changeFrequency: 'monthly' as const,
       priority: 0.7,
     }))
-    const enPages = allDevNotesEn.map((item) => ({
-      url: `${SITE_CONFIG.url}${item.href}`,
-      lastModified: new Date(item.datetime),
-      changeFrequency: 'monthly' as const,
-      priority: 0.7,
-    }))
-    devNotesPages = [...jaPages, ...enPages]
   } catch (error) {
     logger.error('Failed to load dev-notes for sitemap', {
       error,

--- a/src/app/speaking/page.tsx
+++ b/src/app/speaking/page.tsx
@@ -1,7 +1,9 @@
 import SpeakingPageContent from '@/components/containers/pages/SpeakingPage'
 import { loadWPEvents } from '@/libs/dataSources/events'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
+  alternates: buildAlternates('/speaking'),
   title: 'Speaking',
 }
 

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({
     .then((projects) => projects.find((p) => p.id === slug))
 
   if (!project) {
-    return { title: 'Work | Hidetaka.dev' }
+    return { title: 'Work' }
   }
 
   return generateProjectMetadata(project, 'en')

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,10 +1,12 @@
 import WorkPageContent from '@/components/containers/pages/WorkPage'
 import { listMyNPMPackages } from '@/libs/dataSources/npmjs'
 import { listMyWordPressPlugins } from '@/libs/dataSources/wporg'
+import { buildAlternates } from '@/libs/metadata'
 import { MicroCMSAPI } from '@/libs/microCMS/apis'
 import { createMicroCMSClient } from '@/libs/microCMS/client'
 
 export const metadata = {
+  alternates: buildAlternates('/work'),
   title: 'Work',
 }
 

--- a/src/app/writing/dev-notes/[slug]/page.tsx
+++ b/src/app/writing/dev-notes/[slug]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     }
   }
 
-  return generateDevNoteMetadata(note)
+  return generateDevNoteMetadata(note, `/writing/dev-notes/${slug}`)
 }
 
 export default async function DevNoteDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/writing/dev-notes/page.tsx
+++ b/src/app/writing/dev-notes/page.tsx
@@ -3,20 +3,23 @@ import DevNotesArchivePage from '@/components/containers/pages/DevNotesArchivePa
 import JsonLd from '@/components/JsonLd'
 import { loadDevNotes } from '@/libs/dataSources/devnotes'
 import { generateBlogListJsonLd } from '@/libs/jsonLd'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata: Metadata = {
-  title: 'Development Notes | Hidetaka.dev',
+  title: 'Development Notes',
   description: 'A collection of notes and learnings from daily development work.',
+  alternates: buildAlternates('/writing/dev-notes'),
   openGraph: {
-    title: 'Development Notes | Hidetaka.dev',
+    title: 'Development Notes',
     description: 'A collection of notes and learnings from daily development work.',
     type: 'website',
     url: 'https://hidetaka.dev/writing/dev-notes',
     siteName: 'Hidetaka.dev',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Development Notes | Hidetaka.dev',
+    title: 'Development Notes',
     description: 'A collection of notes and learnings from daily development work.',
   },
 }

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -1,9 +1,11 @@
 import WritingPageContent from '@/components/containers/pages/WritingPage'
 import StatsSection from '@/components/ui/stats/StatsSection'
 import { loadBlogPosts } from '@/libs/dataSources/blogs'
+import { buildAlternates } from '@/libs/metadata'
 import { loadStatsPosts } from '@/libs/stats/loadStatsPosts'
 
 export const metadata = {
+  alternates: buildAlternates('/writing'),
   title: 'Writing',
 }
 

--- a/src/libs/metadata.test.ts
+++ b/src/libs/metadata.test.ts
@@ -109,7 +109,8 @@ describe('generateDevNoteMetadata', () => {
     )
   })
 
-  it('should use custom site URL from environment variable', () => {
+  it('should use SITE_CONFIG.url even when NEXT_PUBLIC_SITE_URL is set', () => {
+    // canonicalやog:urlはSITE_CONFIG.url基準のため、og:imageも同じ正本に揃える
     process.env.NEXT_PUBLIC_SITE_URL = 'https://custom.example.com'
 
     const note = createMockWPThought({
@@ -119,7 +120,7 @@ describe('generateDevNoteMetadata', () => {
     const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
     expect(result.openGraph?.images?.[0]?.url).toBe(
-      'https://custom.example.com/api/thumbnail/dev-notes/111',
+      'https://hidetaka.dev/api/thumbnail/dev-notes/111',
     )
   })
 
@@ -284,7 +285,8 @@ describe('generateBlogPostMetadata', () => {
     )
   })
 
-  it('should use custom site URL from environment variable', () => {
+  it('should use SITE_CONFIG.url even when NEXT_PUBLIC_SITE_URL is set', () => {
+    // canonicalやog:urlはSITE_CONFIG.url基準のため、og:imageも同じ正本に揃える
     process.env.NEXT_PUBLIC_SITE_URL = 'https://custom.example.com'
 
     const thought = createMockWPThought({
@@ -294,7 +296,7 @@ describe('generateBlogPostMetadata', () => {
     const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
     expect(result.openGraph?.images?.[0]?.url).toBe(
-      'https://custom.example.com/api/thumbnail/thoughts/111',
+      'https://hidetaka.dev/api/thumbnail/thoughts/111',
     )
   })
 

--- a/src/libs/metadata.test.ts
+++ b/src/libs/metadata.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { WPThought } from './dataSources/types'
 import {
+  buildAlternates,
   generateBlogPostMetadata,
   generateDevNoteMetadata,
   generateProjectMetadata,
+  getOpenGraphLocale,
 } from './metadata'
 import type { MicroCMSProjectsRecord } from './microCMS/types'
 
@@ -64,7 +66,7 @@ describe('generateDevNoteMetadata', () => {
       date: '2024-07-01T12:00:00',
     })
 
-    const result = generateDevNoteMetadata(note)
+    const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
     expect(result.title).toBe('Test Dev Note')
     expect(result.openGraph).toBeDefined()
@@ -81,7 +83,7 @@ describe('generateDevNoteMetadata', () => {
       id: 789,
     })
 
-    const result = generateDevNoteMetadata(note)
+    const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
     expect(result.openGraph?.images).toBeDefined()
     expect(result.openGraph?.images).toHaveLength(1)
@@ -100,7 +102,7 @@ describe('generateDevNoteMetadata', () => {
       id: 999,
     })
 
-    const result = generateDevNoteMetadata(note)
+    const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
     expect(result.openGraph?.images?.[0]?.url).toBe(
       'https://hidetaka.dev/api/thumbnail/dev-notes/999',
@@ -114,7 +116,7 @@ describe('generateDevNoteMetadata', () => {
       id: 111,
     })
 
-    const result = generateDevNoteMetadata(note)
+    const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
     expect(result.openGraph?.images?.[0]?.url).toBe(
       'https://custom.example.com/api/thumbnail/dev-notes/111',
@@ -126,7 +128,7 @@ describe('generateDevNoteMetadata', () => {
       title: { rendered: 'My Custom Title' },
     })
 
-    const result = generateDevNoteMetadata(note)
+    const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
     expect(result.twitter?.title).toBe('My Custom Title')
     expect(result.twitter?.images).toBeDefined()
@@ -140,7 +142,7 @@ describe('generateDevNoteMetadata', () => {
         excerpt: { rendered: '<p>This is a useful summary of the note.</p>' },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBe('This is a useful summary of the note.')
       expect(result.openGraph?.description).toBe('This is a useful summary of the note.')
@@ -152,7 +154,7 @@ describe('generateDevNoteMetadata', () => {
         excerpt: { rendered: '<p>Hello <strong>world</strong> from <a href="#">here</a>.</p>' },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBe('Hello world from here.')
       expect(result.description).not.toMatch(/<[^>]*>/)
@@ -163,7 +165,7 @@ describe('generateDevNoteMetadata', () => {
         excerpt: { rendered: '<p>Multiple   spaces\n\nand newlines</p>' },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBe('Multiple spaces and newlines')
     })
@@ -174,7 +176,7 @@ describe('generateDevNoteMetadata', () => {
         excerpt: { rendered: `<p>${longText}</p>` },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBeDefined()
       expect((result.description as string).length).toBeLessThanOrEqual(123)
@@ -186,7 +188,7 @@ describe('generateDevNoteMetadata', () => {
         content: { rendered: '<p>Fallback content body.</p>' },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBe('Fallback content body.')
     })
@@ -198,7 +200,7 @@ describe('generateDevNoteMetadata', () => {
         content: { rendered: '' },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBe('Only Title Available')
     })
@@ -210,7 +212,7 @@ describe('generateDevNoteMetadata', () => {
         content: { rendered: '<p></p>' },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBeTruthy()
     })
@@ -239,7 +241,7 @@ describe('generateBlogPostMetadata', () => {
       date: '2024-07-01T12:00:00',
     })
 
-    const result = generateBlogPostMetadata(thought)
+    const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
     expect(result.title).toBe('Test Blog Post')
     expect(result.openGraph).toBeDefined()
@@ -256,7 +258,7 @@ describe('generateBlogPostMetadata', () => {
       id: 789,
     })
 
-    const result = generateBlogPostMetadata(thought)
+    const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
     expect(result.openGraph?.images).toBeDefined()
     expect(result.openGraph?.images).toHaveLength(1)
@@ -275,7 +277,7 @@ describe('generateBlogPostMetadata', () => {
       id: 999,
     })
 
-    const result = generateBlogPostMetadata(thought)
+    const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
     expect(result.openGraph?.images?.[0]?.url).toBe(
       'https://hidetaka.dev/api/thumbnail/thoughts/999',
@@ -289,7 +291,7 @@ describe('generateBlogPostMetadata', () => {
       id: 111,
     })
 
-    const result = generateBlogPostMetadata(thought)
+    const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
     expect(result.openGraph?.images?.[0]?.url).toBe(
       'https://custom.example.com/api/thumbnail/thoughts/111',
@@ -301,7 +303,7 @@ describe('generateBlogPostMetadata', () => {
       title: { rendered: 'My Custom Blog Title' },
     })
 
-    const result = generateBlogPostMetadata(thought)
+    const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
     expect(result.twitter?.title).toBe('My Custom Blog Title')
     expect(result.twitter?.images).toBeDefined()
@@ -313,8 +315,8 @@ describe('generateBlogPostMetadata', () => {
     const thought1 = createMockWPThought({ id: 1 })
     const thought2 = createMockWPThought({ id: 2 })
 
-    const result1 = generateBlogPostMetadata(thought1)
-    const result2 = generateBlogPostMetadata(thought2)
+    const result1 = generateBlogPostMetadata(thought1, '/blog/post-1')
+    const result2 = generateBlogPostMetadata(thought2, '/blog/post-2')
 
     expect(result1.openGraph?.images?.[0]?.url).toContain('/thoughts/1')
     expect(result2.openGraph?.images?.[0]?.url).toContain('/thoughts/2')
@@ -326,7 +328,7 @@ describe('generateBlogPostMetadata', () => {
         excerpt: { rendered: '<p>This is a useful summary of the post.</p>' },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBe('This is a useful summary of the post.')
       expect(result.openGraph?.description).toBe('This is a useful summary of the post.')
@@ -338,7 +340,7 @@ describe('generateBlogPostMetadata', () => {
         excerpt: { rendered: '<p>Hello <strong>world</strong> from <a href="#">here</a>.</p>' },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBe('Hello world from here.')
       expect(result.description).not.toMatch(/<[^>]*>/)
@@ -349,7 +351,7 @@ describe('generateBlogPostMetadata', () => {
         excerpt: { rendered: '<p>Multiple   spaces\n\nand newlines</p>' },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBe('Multiple spaces and newlines')
     })
@@ -360,7 +362,7 @@ describe('generateBlogPostMetadata', () => {
         excerpt: { rendered: `<p>${longText}</p>` },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBeDefined()
       expect((result.description as string).length).toBeLessThanOrEqual(123)
@@ -372,7 +374,7 @@ describe('generateBlogPostMetadata', () => {
         content: { rendered: '<p>Fallback content body.</p>' },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBe('Fallback content body.')
     })
@@ -384,7 +386,7 @@ describe('generateBlogPostMetadata', () => {
         content: { rendered: '' },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBe('Only Title Available')
     })
@@ -396,7 +398,7 @@ describe('generateBlogPostMetadata', () => {
         content: { rendered: '<p></p>' },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBeTruthy()
     })
@@ -490,5 +492,174 @@ describe('generateProjectMetadata', () => {
     const result = generateProjectMetadata(project, 'en')
 
     expect(result.openGraph?.images).toBeUndefined()
+  })
+})
+
+describe('buildAlternates', () => {
+  it('should build canonical and hreflang for an English path', () => {
+    const result = buildAlternates('/work')
+
+    expect(result.canonical).toBe('https://hidetaka.dev/work')
+    expect(result.languages).toEqual({
+      en: 'https://hidetaka.dev/work',
+      ja: 'https://hidetaka.dev/ja/work',
+      'x-default': 'https://hidetaka.dev/work',
+    })
+  })
+
+  it('should build canonical and hreflang for a Japanese path', () => {
+    const result = buildAlternates('/ja/work')
+
+    expect(result.canonical).toBe('https://hidetaka.dev/ja/work')
+    expect(result.languages).toEqual({
+      en: 'https://hidetaka.dev/work',
+      ja: 'https://hidetaka.dev/ja/work',
+      'x-default': 'https://hidetaka.dev/work',
+    })
+  })
+
+  it('should handle the root path', () => {
+    const result = buildAlternates('/')
+
+    expect(result.canonical).toBe('https://hidetaka.dev')
+    expect(result.languages).toEqual({
+      en: 'https://hidetaka.dev',
+      ja: 'https://hidetaka.dev/ja',
+      'x-default': 'https://hidetaka.dev',
+    })
+  })
+
+  it('should handle the Japanese root path', () => {
+    const result = buildAlternates('/ja')
+
+    expect(result.canonical).toBe('https://hidetaka.dev/ja')
+    expect(result.languages).toEqual({
+      en: 'https://hidetaka.dev',
+      ja: 'https://hidetaka.dev/ja',
+      'x-default': 'https://hidetaka.dev',
+    })
+  })
+
+  it('should normalize canonical to the Japanese path when canonicalLang is ja', () => {
+    const result = buildAlternates('/writing/dev-notes/my-note', { canonicalLang: 'ja' })
+
+    expect(result.canonical).toBe('https://hidetaka.dev/ja/writing/dev-notes/my-note')
+    expect(result.languages).toEqual({
+      en: 'https://hidetaka.dev/writing/dev-notes/my-note',
+      ja: 'https://hidetaka.dev/ja/writing/dev-notes/my-note',
+      'x-default': 'https://hidetaka.dev/writing/dev-notes/my-note',
+    })
+  })
+
+  it('should normalize canonical to the English path when canonicalLang is en', () => {
+    const result = buildAlternates('/ja/blog/my-post', { canonicalLang: 'en' })
+
+    expect(result.canonical).toBe('https://hidetaka.dev/blog/my-post')
+  })
+
+  it('should limit hreflang to available languages for single-language pages', () => {
+    const result = buildAlternates('/ja/events/my-event', { availableLanguages: ['ja'] })
+
+    expect(result.canonical).toBe('https://hidetaka.dev/ja/events/my-event')
+    expect(result.languages).toEqual({
+      ja: 'https://hidetaka.dev/ja/events/my-event',
+      'x-default': 'https://hidetaka.dev/ja/events/my-event',
+    })
+  })
+})
+
+describe('getOpenGraphLocale', () => {
+  it('should return en_US for English', () => {
+    expect(getOpenGraphLocale('en')).toBe('en_US')
+  })
+
+  it('should return ja_JP for Japanese', () => {
+    expect(getOpenGraphLocale('ja')).toBe('ja_JP')
+  })
+})
+
+describe('canonical / hreflang / og:url integration', () => {
+  it('generateBlogPostMetadata should use the given path as canonical and og:url', () => {
+    const thought = createMockWPThought()
+
+    const result = generateBlogPostMetadata(thought, '/blog/test-post')
+
+    expect(result.alternates?.canonical).toBe('https://hidetaka.dev/blog/test-post')
+    expect(result.alternates?.languages).toEqual({
+      en: 'https://hidetaka.dev/blog/test-post',
+      ja: 'https://hidetaka.dev/ja/blog/test-post',
+      'x-default': 'https://hidetaka.dev/blog/test-post',
+    })
+    expect(result.openGraph?.url).toBe('https://hidetaka.dev/blog/test-post')
+    expect(result.openGraph?.siteName).toBe('Hidetaka.dev')
+    expect(result.openGraph?.locale).toBe('en_US')
+  })
+
+  it('generateBlogPostMetadata should use ja locale for Japanese paths', () => {
+    const thought = createMockWPThought()
+
+    const result = generateBlogPostMetadata(thought, '/ja/blog/test-post')
+
+    expect(result.alternates?.canonical).toBe('https://hidetaka.dev/ja/blog/test-post')
+    expect(result.openGraph?.url).toBe('https://hidetaka.dev/ja/blog/test-post')
+    expect(result.openGraph?.locale).toBe('ja_JP')
+  })
+
+  it('generateBlogPostMetadata should respect availableLanguages option', () => {
+    const thought = createMockWPThought()
+
+    const result = generateBlogPostMetadata(thought, '/ja/events/test-event', {
+      availableLanguages: ['ja'],
+    })
+
+    expect(result.alternates?.canonical).toBe('https://hidetaka.dev/ja/events/test-event')
+    expect(result.alternates?.languages).toEqual({
+      ja: 'https://hidetaka.dev/ja/events/test-event',
+      'x-default': 'https://hidetaka.dev/ja/events/test-event',
+    })
+  })
+
+  it('generateDevNoteMetadata should normalize canonical and og:url to the Japanese path', () => {
+    const note = createMockWPThought()
+
+    const enResult = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
+    const jaResult = generateDevNoteMetadata(note, '/ja/writing/dev-notes/test-post')
+
+    // en/jaで同一コンテンツのため、どちらもja側のURLをcanonicalとする
+    expect(enResult.alternates?.canonical).toBe(
+      'https://hidetaka.dev/ja/writing/dev-notes/test-post',
+    )
+    expect(jaResult.alternates?.canonical).toBe(
+      'https://hidetaka.dev/ja/writing/dev-notes/test-post',
+    )
+    expect(enResult.openGraph?.url).toBe('https://hidetaka.dev/ja/writing/dev-notes/test-post')
+    expect(enResult.alternates?.languages).toEqual({
+      en: 'https://hidetaka.dev/writing/dev-notes/test-post',
+      ja: 'https://hidetaka.dev/ja/writing/dev-notes/test-post',
+      'x-default': 'https://hidetaka.dev/writing/dev-notes/test-post',
+    })
+    // og:localeは表示中のページの言語に従う
+    expect(enResult.openGraph?.locale).toBe('en_US')
+    expect(jaResult.openGraph?.locale).toBe('ja_JP')
+  })
+
+  it('generateProjectMetadata should build canonical from lang and project id', () => {
+    const project = createMockProject({ id: 'my-project' })
+
+    const enResult = generateProjectMetadata(project, 'en')
+    const jaResult = generateProjectMetadata(project, 'ja')
+
+    expect(enResult.alternates?.canonical).toBe('https://hidetaka.dev/work/my-project')
+    expect(enResult.openGraph?.url).toBe('https://hidetaka.dev/work/my-project')
+    expect(enResult.openGraph?.locale).toBe('en_US')
+    expect(enResult.openGraph?.siteName).toBe('Hidetaka.dev')
+    expect(jaResult.alternates?.canonical).toBe('https://hidetaka.dev/ja/work/my-project')
+    expect(jaResult.openGraph?.url).toBe('https://hidetaka.dev/ja/work/my-project')
+    expect(jaResult.openGraph?.locale).toBe('ja_JP')
+    expect(jaResult.alternates?.languages).toEqual({
+      en: 'https://hidetaka.dev/work/my-project',
+      ja: 'https://hidetaka.dev/ja/work/my-project',
+      'x-default': 'https://hidetaka.dev/work/my-project',
+    })
   })
 })

--- a/src/libs/metadata.ts
+++ b/src/libs/metadata.ts
@@ -92,10 +92,7 @@ function buildDescription(thought: WPThought): string {
 }
 
 export function generateDevNoteMetadata(note: WPThought, path: string): Metadata {
-  const ogImageUrl = new URL(
-    `/api/thumbnail/dev-notes/${note.id}`,
-    process.env.NEXT_PUBLIC_SITE_URL || 'https://hidetaka.dev',
-  )
+  const ogImageUrl = new URL(`/api/thumbnail/dev-notes/${note.id}`, SITE_CONFIG.url)
 
   const description = buildDescription(note)
   const lang = getLanguageFromURL(path)
@@ -139,10 +136,7 @@ export function generateBlogPostMetadata(
 ): Metadata {
   // セキュリティ強化: post_idからWordPress APIで記事を取得してタイトルを使用
   // これにより、任意の文字列で画像を生成することを防止
-  const ogImageUrl = new URL(
-    `/api/thumbnail/thoughts/${thought.id}`,
-    process.env.NEXT_PUBLIC_SITE_URL || 'https://hidetaka.dev',
-  )
+  const ogImageUrl = new URL(`/api/thumbnail/thoughts/${thought.id}`, SITE_CONFIG.url)
 
   const description = buildDescription(thought)
   const lang = getLanguageFromURL(path)

--- a/src/libs/metadata.ts
+++ b/src/libs/metadata.ts
@@ -1,9 +1,74 @@
 import type { Metadata } from 'next'
+import { SITE_CONFIG } from '@/config'
 import type { WPThought } from './dataSources/types'
 import type { MicroCMSProjectsRecord } from './microCMS/types'
 import { removeHtmlTags } from './sanitize'
+import { changeLanguageURL, getLanguageFromURL } from './urlUtils/lang.util'
 
 const MAX_DESCRIPTION_LENGTH = 120
+
+type SupportedLang = 'en' | 'ja'
+
+/**
+ * パスを絶対URLに変換する。
+ * 末尾スラッシュを正規化し、ルート（`/`）の場合はサイトURLそのものを返す。
+ */
+const toAbsoluteUrl = (path: string): string => {
+  const normalized = path !== '/' && path.endsWith('/') ? path.slice(0, -1) : path
+  return normalized === '/' ? SITE_CONFIG.url : `${SITE_CONFIG.url}${normalized}`
+}
+
+/**
+ * 言語コードからOpen Graphのlocale値を返す。
+ */
+export function getOpenGraphLocale(lang: SupportedLang): 'en_US' | 'ja_JP' {
+  return lang === 'ja' ? 'ja_JP' : 'en_US'
+}
+
+export type BuildAlternatesOptions = {
+  /**
+   * canonicalを特定の言語側へ正規化する場合に指定する。
+   * 省略時は渡されたパス自身がcanonicalになる。
+   * （例: dev-notesはen/jaで同一の日本語コンテンツのため'ja'へ正規化する）
+   */
+  canonicalLang?: SupportedLang
+  /**
+   * ページが存在する言語。片方の言語にしか存在しないページでは
+   * 存在しない言語へのhreflangを出力しないために指定する。
+   * 省略時は en/ja の両方が存在するものとして扱う。
+   */
+  availableLanguages?: SupportedLang[]
+}
+
+/**
+ * パスからcanonical + hreflang（en/ja/x-default）のalternatesを生成する。
+ * en/jaパスの相互変換は `/ja` プレフィックスの付与/除去で行う。
+ */
+export function buildAlternates(
+  path: string,
+  options: BuildAlternatesOptions = {},
+): NonNullable<Metadata['alternates']> {
+  const enPath = changeLanguageURL(path, 'en')
+  const jaPath = changeLanguageURL(path, 'ja')
+  const available = options.availableLanguages ?? ['en', 'ja']
+  const canonicalPath =
+    options.canonicalLang === 'ja' ? jaPath : options.canonicalLang === 'en' ? enPath : path
+
+  const languages: Partial<Record<'en' | 'ja' | 'x-default', string>> = {}
+  if (available.includes('en')) {
+    languages.en = toAbsoluteUrl(enPath)
+  }
+  if (available.includes('ja')) {
+    languages.ja = toAbsoluteUrl(jaPath)
+  }
+  // x-defaultは英語版があれば英語版、なければ日本語版を指す
+  languages['x-default'] = toAbsoluteUrl(available.includes('en') ? enPath : jaPath)
+
+  return {
+    canonical: toAbsoluteUrl(canonicalPath),
+    languages,
+  }
+}
 
 /**
  * WordPressのexcerpt/contentからmeta description用のプレーンテキストを生成する。
@@ -26,22 +91,29 @@ function buildDescription(thought: WPThought): string {
   return thought.title.rendered
 }
 
-export function generateDevNoteMetadata(note: WPThought): Metadata {
+export function generateDevNoteMetadata(note: WPThought, path: string): Metadata {
   const ogImageUrl = new URL(
     `/api/thumbnail/dev-notes/${note.id}`,
     process.env.NEXT_PUBLIC_SITE_URL || 'https://hidetaka.dev',
   )
 
   const description = buildDescription(note)
+  const lang = getLanguageFromURL(path)
+  // dev-notesはen/jaで同一の日本語コンテンツを返すため、canonicalはja側へ正規化する
+  const alternates = buildAlternates(path, { canonicalLang: 'ja' })
 
   return {
     title: note.title.rendered,
     description,
+    alternates,
     openGraph: {
       title: note.title.rendered,
       description,
       type: 'article',
       publishedTime: note.date,
+      url: toAbsoluteUrl(changeLanguageURL(path, 'ja')),
+      siteName: SITE_CONFIG.name,
+      locale: getOpenGraphLocale(lang),
       images: [
         {
           url: ogImageUrl.toString(),
@@ -60,7 +132,11 @@ export function generateDevNoteMetadata(note: WPThought): Metadata {
   }
 }
 
-export function generateBlogPostMetadata(thought: WPThought): Metadata {
+export function generateBlogPostMetadata(
+  thought: WPThought,
+  path: string,
+  alternatesOptions: BuildAlternatesOptions = {},
+): Metadata {
   // セキュリティ強化: post_idからWordPress APIで記事を取得してタイトルを使用
   // これにより、任意の文字列で画像を生成することを防止
   const ogImageUrl = new URL(
@@ -69,15 +145,20 @@ export function generateBlogPostMetadata(thought: WPThought): Metadata {
   )
 
   const description = buildDescription(thought)
+  const lang = getLanguageFromURL(path)
 
   return {
     title: thought.title.rendered,
     description,
+    alternates: buildAlternates(path, alternatesOptions),
     openGraph: {
       title: thought.title.rendered,
       description,
       type: 'article',
       publishedTime: thought.date,
+      url: toAbsoluteUrl(path),
+      siteName: SITE_CONFIG.name,
+      locale: getOpenGraphLocale(lang),
       images: [
         {
           url: ogImageUrl.toString(),
@@ -100,8 +181,9 @@ const PROJECT_DESCRIPTION_MAX_LENGTH = 120
 
 export function generateProjectMetadata(
   project: MicroCMSProjectsRecord,
-  _lang: 'ja' | 'en',
+  lang: SupportedLang,
 ): Metadata {
+  const path = lang === 'ja' ? `/ja/work/${project.id}` : `/work/${project.id}`
   // aboutからHTMLタグを除去し、空白を正規化して説明文を生成する
   // aboutが無ければtitleをフォールバックとして使用する
   const rawDescription = project.about
@@ -119,10 +201,14 @@ export function generateProjectMetadata(
   return {
     title: project.title,
     description,
+    alternates: buildAlternates(path),
     openGraph: {
       title: project.title,
       description,
       type: 'website',
+      url: toAbsoluteUrl(path),
+      siteName: SITE_CONFIG.name,
+      locale: getOpenGraphLocale(lang),
       ...(project.image
         ? {
             images: [


### PR DESCRIPTION
fixing-metadata スキル観点の監査で検出した SEO 基盤の欠落への対応です(フェーズ2/3)。Search Console 実測でホームが掲載順位3.5に対しCTR 3.8%、`/ja/work/bq-cle0v37t` が表示2,922回でCTR 1.2%と低迷しており、その構造的要因(canonical/hreflang全面欠如・og:url不一致・ブランドなしtitle)を解消します。

## 変更内容

- **titleテンプレート導入**: ルート/jaレイアウトに `title: { default, template }` を設定。一覧ページの裸title(「Work」等)が「Work | Hidetaka Okamoto」形式に
- **canonical + hreflang ヘルパー**: `src/libs/metadata.ts` にパスから `alternates`(canonical / languages en・ja・x-default)を生成するヘルパーを追加(Vitestテスト付き)
- **適用**: ホーム・主要一覧ページ・blog/dev-notes/work/news 詳細(日英)の `generateMetadata` に canonical+hreflang を出力
- **og:url / og:siteName / og:locale 補完**: 各 generate*Metadata の openGraph に追加(従来は og:url が正しいページがほぼ存在しなかった)
- **言語重複の正規化**: `generateProjectMetadata` が `lang` 引数を無視していた問題を修正。同一コンテンツの en/ja 重複は canonical/hreflang で正規化

※ 専用OG画像(1200×630)の作成はスコープ外(別途対応)。

## 検証

- ✅ `pnpm lint:check` / `pnpm test` / `pnpm build` すべて合格

https://claude.ai/code/session_016RMVPFpo2HeNJ7bDhBmwFK

---
_Generated by [Claude Code](https://claude.ai/code/session_016RMVPFpo2HeNJ7bDhBmwFK)_