### PR TITLE
fix: モバイルダイアログのフォーカス管理などa11y基盤を整備(フェーズ3)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,26 @@
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 
+/* Accessibility: visible focus indicator for keyboard navigation */
+@layer base {
+  :focus-visible {
+    outline: 2px solid theme('colors.indigo.500');
+    outline-offset: 2px;
+  }
+}
+
+/* Accessibility: respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* Blog content styling */
 .blog-content {
   @apply text-base sm:text-lg;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -64,8 +64,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </div>
           </div>
           <div className="relative">
+            <a
+              href="#main-content"
+              className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-white focus:px-4 focus:py-2 focus:text-indigo-600 focus:shadow-lg dark:focus:bg-zinc-800 dark:focus:text-indigo-400"
+            >
+              Skip to content
+            </a>
             <Header />
-            <main>{children}</main>
+            <main id="main-content">{children}</main>
             <Footer />
           </div>
         </SentryProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -71,7 +71,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               Skip to content
             </a>
             <Header />
-            <main id="main-content">{children}</main>
+            <main id="main-content" tabIndex={-1} className="focus:outline-none">
+              {children}
+            </main>
             <Footer />
           </div>
         </SentryProvider>

--- a/src/components/tailwindui/Header.tsx
+++ b/src/components/tailwindui/Header.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import { useDialogA11y } from '@/libs/hooks/useDialogA11y'
 import {
   changeLanguageURL,
   getLanguageFromURL,
@@ -134,6 +135,7 @@ function MobileMenu({ isOpen, onClose }: { isOpen: boolean; onClose: () => void 
   const currentLang = lang
 
   const navItems = getNavItems(lang)
+  const dialogRef = useDialogA11y<HTMLDivElement>(isOpen, onClose)
 
   useEffect(() => {
     if (isOpen) {
@@ -159,7 +161,13 @@ function MobileMenu({ isOpen, onClose }: { isOpen: boolean; onClose: () => void 
       />
 
       {/* Menu Panel */}
-      <div className="fixed inset-y-0 right-0 z-50 w-full max-w-sm bg-white/95 backdrop-blur-md shadow-2xl ring-1 ring-zinc-900/5 dark:bg-zinc-900/95 dark:ring-white/10 lg:hidden">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Menu"
+        className="fixed inset-y-0 right-0 z-50 w-full max-w-sm bg-white/95 backdrop-blur-md shadow-2xl ring-1 ring-zinc-900/5 dark:bg-zinc-900/95 dark:ring-white/10 lg:hidden"
+      >
         <div className="flex flex-col h-full">
           {/* Header */}
           <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-200 dark:border-zinc-800">
@@ -320,9 +328,9 @@ export default function Header() {
               <Link href="/" className="group relative flex-shrink-0">
                 <span className="sr-only">Hidetaka.dev</span>
                 <div className="relative">
-                  <h1 className="text-xl sm:text-2xl font-extrabold tracking-tight text-slate-900 dark:text-white transition-colors group-hover:text-indigo-600 dark:group-hover:text-indigo-400">
+                  <p className="text-xl sm:text-2xl font-extrabold tracking-tight text-slate-900 dark:text-white transition-colors group-hover:text-indigo-600 dark:group-hover:text-indigo-400">
                     Hidetaka.dev
-                  </h1>
+                  </p>
                   <div className="absolute -bottom-1 left-0 h-0.5 w-0 bg-indigo-600 transition-all duration-300 group-hover:w-full dark:bg-indigo-400" />
                 </div>
               </Link>

--- a/src/components/tailwindui/Header.tsx
+++ b/src/components/tailwindui/Header.tsx
@@ -165,7 +165,7 @@ function MobileMenu({ isOpen, onClose }: { isOpen: boolean; onClose: () => void 
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        aria-label="Menu"
+        aria-label={lang === 'ja' ? 'メニュー' : 'Menu'}
         className="fixed inset-y-0 right-0 z-50 w-full max-w-sm bg-white/95 backdrop-blur-md shadow-2xl ring-1 ring-zinc-900/5 dark:bg-zinc-900/95 dark:ring-white/10 lg:hidden"
       >
         <div className="flex flex-col h-full">

--- a/src/components/ui/ArticleSummary.tsx
+++ b/src/components/ui/ArticleSummary.tsx
@@ -190,7 +190,10 @@ export default function ArticleSummary({ content, locale, className = '' }: Arti
 
       {/* ローディング状態 */}
       {isLoading && (
-        <div className="mt-3 flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+        <output
+          aria-live="polite"
+          className="mt-3 flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400"
+        >
           <svg className="animate-spin size-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
             <circle
               className="opacity-25"
@@ -207,12 +210,15 @@ export default function ArticleSummary({ content, locale, className = '' }: Arti
             />
           </svg>
           {text.loading}
-        </div>
+        </output>
       )}
 
       {/* エラーメッセージ */}
       {error && (
-        <div className="mt-3 rounded-lg bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+        <div
+          role="alert"
+          className="mt-3 rounded-lg bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400"
+        >
           {error}
         </div>
       )}

--- a/src/components/ui/ArticleSummary.tsx
+++ b/src/components/ui/ArticleSummary.tsx
@@ -188,30 +188,36 @@ export default function ArticleSummary({ content, locale, className = '' }: Arti
         <p className="mt-2 text-sm text-amber-600 dark:text-amber-400">⚠️ {text.downloading}</p>
       )}
 
-      {/* ローディング状態 */}
-      {isLoading && (
-        <output
-          aria-live="polite"
-          className="mt-3 flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400"
-        >
-          <svg className="animate-spin size-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            />
-          </svg>
-          {text.loading}
-        </output>
-      )}
+      {/* ローディング状態(aria-live領域は常にマウントし、中身のみ切り替える) */}
+      <output
+        aria-live="polite"
+        className={
+          isLoading
+            ? 'mt-3 flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400'
+            : undefined
+        }
+      >
+        {isLoading && (
+          <>
+            <svg className="animate-spin size-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            {text.loading}
+          </>
+        )}
+      </output>
 
       {/* エラーメッセージ */}
       {error && (

--- a/src/components/ui/BlogTranslation.tsx
+++ b/src/components/ui/BlogTranslation.tsx
@@ -376,7 +376,10 @@ export default function BlogTranslation({
 
       {/* エラーメッセージ */}
       {error && (
-        <div className="mt-3 rounded-lg bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+        <div
+          role="alert"
+          className="mt-3 rounded-lg bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400"
+        >
           {error}
         </div>
       )}

--- a/src/components/ui/FilterItem.tsx
+++ b/src/components/ui/FilterItem.tsx
@@ -17,6 +17,7 @@ export default function FilterItem({
     <button
       type="button"
       onClick={onClick}
+      aria-pressed={active}
       className={`w-full flex items-center justify-between rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors ${
         active
           ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-400'

--- a/src/components/ui/MobileFilterDrawer.tsx
+++ b/src/components/ui/MobileFilterDrawer.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react'
 import FilterItem from '@/components/ui/FilterItem'
 import SearchBar from '@/components/ui/SearchBar'
+import { useDialogA11y } from '@/libs/hooks/useDialogA11y'
 
 export type FilterGroup = {
   title: string
@@ -37,6 +38,8 @@ export default function MobileFilterDrawer({
   title = 'Filter',
   lang = 'ja',
 }: MobileFilterDrawerProps) {
+  const dialogRef = useDialogA11y<HTMLDivElement>(isOpen, onClose)
+
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = 'hidden'
@@ -61,7 +64,13 @@ export default function MobileFilterDrawer({
       />
 
       {/* Drawer Panel */}
-      <div className="fixed inset-y-0 right-0 z-50 w-full max-w-sm bg-white/95 backdrop-blur-md shadow-2xl ring-1 ring-zinc-900/5 dark:bg-zinc-900/95 dark:ring-white/10 lg:hidden">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="fixed inset-y-0 right-0 z-50 w-full max-w-sm bg-white/95 backdrop-blur-md shadow-2xl ring-1 ring-zinc-900/5 dark:bg-zinc-900/95 dark:ring-white/10 lg:hidden"
+      >
         <div className="flex flex-col h-full">
           {/* Header */}
           <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-200 dark:border-zinc-800">

--- a/src/components/ui/SearchBar.tsx
+++ b/src/components/ui/SearchBar.tsx
@@ -2,6 +2,7 @@ type SearchBarProps = {
   value: string
   onChange: (value: string) => void
   placeholder?: string
+  label?: string
   className?: string
 }
 
@@ -9,6 +10,7 @@ export default function SearchBar({
   value,
   onChange,
   placeholder = 'Search...',
+  label,
   className = '',
 }: SearchBarProps) {
   return (
@@ -19,6 +21,7 @@ export default function SearchBar({
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
+          aria-hidden="true"
         >
           <path
             strokeLinecap="round"
@@ -29,10 +32,11 @@ export default function SearchBar({
         </svg>
       </div>
       <input
-        type="text"
+        type="search"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        aria-label={label ?? placeholder}
         className="block w-full rounded-lg border border-zinc-200 bg-white py-2.5 pl-10 pr-4 text-sm text-slate-900 placeholder-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white dark:placeholder-slate-500 dark:focus:border-indigo-400 dark:focus:ring-indigo-400"
       />
     </div>

--- a/src/libs/hooks/useDialogA11y.component.test.tsx
+++ b/src/libs/hooks/useDialogA11y.component.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { useDialogA11y } from './useDialogA11y'
+
+function TestDialog({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  const dialogRef = useDialogA11y<HTMLDivElement>(isOpen, onClose)
+
+  if (!isOpen) return null
+
+  return (
+    <div ref={dialogRef} role="dialog" aria-modal="true" aria-label="Test dialog">
+      <button type="button">First</button>
+      <button type="button">Second</button>
+      <button type="button">Last</button>
+    </div>
+  )
+}
+
+function TestApp() {
+  const [isOpen, setIsOpen] = useState(false)
+  return (
+    <>
+      <button type="button" onClick={() => setIsOpen(true)}>
+        Toggle
+      </button>
+      <TestDialog isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </>
+  )
+}
+
+describe('useDialogA11y', () => {
+  it('開時に最初のフォーカス可能要素へフォーカスを移動する', () => {
+    render(<TestApp />)
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle' }))
+
+    expect(screen.getByRole('button', { name: 'First' })).toHaveFocus()
+  })
+
+  it('Escape キーで onClose を呼び出す', () => {
+    const onClose = vi.fn()
+    render(<TestDialog isOpen={true} onClose={onClose} />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('閉じている間はキーボードイベントを処理しない', () => {
+    const onClose = vi.fn()
+    render(<TestDialog isOpen={false} onClose={onClose} />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('Tab で最後の要素から最初の要素へフォーカスをラップする', () => {
+    render(<TestDialog isOpen={true} onClose={() => {}} />)
+
+    screen.getByRole('button', { name: 'Last' }).focus()
+    fireEvent.keyDown(document, { key: 'Tab' })
+
+    expect(screen.getByRole('button', { name: 'First' })).toHaveFocus()
+  })
+
+  it('Shift+Tab で最初の要素から最後の要素へフォーカスをラップする', () => {
+    render(<TestDialog isOpen={true} onClose={() => {}} />)
+
+    screen.getByRole('button', { name: 'First' }).focus()
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+
+    expect(screen.getByRole('button', { name: 'Last' })).toHaveFocus()
+  })
+
+  it('閉時に開く前にフォーカスされていた要素へフォーカスを復元する', () => {
+    render(<TestApp />)
+    const toggle = screen.getByRole('button', { name: 'Toggle' })
+
+    toggle.focus()
+    fireEvent.click(toggle)
+    expect(screen.getByRole('button', { name: 'First' })).toHaveFocus()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(toggle).toHaveFocus()
+  })
+})

--- a/src/libs/hooks/useDialogA11y.ts
+++ b/src/libs/hooks/useDialogA11y.ts
@@ -79,16 +79,32 @@ export function useDialogA11y<T extends HTMLElement = HTMLDivElement>(
       const first = elements[0]
       const last = elements[elements.length - 1]
       const active = document.activeElement
-      const isInside = active instanceof HTMLElement && dialogRef.current?.contains(active)
+      // ダイアログ内であっても tabindex="-1" の要素(パネル自身など)に
+      // フォーカスがある場合は active が elements に含まれないため、
+      // 前後にフォーカス可能要素が存在するかを文書順で判定してラップする
+      const activeInDialog =
+        active instanceof HTMLElement && dialogRef.current?.contains(active) ? active : null
 
       if (event.shiftKey) {
-        if (!isInside || active === first) {
+        const hasFocusableBefore = elements.some(
+          (el) =>
+            activeInDialog !== null &&
+            (el.compareDocumentPosition(activeInDialog) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0,
+        )
+        if (!hasFocusableBefore) {
           event.preventDefault()
           last.focus()
         }
-      } else if (!isInside || active === last) {
-        event.preventDefault()
-        first.focus()
+      } else {
+        const hasFocusableAfter = elements.some(
+          (el) =>
+            activeInDialog !== null &&
+            (el.compareDocumentPosition(activeInDialog) & Node.DOCUMENT_POSITION_PRECEDING) !== 0,
+        )
+        if (!hasFocusableAfter) {
+          event.preventDefault()
+          first.focus()
+        }
       }
     }
 

--- a/src/libs/hooks/useDialogA11y.ts
+++ b/src/libs/hooks/useDialogA11y.ts
@@ -1,0 +1,105 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ')
+
+/**
+ * ダイアログ内のフォーカス可能な要素を取得する。
+ *
+ * @param container - 検索対象のコンテナ要素
+ * @returns フォーカス可能な要素の配列(コンテナが無い場合は空配列)
+ */
+export function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return []
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+}
+
+/**
+ * モーダルダイアログのアクセシビリティ挙動を提供するフック。
+ *
+ * - 開時: 直前のフォーカス要素を記憶し、ダイアログ内の最初のフォーカス可能要素へフォーカスを移動する
+ * - 開いている間: Tab / Shift+Tab のフォーカスをダイアログ内でラップ(フォーカストラップ)する
+ * - Escape キーで `onClose` を呼び出す
+ * - 閉時(アンマウント/`isOpen` が false になった時): 開く前にフォーカスされていた要素へフォーカスを復元する
+ *
+ * 返り値の ref をダイアログのパネル要素(`role="dialog"` を付与した要素)に設定して使用する。
+ *
+ * @param isOpen - ダイアログが開いているかどうか
+ * @param onClose - ダイアログを閉じることを要求する際に呼び出されるコールバック
+ * @returns ダイアログパネル要素に設定する ref
+ */
+export function useDialogA11y<T extends HTMLElement = HTMLDivElement>(
+  isOpen: boolean,
+  onClose: () => void,
+) {
+  const dialogRef = useRef<T>(null)
+  const onCloseRef = useRef(onClose)
+
+  useEffect(() => {
+    onCloseRef.current = onClose
+  }, [onClose])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const previousFocus =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null
+
+    // 開時に最初のフォーカス可能要素へフォーカスを移動
+    const focusables = getFocusableElements(dialogRef.current)
+    if (focusables.length > 0) {
+      focusables[0].focus()
+    } else {
+      dialogRef.current?.focus()
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onCloseRef.current()
+        return
+      }
+
+      if (event.key !== 'Tab') return
+
+      const elements = getFocusableElements(dialogRef.current)
+      if (elements.length === 0) {
+        event.preventDefault()
+        return
+      }
+
+      const first = elements[0]
+      const last = elements[elements.length - 1]
+      const active = document.activeElement
+      const isInside = active instanceof HTMLElement && dialogRef.current?.contains(active)
+
+      if (event.shiftKey) {
+        if (!isInside || active === first) {
+          event.preventDefault()
+          last.focus()
+        }
+      } else if (!isInside || active === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      // 閉時にトグルボタンなど元の要素へフォーカスを復元
+      previousFocus?.focus()
+    }
+  }, [isOpen])
+
+  return dialogRef
+}


### PR DESCRIPTION
fixing-accessibility / baseline-ui スキル観点の監査で検出したアクセシビリティ問題への対応です(フェーズ3/3)。最重要は、キーボード・スクリーンリーダーユーザーがモバイルメニューとフィルタドロワーを実質操作できなかった問題(WCAG 2.1.2 / 4.1.2 相当)の解消です。

## 変更内容

- **共通フック `useDialogA11y` を新設**(`src/libs/hooks/useDialogA11y.ts`、テスト付き): フォーカストラップ、Escapeで閉じる、開時のフォーカス移動、閉時のトリガーへのフォーカス復元を提供(新規依存なし)
- **Header のモバイルメニューと MobileFilterDrawer をダイアログ化**: `role="dialog"` / `aria-modal="true"` + 上記フック適用
- **SearchBar**: `type="search"` 化と `aria-label` 付与(Speaking/Work/Writing の計6箇所以上に波及)、装飾SVGに `aria-hidden`
- **FilterItem**: `aria-pressed` でトグル状態を通知
- **h1重複解消**: Header ロゴの `<h1>` を `<p>` に(全ページで h1 が2重になっていた)
- **スキップリンク**: `<main id="main-content">` への「Skip to content」を追加
- **`:focus-visible` グローバルルール**: indigo のフォーカスリングを全要素に
- **`prefers-reduced-motion` 対応**: アニメーション・トランジションを抑制するメディアクエリを追加
- **aria-live 小修正**: ArticleSummary のローディングを `<output aria-live="polite">` 化、エラーに `role="alert"`(BlogTranslation も)

## 検証

- ✅ `pnpm lint:check` / `pnpm test` / `pnpm build` すべて合格

https://claude.ai/code/session_016RMVPFpo2HeNJ7bDhBmwFK

---
_Generated by [Claude Code](https://claude.ai/code/session_016RMVPFpo2HeNJ7bDhBmwFK)_