### PR TITLE
Refactor metadata generation and improve accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "fast-xml-parser": "^5.8.0",
     "microcms-js-sdk": "^2.3.2",
     "next": "^16.2.6",
+    "node-wp-api-client": "0.1.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "recharts": "^3.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       next:
         specifier: ^16.2.6
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      node-wp-api-client:
+        specifier: 0.1.0
+        version: 0.1.0
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -3107,6 +3110,10 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  node-wp-api-client@0.1.0:
+    resolution: {integrity: sha512-MVngjZBqrEQsXaNk8mG+V9jc5shRzlNdoOQCfpm4UJfo/ozQTfOWc/pcb/stKxbWreSmUS9POOuJHa3R8l72YA==}
+    engines: {node: '>=20.19'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -7332,6 +7339,8 @@ snapshots:
       encoding: 0.1.13
 
   node-releases@2.0.27: {}
+
+  node-wp-api-client@0.1.0: {}
 
   normalize-path@3.0.0: {}
 

--- a/public/favicons/browserconfig.xml
+++ b/public/favicons/browserconfig.xml
@@ -2,8 +2,8 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/mstile-150x150.png"/>
-            <TileColor>#da532c</TileColor>
+            <square150x150logo src="/favicons/mstile-150x150.png"/>
+            <TileColor>#4f46e5</TileColor>
         </tile>
     </msapplication>
 </browserconfig>

--- a/public/favicons/site.webmanifest
+++ b/public/favicons/site.webmanifest
@@ -1,19 +1,19 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Hidetaka.dev",
+    "short_name": "Hidetaka",
     "icons": [
         {
-            "src": "/android-chrome-192x192.png",
+            "src": "/favicons/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-512x512.png",
+            "src": "/favicons/android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
+    "theme_color": "#4f46e5",
     "background_color": "#ffffff",
     "display": "standalone"
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,7 +1,9 @@
 import AboutPageContent from '@/components/containers/pages/AboutPage'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
-  title: 'About Hidetaka Okamoto',
+  alternates: buildAlternates('/about'),
+  title: 'About',
 }
 
 export default function AboutPage() {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     }
   }
 
-  return generateBlogPostMetadata(thought)
+  return generateBlogPostMetadata(thought, `/blog/${slug}`)
 }
 
 export default async function BlogDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,8 +3,10 @@ import BlogPageContent from '@/components/containers/pages/BlogPage'
 import JsonLd from '@/components/JsonLd'
 import { loadAllCategories, loadThoughts } from '@/libs/dataSources/thoughts'
 import { generateBlogListJsonLd } from '@/libs/jsonLd'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
+  alternates: buildAlternates('/blog'),
   title: 'Blog',
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,26 @@
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 
+/* Accessibility: visible focus indicator for keyboard navigation */
+@layer base {
+  :focus-visible {
+    outline: 2px solid theme('colors.indigo.500');
+    outline-offset: 2px;
+  }
+}
+
+/* Accessibility: respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* Blog content styling */
 .blog-content {
   @apply text-base sm:text-lg;

--- a/src/app/ja/about/page.tsx
+++ b/src/app/ja/about/page.tsx
@@ -1,7 +1,9 @@
 import AboutPageContent from '@/components/containers/pages/AboutPage'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
-  title: 'About Hidetaka Okamoto',
+  alternates: buildAlternates('/ja/about'),
+  title: 'About',
 }
 
 export default function AboutPage() {

--- a/src/app/ja/blog/[slug]/page.tsx
+++ b/src/app/ja/blog/[slug]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     }
   }
 
-  return generateBlogPostMetadata(thought)
+  return generateBlogPostMetadata(thought, `/ja/blog/${slug}`)
 }
 
 export default async function BlogDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/ja/blog/page.tsx
+++ b/src/app/ja/blog/page.tsx
@@ -3,8 +3,10 @@ import BlogPageContent from '@/components/containers/pages/BlogPage'
 import JsonLd from '@/components/JsonLd'
 import { loadAllCategories, loadThoughts } from '@/libs/dataSources/thoughts'
 import { generateBlogListJsonLd } from '@/libs/jsonLd'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
+  alternates: buildAlternates('/ja/blog'),
   title: 'ブログ',
 }
 

--- a/src/app/ja/events/[slug]/page.tsx
+++ b/src/app/ja/events/[slug]/page.tsx
@@ -37,7 +37,10 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   // WPEventをWPThought形式に変換してメタデータを生成
   const thought = eventToThought(event)
 
-  return generateBlogPostMetadata(thought)
+  // イベントページは日本語版のみ存在するため、hreflangは日本語のみ出力する
+  return generateBlogPostMetadata(thought, `/ja/events/${slug}`, {
+    availableLanguages: ['ja'],
+  })
 }
 
 export default async function EventDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/ja/layout.tsx
+++ b/src/app/ja/layout.tsx
@@ -2,7 +2,10 @@ import type { Metadata } from 'next'
 import { SITE_DESCRIPTION_JA, SITE_TITLE_JA } from '@/consts'
 
 export const metadata: Metadata = {
-  title: SITE_TITLE_JA,
+  title: {
+    default: SITE_TITLE_JA,
+    template: '%s | 岡本 秀高',
+  },
   description: SITE_DESCRIPTION_JA,
   metadataBase: new URL('https://hidetaka.dev'),
   openGraph: {

--- a/src/app/ja/news/[slug]/page.tsx
+++ b/src/app/ja/news/[slug]/page.tsx
@@ -50,7 +50,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   // WPProductをWPThought形式に変換してメタデータを生成
   const thought = productToThought(product)
 
-  return generateBlogPostMetadata(thought)
+  return generateBlogPostMetadata(thought, `/ja/news/${slug}`)
 }
 
 export default async function NewsDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/ja/news/page.tsx
+++ b/src/app/ja/news/page.tsx
@@ -1,7 +1,9 @@
 import NewsPageContent from '@/components/containers/pages/NewsPage'
 import { loadProducts } from '@/libs/dataSources/products'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
+  alternates: buildAlternates('/ja/news'),
   title: 'News',
 }
 

--- a/src/app/ja/page.tsx
+++ b/src/app/ja/page.tsx
@@ -1,7 +1,13 @@
+import type { Metadata } from 'next'
 import FeaturedContent from '@/components/containers/FeaturedContent'
 import Hero from '@/components/Hero/Hero'
 import Capabilities from '@/components/home/Capabilities'
 import StackShowcase from '@/components/home/StackShowcase'
+import { buildAlternates } from '@/libs/metadata'
+
+export const metadata: Metadata = {
+  alternates: buildAlternates('/ja'),
+}
 
 export default async function HomePage() {
   const lang = 'ja'

--- a/src/app/ja/projects/[slug]/page.tsx
+++ b/src/app/ja/projects/[slug]/page.tsx
@@ -149,7 +149,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50 dark:focus:ring-offset-zinc-900"
                 >
                   Visit application
                 </a>

--- a/src/app/ja/projects/[slug]/page.tsx
+++ b/src/app/ja/projects/[slug]/page.tsx
@@ -24,7 +24,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
 
   return (
     <Container className="mt-8 sm:mt-16">
-      <div className="bg-white">
+      <div className="bg-white dark:bg-zinc-900">
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:grid lg:max-w-7xl lg:grid-cols-2 lg:gap-x-8 lg:px-8">
           <div className="lg:max-w-lg lg:self-end">
             <nav aria-label="Breadcrumb">
@@ -33,7 +33,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   <div className="flex items-center text-sm">
                     <a
                       href="/ja/projects"
-                      className="font-medium text-gray-500 hover:text-gray-900"
+                      className="font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"
                     >
                       Projects
                     </a>
@@ -41,7 +41,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                       viewBox="0 0 20 20"
                       fill="currentColor"
                       aria-hidden="true"
-                      className="ml-2 size-5 shrink-0 text-gray-300"
+                      className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                     >
                       <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                     </svg>
@@ -50,12 +50,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 {project.project_type.map((type) => (
                   <li key={type}>
                     <div className="flex items-center text-sm">
-                      <span className="font-medium text-gray-500">{type}</span>
+                      <span className="font-medium text-zinc-500 dark:text-zinc-400">{type}</span>
                       <svg
                         viewBox="0 0 20 20"
                         fill="currentColor"
                         aria-hidden="true"
-                        className="ml-2 size-5 shrink-0 text-gray-300"
+                        className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                       >
                         <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                       </svg>
@@ -65,7 +65,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </ol>
             </nav>
             <div className="mt-4">
-              <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+              <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-4xl">
                 {project.title}
               </h1>
             </div>
@@ -74,12 +74,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 Product information
               </h2>
               <div className="flex items-center">
-                <p className="text-lg text-gray-900 sm:text-xl">Free to use</p>
+                <p className="text-lg text-zinc-900 dark:text-white sm:text-xl">Free to use</p>
                 {project.published_at && (
-                  <div className="ml-4 border-l border-gray-300 pl-4">
+                  <div className="ml-4 border-l border-zinc-300 dark:border-zinc-600 pl-4">
                     <h2 className="sr-only">Release date</h2>
                     <div className="flex items-center">
-                      <p className="ml-2 text-sm text-gray-500">
+                      <p className="ml-2 text-sm text-zinc-500 dark:text-zinc-400">
                         Released at{' '}
                         {new Date(project.published_at).toLocaleDateString('ja-JP', {
                           day: 'numeric',
@@ -94,7 +94,9 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </div>
               {project.about && (
                 <div className="mt-4 space-y-6">
-                  <p className="text-base text-gray-500">{project.about.replace(/<[^>]*>/g, '')}</p>
+                  <p className="text-base text-zinc-500 dark:text-zinc-400">
+                    {project.about.replace(/<[^>]*>/g, '')}
+                  </p>
                 </div>
               )}
             </section>
@@ -129,7 +131,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </h2>
               <div className="mt-8">
                 <div className="flex items-center justify-between">
-                  <h2 className="text-sm font-medium text-gray-900">tools</h2>
+                  <h2 className="text-sm font-medium text-zinc-900 dark:text-white">tools</h2>
                 </div>
                 <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
                   {project.tags.map((tag) => (
@@ -147,7 +149,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
                 >
                   Visit application
                 </a>
@@ -158,10 +160,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       </div>
       {project.background && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Background
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:
@@ -174,10 +177,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       )}
       {project.architecture && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Architecture
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:

--- a/src/app/ja/speaking/page.tsx
+++ b/src/app/ja/speaking/page.tsx
@@ -1,7 +1,9 @@
 import SpeakingPageContent from '@/components/containers/pages/SpeakingPage'
 import { loadWPEvents } from '@/libs/dataSources/events'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
+  alternates: buildAlternates('/ja/speaking'),
   title: '登壇・講演',
 }
 

--- a/src/app/ja/test-sentry/page.tsx
+++ b/src/app/ja/test-sentry/page.tsx
@@ -5,13 +5,18 @@
  * 開発モードでのみアクセス可能です。
  */
 
+import type { Metadata } from 'next'
 import SentryTestClient from '@/components/sentry/SentryTestClient.ja'
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
 
 export default async function TestSentryPage() {
   // 開発モードかどうかを確認
   if (process.env.NODE_ENV !== 'development') {
     return (
-      <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="flex min-h-dvh items-center justify-center px-4">
         <div className="text-center max-w-md">
           <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-4">
             本番環境では利用できません

--- a/src/app/ja/work/[slug]/page.tsx
+++ b/src/app/ja/work/[slug]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({
     .then((projects) => projects.find((p) => p.id === slug))
 
   if (!project) {
-    return { title: 'Work | Hidetaka.dev' }
+    return { title: 'Work' }
   }
 
   return generateProjectMetadata(project, 'ja')

--- a/src/app/ja/work/[slug]/page.tsx
+++ b/src/app/ja/work/[slug]/page.tsx
@@ -169,7 +169,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50 dark:focus:ring-offset-zinc-900"
                 >
                   Visit application
                 </a>

--- a/src/app/ja/work/[slug]/page.tsx
+++ b/src/app/ja/work/[slug]/page.tsx
@@ -44,21 +44,24 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
 
   return (
     <Container className="mt-8 sm:mt-16">
-      <div className="bg-white">
+      <div className="bg-white dark:bg-zinc-900">
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:grid lg:max-w-7xl lg:grid-cols-2 lg:gap-x-8 lg:px-8">
           <div className="lg:max-w-lg lg:self-end">
             <nav aria-label="Breadcrumb">
               <ol className="flex items-center space-x-2">
                 <li>
                   <div className="flex items-center text-sm">
-                    <a href="/ja/work" className="font-medium text-gray-500 hover:text-gray-900">
+                    <a
+                      href="/ja/work"
+                      className="font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"
+                    >
                       Work
                     </a>
                     <svg
                       viewBox="0 0 20 20"
                       fill="currentColor"
                       aria-hidden="true"
-                      className="ml-2 size-5 shrink-0 text-gray-300"
+                      className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                     >
                       <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                     </svg>
@@ -67,12 +70,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 {project.project_type.map((type) => (
                   <li key={type}>
                     <div className="flex items-center text-sm">
-                      <span className="font-medium text-gray-500">{type}</span>
+                      <span className="font-medium text-zinc-500 dark:text-zinc-400">{type}</span>
                       <svg
                         viewBox="0 0 20 20"
                         fill="currentColor"
                         aria-hidden="true"
-                        className="ml-2 size-5 shrink-0 text-gray-300"
+                        className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                       >
                         <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                       </svg>
@@ -82,7 +85,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </ol>
             </nav>
             <div className="mt-4">
-              <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+              <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-4xl">
                 {project.title}
               </h1>
             </div>
@@ -91,12 +94,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 Product information
               </h2>
               <div className="flex items-center">
-                <p className="text-lg text-gray-900 sm:text-xl">Free to use</p>
+                <p className="text-lg text-zinc-900 dark:text-white sm:text-xl">Free to use</p>
                 {project.published_at && (
-                  <div className="ml-4 border-l border-gray-300 pl-4">
+                  <div className="ml-4 border-l border-zinc-300 dark:border-zinc-600 pl-4">
                     <h2 className="sr-only">Release date</h2>
                     <div className="flex items-center">
-                      <p className="ml-2 text-sm text-gray-500">
+                      <p className="ml-2 text-sm text-zinc-500 dark:text-zinc-400">
                         Released at{' '}
                         {new Date(project.published_at).toLocaleDateString('ja-JP', {
                           day: 'numeric',
@@ -111,7 +114,9 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </div>
               {project.about && (
                 <div className="mt-4 space-y-6">
-                  <p className="text-base text-gray-500">{project.about.replace(/<[^>]*>/g, '')}</p>
+                  <p className="text-base text-zinc-500 dark:text-zinc-400">
+                    {project.about.replace(/<[^>]*>/g, '')}
+                  </p>
                 </div>
               )}
             </section>
@@ -146,7 +151,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </h2>
               <div className="mt-8">
                 <div className="flex items-center justify-between">
-                  <h2 className="text-sm font-medium text-gray-900">tools</h2>
+                  <h2 className="text-sm font-medium text-zinc-900 dark:text-white">tools</h2>
                 </div>
                 <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
                   {project.tags.map((tag) => (
@@ -164,7 +169,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
                 >
                   Visit application
                 </a>
@@ -175,10 +180,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       </div>
       {project.background && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Background
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:
@@ -191,10 +197,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       )}
       {project.architecture && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Architecture
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:

--- a/src/app/ja/work/page.tsx
+++ b/src/app/ja/work/page.tsx
@@ -1,10 +1,12 @@
 import WorkPageContent from '@/components/containers/pages/WorkPage'
 import { listMyNPMPackages } from '@/libs/dataSources/npmjs'
 import { listMyWordPressPlugins } from '@/libs/dataSources/wporg'
+import { buildAlternates } from '@/libs/metadata'
 import { MicroCMSAPI } from '@/libs/microCMS/apis'
 import { createMicroCMSClient } from '@/libs/microCMS/client'
 
 export const metadata = {
+  alternates: buildAlternates('/ja/work'),
   title: 'Work',
 }
 

--- a/src/app/ja/writing/dev-notes/[slug]/page.tsx
+++ b/src/app/ja/writing/dev-notes/[slug]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     }
   }
 
-  return generateDevNoteMetadata(note)
+  return generateDevNoteMetadata(note, `/ja/writing/dev-notes/${slug}`)
 }
 
 export default async function DevNoteDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/ja/writing/dev-notes/page.tsx
+++ b/src/app/ja/writing/dev-notes/page.tsx
@@ -3,19 +3,22 @@ import DevNotesArchivePage from '@/components/containers/pages/DevNotesArchivePa
 import JsonLd from '@/components/JsonLd'
 import { loadDevNotes } from '@/libs/dataSources/devnotes'
 import { generateBlogListJsonLd } from '@/libs/jsonLd'
+import { buildAlternates } from '@/libs/metadata'
 
-const title = '開発メモ | Hidetaka.dev'
+const title = '開発メモ'
 const description = '日々の開発で気づいたことや学んだことを記録しています。'
 
 export const metadata: Metadata = {
   title,
   description,
+  alternates: buildAlternates('/ja/writing/dev-notes'),
   openGraph: {
     title,
     description,
     type: 'website',
     url: 'https://hidetaka.dev/ja/writing/dev-notes',
     siteName: 'Hidetaka.dev',
+    locale: 'ja_JP',
   },
   twitter: {
     card: 'summary_large_image',

--- a/src/app/ja/writing/page.tsx
+++ b/src/app/ja/writing/page.tsx
@@ -1,9 +1,11 @@
 import WritingPageContent from '@/components/containers/pages/WritingPage'
 import StatsSection from '@/components/ui/stats/StatsSection'
 import { loadBlogPosts } from '@/libs/dataSources/blogs'
+import { buildAlternates } from '@/libs/metadata'
 import { loadStatsPosts } from '@/libs/stats/loadStatsPosts'
 
 export const metadata = {
+  alternates: buildAlternates('/ja/writing'),
   title: 'Writing',
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -64,8 +64,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </div>
           </div>
           <div className="relative">
+            <a
+              href="#main-content"
+              className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-white focus:px-4 focus:py-2 focus:text-indigo-600 focus:shadow-lg dark:focus:bg-zinc-800 dark:focus:text-indigo-400"
+            >
+              Skip to content
+            </a>
             <Header />
-            <main>{children}</main>
+            <main id="main-content">{children}</main>
             <Footer />
           </div>
         </SentryProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,7 +53,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <JsonLd data={generatePersonJsonLd()} />
       </head>
       <body className="flex h-full flex-col bg-zinc-50 dark:bg-black">
-        <JsonLd data={generatePersonJsonLd()} />
         <SentryProvider>
           <GoogleAnalytics gaId="G-RV8PYHHYHN" />
           <DarkModeScript />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -71,7 +71,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               Skip to content
             </a>
             <Header />
-            <main id="main-content">{children}</main>
+            <main id="main-content" tabIndex={-1} className="focus:outline-none">
+              {children}
+            </main>
             <Footer />
           </div>
         </SentryProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,10 @@ import Header from '@/components/tailwindui/Header'
 import { generatePersonJsonLd } from '@/libs/jsonLd'
 
 export const metadata: Metadata = {
-  title: SITE_TITLE,
+  title: {
+    default: SITE_TITLE,
+    template: '%s | Hidetaka Okamoto',
+  },
   description: SITE_DESCRIPTION,
   metadataBase: new URL('https://hidetaka.dev'),
   openGraph: {

--- a/src/app/news/[slug]/page.tsx
+++ b/src/app/news/[slug]/page.tsx
@@ -50,7 +50,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   // WPProductをWPThought形式に変換してメタデータを生成
   const thought = productToThought(product)
 
-  return generateBlogPostMetadata(thought)
+  return generateBlogPostMetadata(thought, `/news/${slug}`)
 }
 
 export default async function NewsDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,7 +1,9 @@
 import NewsPageContent from '@/components/containers/pages/NewsPage'
 import { loadProducts } from '@/libs/dataSources/products'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
+  alternates: buildAlternates('/news'),
   title: 'News',
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,13 @@
+import type { Metadata } from 'next'
 import FeaturedContent from '@/components/containers/FeaturedContent'
 import Hero from '@/components/Hero/Hero'
 import Capabilities from '@/components/home/Capabilities'
 import StackShowcase from '@/components/home/StackShowcase'
+import { buildAlternates } from '@/libs/metadata'
+
+export const metadata: Metadata = {
+  alternates: buildAlternates('/'),
+}
 
 export default async function HomePage() {
   const lang = 'en'

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -149,7 +149,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50 dark:focus:ring-offset-zinc-900"
                 >
                   Visit application
                 </a>

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -24,21 +24,24 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
 
   return (
     <Container className="mt-8 sm:mt-16">
-      <div className="bg-white">
+      <div className="bg-white dark:bg-zinc-900">
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:grid lg:max-w-7xl lg:grid-cols-2 lg:gap-x-8 lg:px-8">
           <div className="lg:max-w-lg lg:self-end">
             <nav aria-label="Breadcrumb">
               <ol className="flex items-center space-x-2">
                 <li>
                   <div className="flex items-center text-sm">
-                    <a href="/projects" className="font-medium text-gray-500 hover:text-gray-900">
+                    <a
+                      href="/projects"
+                      className="font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"
+                    >
                       Projects
                     </a>
                     <svg
                       viewBox="0 0 20 20"
                       fill="currentColor"
                       aria-hidden="true"
-                      className="ml-2 size-5 shrink-0 text-gray-300"
+                      className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                     >
                       <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                     </svg>
@@ -47,12 +50,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 {project.project_type.map((type) => (
                   <li key={type}>
                     <div className="flex items-center text-sm">
-                      <span className="font-medium text-gray-500">{type}</span>
+                      <span className="font-medium text-zinc-500 dark:text-zinc-400">{type}</span>
                       <svg
                         viewBox="0 0 20 20"
                         fill="currentColor"
                         aria-hidden="true"
-                        className="ml-2 size-5 shrink-0 text-gray-300"
+                        className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                       >
                         <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                       </svg>
@@ -62,7 +65,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </ol>
             </nav>
             <div className="mt-4">
-              <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+              <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-4xl">
                 {project.title}
               </h1>
             </div>
@@ -71,12 +74,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 Product information
               </h2>
               <div className="flex items-center">
-                <p className="text-lg text-gray-900 sm:text-xl">Free to use</p>
+                <p className="text-lg text-zinc-900 dark:text-white sm:text-xl">Free to use</p>
                 {project.published_at && (
-                  <div className="ml-4 border-l border-gray-300 pl-4">
+                  <div className="ml-4 border-l border-zinc-300 dark:border-zinc-600 pl-4">
                     <h2 className="sr-only">Release date</h2>
                     <div className="flex items-center">
-                      <p className="ml-2 text-sm text-gray-500">
+                      <p className="ml-2 text-sm text-zinc-500 dark:text-zinc-400">
                         Released at{' '}
                         {new Date(project.published_at).toLocaleDateString('en-US', {
                           day: 'numeric',
@@ -91,7 +94,9 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </div>
               {project.about && (
                 <div className="mt-4 space-y-6">
-                  <p className="text-base text-gray-500">{project.about.replace(/<[^>]*>/g, '')}</p>
+                  <p className="text-base text-zinc-500 dark:text-zinc-400">
+                    {project.about.replace(/<[^>]*>/g, '')}
+                  </p>
                 </div>
               )}
             </section>
@@ -126,7 +131,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </h2>
               <div className="mt-8">
                 <div className="flex items-center justify-between">
-                  <h2 className="text-sm font-medium text-gray-900">tools</h2>
+                  <h2 className="text-sm font-medium text-zinc-900 dark:text-white">tools</h2>
                 </div>
                 <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
                   {project.tags.map((tag) => (
@@ -144,7 +149,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
                 >
                   Visit application
                 </a>
@@ -155,10 +160,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       </div>
       {project.background && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Background
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:
@@ -171,10 +177,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       )}
       {project.architecture && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Architecture
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
-      disallow: '/private/',
+      disallow: ['/private/', '/sentry-test', '/test-sentry'],
     },
     sitemap: `${SITE_CONFIG.url}/sitemap.xml`,
   }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
-      disallow: ['/private/', '/sentry-test', '/test-sentry'],
+      disallow: ['/private/', '/sentry-test', '/test-sentry', '/ja/test-sentry'],
     },
     sitemap: `${SITE_CONFIG.url}/sitemap.xml`,
   }

--- a/src/app/sentry-test/layout.tsx
+++ b/src/app/sentry-test/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
+
+export default function SentryTestLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -117,26 +117,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     })
   }
 
-  // Dev Notes（WordPress API、日本語版と英語版）
+  // Dev Notes（WordPress API）
+  // en/jaで同一コンテンツを返すため、canonicalである日本語版URLのみ登録する
+  // （英語版URLはhreflang/canonicalで日本語版へ正規化される）
   let devNotesPages: MetadataRoute.Sitemap = []
   try {
-    const [allDevNotesJa, allDevNotesEn] = await Promise.all([
-      loadAllDevNotes('ja'),
-      loadAllDevNotes('en'),
-    ])
-    const jaPages = allDevNotesJa.map((item) => ({
+    const allDevNotesJa = await loadAllDevNotes('ja')
+    devNotesPages = allDevNotesJa.map((item) => ({
       url: `${SITE_CONFIG.url}${item.href}`,
       lastModified: new Date(item.datetime),
       changeFrequency: 'monthly' as const,
       priority: 0.7,
     }))
-    const enPages = allDevNotesEn.map((item) => ({
-      url: `${SITE_CONFIG.url}${item.href}`,
-      lastModified: new Date(item.datetime),
-      changeFrequency: 'monthly' as const,
-      priority: 0.7,
-    }))
-    devNotesPages = [...jaPages, ...enPages]
   } catch (error) {
     logger.error('Failed to load dev-notes for sitemap', {
       error,

--- a/src/app/speaking/page.tsx
+++ b/src/app/speaking/page.tsx
@@ -1,7 +1,9 @@
 import SpeakingPageContent from '@/components/containers/pages/SpeakingPage'
 import { loadWPEvents } from '@/libs/dataSources/events'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata = {
+  alternates: buildAlternates('/speaking'),
   title: 'Speaking',
 }
 

--- a/src/app/test-sentry/page.tsx
+++ b/src/app/test-sentry/page.tsx
@@ -5,13 +5,18 @@
  * Only accessible in development mode.
  */
 
+import type { Metadata } from 'next'
 import SentryTestClient from '@/components/sentry/SentryTestClient'
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
 
 export default async function TestSentryPage() {
   // Check if we're in development mode
   if (process.env.NODE_ENV !== 'development') {
     return (
-      <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="flex min-h-dvh items-center justify-center px-4">
         <div className="text-center max-w-md">
           <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-4">
             Not Available in Production

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -169,7 +169,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50 dark:focus:ring-offset-zinc-900"
                 >
                   Visit application
                 </a>

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({
     .then((projects) => projects.find((p) => p.id === slug))
 
   if (!project) {
-    return { title: 'Work | Hidetaka.dev' }
+    return { title: 'Work' }
   }
 
   return generateProjectMetadata(project, 'en')

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -44,21 +44,24 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
 
   return (
     <Container className="mt-8 sm:mt-16">
-      <div className="bg-white">
+      <div className="bg-white dark:bg-zinc-900">
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:grid lg:max-w-7xl lg:grid-cols-2 lg:gap-x-8 lg:px-8">
           <div className="lg:max-w-lg lg:self-end">
             <nav aria-label="Breadcrumb">
               <ol className="flex items-center space-x-2">
                 <li>
                   <div className="flex items-center text-sm">
-                    <a href="/work" className="font-medium text-gray-500 hover:text-gray-900">
+                    <a
+                      href="/work"
+                      className="font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"
+                    >
                       Work
                     </a>
                     <svg
                       viewBox="0 0 20 20"
                       fill="currentColor"
                       aria-hidden="true"
-                      className="ml-2 size-5 shrink-0 text-gray-300"
+                      className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                     >
                       <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                     </svg>
@@ -67,12 +70,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 {project.project_type.map((type) => (
                   <li key={type}>
                     <div className="flex items-center text-sm">
-                      <span className="font-medium text-gray-500">{type}</span>
+                      <span className="font-medium text-zinc-500 dark:text-zinc-400">{type}</span>
                       <svg
                         viewBox="0 0 20 20"
                         fill="currentColor"
                         aria-hidden="true"
-                        className="ml-2 size-5 shrink-0 text-gray-300"
+                        className="ml-2 size-5 shrink-0 text-zinc-300 dark:text-zinc-600"
                       >
                         <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
                       </svg>
@@ -82,7 +85,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </ol>
             </nav>
             <div className="mt-4">
-              <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+              <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-4xl">
                 {project.title}
               </h1>
             </div>
@@ -91,12 +94,12 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                 Product information
               </h2>
               <div className="flex items-center">
-                <p className="text-lg text-gray-900 sm:text-xl">Free to use</p>
+                <p className="text-lg text-zinc-900 dark:text-white sm:text-xl">Free to use</p>
                 {project.published_at && (
-                  <div className="ml-4 border-l border-gray-300 pl-4">
+                  <div className="ml-4 border-l border-zinc-300 dark:border-zinc-600 pl-4">
                     <h2 className="sr-only">Release date</h2>
                     <div className="flex items-center">
-                      <p className="ml-2 text-sm text-gray-500">
+                      <p className="ml-2 text-sm text-zinc-500 dark:text-zinc-400">
                         Released at{' '}
                         {new Date(project.published_at).toLocaleDateString('en-US', {
                           day: 'numeric',
@@ -111,7 +114,9 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </div>
               {project.about && (
                 <div className="mt-4 space-y-6">
-                  <p className="text-base text-gray-500">{project.about.replace(/<[^>]*>/g, '')}</p>
+                  <p className="text-base text-zinc-500 dark:text-zinc-400">
+                    {project.about.replace(/<[^>]*>/g, '')}
+                  </p>
                 </div>
               )}
             </section>
@@ -146,7 +151,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
               </h2>
               <div className="mt-8">
                 <div className="flex items-center justify-between">
-                  <h2 className="text-sm font-medium text-gray-900">tools</h2>
+                  <h2 className="text-sm font-medium text-zinc-900 dark:text-white">tools</h2>
                 </div>
                 <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
                   {project.tags.map((tag) => (
@@ -164,7 +169,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
                   href={project.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-50"
+                  className="flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-zinc-50"
                 >
                   Visit application
                 </a>
@@ -175,10 +180,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       </div>
       {project.background && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Background
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:
@@ -191,10 +197,11 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
       )}
       {project.architecture && (
         <div className="mx-auto max-w-2xl px-4 pb-16 sm:px-6 sm:pb-24 lg:max-w-7xl">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-3xl my-4">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-3xl my-4">
             Architecture
           </h2>
           <div
+            className="text-zinc-700 dark:text-zinc-300"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: Content is from trusted microCMS, controlled by site owner
             dangerouslySetInnerHTML={{
               __html:

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,10 +1,12 @@
 import WorkPageContent from '@/components/containers/pages/WorkPage'
 import { listMyNPMPackages } from '@/libs/dataSources/npmjs'
 import { listMyWordPressPlugins } from '@/libs/dataSources/wporg'
+import { buildAlternates } from '@/libs/metadata'
 import { MicroCMSAPI } from '@/libs/microCMS/apis'
 import { createMicroCMSClient } from '@/libs/microCMS/client'
 
 export const metadata = {
+  alternates: buildAlternates('/work'),
   title: 'Work',
 }
 

--- a/src/app/writing/dev-notes/[slug]/page.tsx
+++ b/src/app/writing/dev-notes/[slug]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     }
   }
 
-  return generateDevNoteMetadata(note)
+  return generateDevNoteMetadata(note, `/writing/dev-notes/${slug}`)
 }
 
 export default async function DevNoteDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/writing/dev-notes/page.tsx
+++ b/src/app/writing/dev-notes/page.tsx
@@ -3,20 +3,23 @@ import DevNotesArchivePage from '@/components/containers/pages/DevNotesArchivePa
 import JsonLd from '@/components/JsonLd'
 import { loadDevNotes } from '@/libs/dataSources/devnotes'
 import { generateBlogListJsonLd } from '@/libs/jsonLd'
+import { buildAlternates } from '@/libs/metadata'
 
 export const metadata: Metadata = {
-  title: 'Development Notes | Hidetaka.dev',
+  title: 'Development Notes',
   description: 'A collection of notes and learnings from daily development work.',
+  alternates: buildAlternates('/writing/dev-notes'),
   openGraph: {
-    title: 'Development Notes | Hidetaka.dev',
+    title: 'Development Notes',
     description: 'A collection of notes and learnings from daily development work.',
     type: 'website',
     url: 'https://hidetaka.dev/writing/dev-notes',
     siteName: 'Hidetaka.dev',
+    locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Development Notes | Hidetaka.dev',
+    title: 'Development Notes',
     description: 'A collection of notes and learnings from daily development work.',
   },
 }

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -1,9 +1,11 @@
 import WritingPageContent from '@/components/containers/pages/WritingPage'
 import StatsSection from '@/components/ui/stats/StatsSection'
 import { loadBlogPosts } from '@/libs/dataSources/blogs'
+import { buildAlternates } from '@/libs/metadata'
 import { loadStatsPosts } from '@/libs/stats/loadStatsPosts'
 
 export const metadata = {
+  alternates: buildAlternates('/writing'),
   title: 'Writing',
 }
 

--- a/src/components/sentry/SentryTestClient.ja.tsx
+++ b/src/components/sentry/SentryTestClient.ja.tsx
@@ -103,7 +103,7 @@ export default function SentryTestClient() {
   }
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black py-12 px-4">
+    <div className="min-h-dvh bg-zinc-50 dark:bg-black py-12 px-4">
       <div className="max-w-4xl mx-auto">
         <div className="bg-white dark:bg-zinc-900 rounded-lg shadow-lg p-8">
           <h1 className="text-4xl font-bold text-slate-900 dark:text-white mb-4">

--- a/src/components/sentry/SentryTestClient.tsx
+++ b/src/components/sentry/SentryTestClient.tsx
@@ -97,7 +97,7 @@ export default function SentryTestClient() {
   }
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black py-12 px-4">
+    <div className="min-h-dvh bg-zinc-50 dark:bg-black py-12 px-4">
       <div className="max-w-4xl mx-auto">
         <div className="bg-white dark:bg-zinc-900 rounded-lg shadow-lg p-8">
           <h1 className="text-4xl font-bold text-slate-900 dark:text-white mb-4">

--- a/src/components/tailwindui/Header.tsx
+++ b/src/components/tailwindui/Header.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import { useDialogA11y } from '@/libs/hooks/useDialogA11y'
 import {
   changeLanguageURL,
   getLanguageFromURL,
@@ -134,6 +135,7 @@ function MobileMenu({ isOpen, onClose }: { isOpen: boolean; onClose: () => void 
   const currentLang = lang
 
   const navItems = getNavItems(lang)
+  const dialogRef = useDialogA11y<HTMLDivElement>(isOpen, onClose)
 
   useEffect(() => {
     if (isOpen) {
@@ -159,7 +161,13 @@ function MobileMenu({ isOpen, onClose }: { isOpen: boolean; onClose: () => void 
       />
 
       {/* Menu Panel */}
-      <div className="fixed inset-y-0 right-0 z-50 w-full max-w-sm bg-white/95 backdrop-blur-md shadow-2xl ring-1 ring-zinc-900/5 dark:bg-zinc-900/95 dark:ring-white/10 lg:hidden">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Menu"
+        className="fixed inset-y-0 right-0 z-50 w-full max-w-sm bg-white/95 backdrop-blur-md shadow-2xl ring-1 ring-zinc-900/5 dark:bg-zinc-900/95 dark:ring-white/10 lg:hidden"
+      >
         <div className="flex flex-col h-full">
           {/* Header */}
           <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-200 dark:border-zinc-800">
@@ -320,9 +328,9 @@ export default function Header() {
               <Link href="/" className="group relative flex-shrink-0">
                 <span className="sr-only">Hidetaka.dev</span>
                 <div className="relative">
-                  <h1 className="text-xl sm:text-2xl font-extrabold tracking-tight text-slate-900 dark:text-white transition-colors group-hover:text-indigo-600 dark:group-hover:text-indigo-400">
+                  <p className="text-xl sm:text-2xl font-extrabold tracking-tight text-slate-900 dark:text-white transition-colors group-hover:text-indigo-600 dark:group-hover:text-indigo-400">
                     Hidetaka.dev
-                  </h1>
+                  </p>
                   <div className="absolute -bottom-1 left-0 h-0.5 w-0 bg-indigo-600 transition-all duration-300 group-hover:w-full dark:bg-indigo-400" />
                 </div>
               </Link>

--- a/src/components/tailwindui/Header.tsx
+++ b/src/components/tailwindui/Header.tsx
@@ -165,7 +165,7 @@ function MobileMenu({ isOpen, onClose }: { isOpen: boolean; onClose: () => void 
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        aria-label="Menu"
+        aria-label={lang === 'ja' ? 'メニュー' : 'Menu'}
         className="fixed inset-y-0 right-0 z-50 w-full max-w-sm bg-white/95 backdrop-blur-md shadow-2xl ring-1 ring-zinc-900/5 dark:bg-zinc-900/95 dark:ring-white/10 lg:hidden"
       >
         <div className="flex flex-col h-full">

--- a/src/components/ui/ArticleSummary.tsx
+++ b/src/components/ui/ArticleSummary.tsx
@@ -190,7 +190,10 @@ export default function ArticleSummary({ content, locale, className = '' }: Arti
 
       {/* ローディング状態 */}
       {isLoading && (
-        <div className="mt-3 flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+        <output
+          aria-live="polite"
+          className="mt-3 flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400"
+        >
           <svg className="animate-spin size-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
             <circle
               className="opacity-25"
@@ -207,12 +210,15 @@ export default function ArticleSummary({ content, locale, className = '' }: Arti
             />
           </svg>
           {text.loading}
-        </div>
+        </output>
       )}
 
       {/* エラーメッセージ */}
       {error && (
-        <div className="mt-3 rounded-lg bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+        <div
+          role="alert"
+          className="mt-3 rounded-lg bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400"
+        >
           {error}
         </div>
       )}

--- a/src/components/ui/ArticleSummary.tsx
+++ b/src/components/ui/ArticleSummary.tsx
@@ -188,30 +188,36 @@ export default function ArticleSummary({ content, locale, className = '' }: Arti
         <p className="mt-2 text-sm text-amber-600 dark:text-amber-400">⚠️ {text.downloading}</p>
       )}
 
-      {/* ローディング状態 */}
-      {isLoading && (
-        <output
-          aria-live="polite"
-          className="mt-3 flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400"
-        >
-          <svg className="animate-spin size-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            />
-          </svg>
-          {text.loading}
-        </output>
-      )}
+      {/* ローディング状態(aria-live領域は常にマウントし、中身のみ切り替える) */}
+      <output
+        aria-live="polite"
+        className={
+          isLoading
+            ? 'mt-3 flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400'
+            : undefined
+        }
+      >
+        {isLoading && (
+          <>
+            <svg className="animate-spin size-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            {text.loading}
+          </>
+        )}
+      </output>
 
       {/* エラーメッセージ */}
       {error && (

--- a/src/components/ui/BlogTranslation.tsx
+++ b/src/components/ui/BlogTranslation.tsx
@@ -376,7 +376,10 @@ export default function BlogTranslation({
 
       {/* エラーメッセージ */}
       {error && (
-        <div className="mt-3 rounded-lg bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+        <div
+          role="alert"
+          className="mt-3 rounded-lg bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400"
+        >
           {error}
         </div>
       )}

--- a/src/components/ui/ErrorUI.tsx
+++ b/src/components/ui/ErrorUI.tsx
@@ -22,7 +22,7 @@ export default function ErrorUI({
   return (
     <main
       className={cn(
-        'flex min-h-screen items-center justify-center px-4 bg-zinc-50 dark:bg-black',
+        'flex min-h-dvh items-center justify-center px-4 bg-zinc-50 dark:bg-black',
         className,
       )}
       role="alert"

--- a/src/components/ui/FilterItem.tsx
+++ b/src/components/ui/FilterItem.tsx
@@ -17,6 +17,7 @@ export default function FilterItem({
     <button
       type="button"
       onClick={onClick}
+      aria-pressed={active}
       className={`w-full flex items-center justify-between rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors ${
         active
           ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-400'

--- a/src/components/ui/MobileFilterDrawer.tsx
+++ b/src/components/ui/MobileFilterDrawer.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react'
 import FilterItem from '@/components/ui/FilterItem'
 import SearchBar from '@/components/ui/SearchBar'
+import { useDialogA11y } from '@/libs/hooks/useDialogA11y'
 
 export type FilterGroup = {
   title: string
@@ -37,6 +38,8 @@ export default function MobileFilterDrawer({
   title = 'Filter',
   lang = 'ja',
 }: MobileFilterDrawerProps) {
+  const dialogRef = useDialogA11y<HTMLDivElement>(isOpen, onClose)
+
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = 'hidden'
@@ -61,7 +64,13 @@ export default function MobileFilterDrawer({
       />
 
       {/* Drawer Panel */}
-      <div className="fixed inset-y-0 right-0 z-50 w-full max-w-sm bg-white/95 backdrop-blur-md shadow-2xl ring-1 ring-zinc-900/5 dark:bg-zinc-900/95 dark:ring-white/10 lg:hidden">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="fixed inset-y-0 right-0 z-50 w-full max-w-sm bg-white/95 backdrop-blur-md shadow-2xl ring-1 ring-zinc-900/5 dark:bg-zinc-900/95 dark:ring-white/10 lg:hidden"
+      >
         <div className="flex flex-col h-full">
           {/* Header */}
           <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-200 dark:border-zinc-800">

--- a/src/components/ui/SearchBar.tsx
+++ b/src/components/ui/SearchBar.tsx
@@ -2,6 +2,7 @@ type SearchBarProps = {
   value: string
   onChange: (value: string) => void
   placeholder?: string
+  label?: string
   className?: string
 }
 
@@ -9,6 +10,7 @@ export default function SearchBar({
   value,
   onChange,
   placeholder = 'Search...',
+  label,
   className = '',
 }: SearchBarProps) {
   return (
@@ -19,6 +21,7 @@ export default function SearchBar({
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
+          aria-hidden="true"
         >
           <path
             strokeLinecap="round"
@@ -29,10 +32,11 @@ export default function SearchBar({
         </svg>
       </div>
       <input
-        type="text"
+        type="search"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        aria-label={label ?? placeholder}
         className="block w-full rounded-lg border border-zinc-200 bg-white py-2.5 pl-10 pr-4 text-sm text-slate-900 placeholder-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-white dark:placeholder-slate-500 dark:focus:border-indigo-400 dark:focus:ring-indigo-400"
       />
     </div>

--- a/src/libs/dataSources/devnotes.test.ts
+++ b/src/libs/dataSources/devnotes.test.ts
@@ -444,6 +444,7 @@ describe('getRelatedDevNotes', () => {
 
     const mockResponse = {
       ok: true,
+      headers: new Headers(),
       json: async () => mockNotes,
     }
 
@@ -481,6 +482,7 @@ describe('getRelatedDevNotes', () => {
 
     const mockResponse = {
       ok: true,
+      headers: new Headers(),
       json: async () => [
         {
           id: 2,

--- a/src/libs/dataSources/devnotes.ts
+++ b/src/libs/dataSources/devnotes.ts
@@ -210,10 +210,14 @@ export const getAdjacentDevNotes = async (currentNote: WPThought): Promise<Adjac
 
     const [previousResult, nextResult] = await Promise.all([previousPromise, nextPromise])
 
-    // _fields で id/title/slug のみ取得しているため、WPThought として返すためにキャスト
+    // _fields で id/title/slug のみ取得しているため、型安全性のためPick型を経由してキャスト
+    const previous =
+      (previousResult.items[0] as Pick<WPThought, 'id' | 'title' | 'slug'> | undefined) ?? null
+    const next =
+      (nextResult.items[0] as Pick<WPThought, 'id' | 'title' | 'slug'> | undefined) ?? null
     return {
-      previous: (previousResult.items[0] as WPThought | undefined) ?? null,
-      next: (nextResult.items[0] as WPThought | undefined) ?? null,
+      previous: previous as WPThought | null,
+      next: next as WPThought | null,
     }
   } catch (error) {
     logger.error('Failed to load adjacent dev-notes', {

--- a/src/libs/dataSources/devnotes.ts
+++ b/src/libs/dataSources/devnotes.ts
@@ -1,6 +1,7 @@
-import { APIError } from '@/libs/errors'
+import type { WPQueryValue } from 'node-wp-api-client'
 import { logger } from '@/libs/logger'
 import type { BlogItem, Category, WPThought } from './types'
+import { wpClient } from './wpClient'
 
 export type DevNotesResult = {
   items: BlogItem[]
@@ -9,11 +10,41 @@ export type DevNotesResult = {
   currentPage: number
 }
 
+const devNotesCollection = () => wpClient.postType<WPThought>('dev-notes')
+
+const DEV_NOTE_LIST_FIELDS = [
+  '_links.wp:term',
+  '_embedded',
+  'id',
+  'title',
+  'date',
+  'date_gmt',
+  'excerpt',
+  'slug',
+  'link',
+  'categories',
+] as const
+
+// _embedded.wp:term のみを参照する最小限の入力型
+// （node-wp-api-client が _fields 指定で返す絞り込み型でも受け取れるようにするため）
+type EmbeddedTermSource = {
+  _embedded?: {
+    'wp:term'?: ReadonlyArray<
+      ReadonlyArray<{
+        id: number
+        name: string
+        slug: string
+        taxonomy: string
+      }>
+    >
+  }
+}
+
 // カテゴリ情報を抽出するヘルパー関数
 // dev-notesのカスタム投稿タイプでは、カテゴリのタクソノミー名が異なる可能性があるため、
 // すべてのタクソノミーからカテゴリを抽出する
 // テスト可能にするためにexport
-export const extractCategories = (note: WPThought): Category[] => {
+export const extractCategories = (note: EmbeddedTermSource): Category[] => {
   if (!note._embedded?.['wp:term']) {
     return []
   }
@@ -52,28 +83,24 @@ export const loadDevNotes = async (
 ): Promise<DevNotesResult> => {
   try {
     // after を渡すとその日時以降の記事のみ取得し、過剰なデータ取得を避ける
-    const afterParam = after ? `&after=${encodeURIComponent(after)}` : ''
-    const response = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes?page=${page}&per_page=${perPage}${afterParam}&_embed=wp:term&_fields=_links.wp:term,_embedded,id,title,date,date_gmt,excerpt,slug,link,categories`,
+    const {
+      items: notes,
+      total: totalItems,
+      totalPages,
+    } = await devNotesCollection().list(
+      {
+        page,
+        per_page: perPage,
+        ...(after ? { after } : {}),
+        _embed: 'wp:term',
+        _fields: DEV_NOTE_LIST_FIELDS,
+      },
       {
         next: { revalidate: 1800 }, // 30分ごとに再検証（WordPress記事）
       },
     )
 
-    if (!response.ok) {
-      throw await APIError.fromResponse(response, '/wp-json/wp/v2/dev-notes', {
-        page,
-        perPage,
-        lang,
-      })
-    }
-
-    const notes: WPThought[] = await response.json()
-
-    const totalItems = Number.parseInt(response.headers.get('X-WP-Total') || '0', 10)
-    const totalPages = Number.parseInt(response.headers.get('X-WP-TotalPages') || '0', 10)
-
-    const items: BlogItem[] = notes.map((note: WPThought): BlogItem => {
+    const items: BlogItem[] = notes.map((note): BlogItem => {
       const basePath = lang === 'ja' ? '/ja/writing/dev-notes' : '/writing/dev-notes'
       const href = `${basePath}/${note.slug}`
 
@@ -113,26 +140,30 @@ export const loadDevNotes = async (
  */
 export const getDevNoteBySlug = async (slug: string): Promise<WPThought | null> => {
   try {
-    const response = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes?slug=${encodeURIComponent(slug)}&_embed=wp:term&_fields=_links.wp:term,_embedded,id,title,date,date_gmt,excerpt,content,slug,link,categories`,
+    return await devNotesCollection().getBySlug(
+      slug,
+      {
+        _embed: 'wp:term',
+        _fields: [
+          '_links.wp:term',
+          '_embedded',
+          'id',
+          'title',
+          'date',
+          'date_gmt',
+          'modified',
+          'modified_gmt',
+          'excerpt',
+          'content',
+          'slug',
+          'link',
+          'categories',
+        ],
+      },
       {
         next: { revalidate: 1800 }, // 30分ごとに再検証
       },
     )
-
-    if (!response.ok) {
-      throw await APIError.fromResponse(response, '/wp-json/wp/v2/dev-notes', {
-        slug,
-      })
-    }
-
-    const notes: WPThought[] = await response.json()
-
-    if (notes.length === 0) {
-      return null
-    }
-
-    return notes[0]
   } catch (error) {
     logger.error('Failed to load dev-note by slug', {
       error,
@@ -147,43 +178,42 @@ export type AdjacentDevNotes = {
   next: WPThought | null
 }
 
-// WordPress APIから記事を取得するヘルパー関数
-const fetchDevNote = async (url: string): Promise<WPThought | null> => {
-  try {
-    const response = await fetch(url, {
-      next: { revalidate: 1800 }, // 30分ごとに再検証
-    })
-    if (!response.ok) {
-      logger.error('Failed to fetch dev-note', {
-        status: response.status,
-        url,
-      })
-      return null
-    }
-    const notes: WPThought[] = await response.json()
-    return notes.length > 0 ? notes[0] : null
-  } catch (error) {
-    logger.error('Failed to fetch dev-note', {
-      error,
-      url,
-    })
-    return null
-  }
-}
-
 /**
  * 前後の記事を取得
  */
 export const getAdjacentDevNotes = async (currentNote: WPThought): Promise<AdjacentDevNotes> => {
   try {
-    const previousUrl = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes?before=${encodeURIComponent(currentNote.date)}&per_page=1&orderby=date&order=desc&_fields=id,title,slug`
-    const nextUrl = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes?after=${encodeURIComponent(currentNote.date)}&per_page=1&orderby=date&order=asc&_fields=id,title,slug`
+    const previousPromise = devNotesCollection().list(
+      {
+        before: currentNote.date,
+        per_page: 1,
+        orderby: 'date',
+        order: 'desc',
+        _fields: ['id', 'title', 'slug'],
+      },
+      {
+        next: { revalidate: 1800 }, // 30分ごとに再検証
+      },
+    )
+    const nextPromise = devNotesCollection().list(
+      {
+        after: currentNote.date,
+        per_page: 1,
+        orderby: 'date',
+        order: 'asc',
+        _fields: ['id', 'title', 'slug'],
+      },
+      {
+        next: { revalidate: 1800 }, // 30分ごとに再検証
+      },
+    )
 
-    const [previous, next] = await Promise.all([fetchDevNote(previousUrl), fetchDevNote(nextUrl)])
+    const [previousResult, nextResult] = await Promise.all([previousPromise, nextPromise])
 
+    // _fields で id/title/slug のみ取得しているため、WPThought として返すためにキャスト
     return {
-      previous,
-      next,
+      previous: (previousResult.items[0] as WPThought | undefined) ?? null,
+      next: (nextResult.items[0] as WPThought | undefined) ?? null,
     }
   } catch (error) {
     logger.error('Failed to load adjacent dev-notes', {
@@ -215,33 +245,29 @@ export const getRelatedDevNotes = async (
     const fetchLimit = Math.max(limit * 2.5, 10)
 
     // カテゴリがある場合は同じカテゴリの記事を取得、ない場合はすべての記事を取得
-    let url: string
+    const taxonomyFilter: Record<string, WPQueryValue> = {}
     if (categories.length > 0) {
       const category = categories[0]
       // カスタム投稿タイプでは、カテゴリのタクソノミー名をパラメータとして使用
       // 例: categories (デフォルト) または dev-note-category (カスタム)
       const taxonomyParam = category.taxonomy === 'category' ? 'categories' : category.taxonomy
-      url = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes?${taxonomyParam}=${category.id}&exclude=${currentNote.id}&per_page=${fetchLimit}&_embed=wp:term&_fields=_links.wp:term,_embedded,id,title,date,date_gmt,excerpt,slug,link,categories`
-    } else {
-      url = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/dev-notes?exclude=${currentNote.id}&per_page=${fetchLimit}&_embed=wp:term&_fields=_links.wp:term,_embedded,id,title,date,date_gmt,excerpt,slug,link,categories`
+      taxonomyFilter[taxonomyParam] = category.id
     }
 
-    const response = await fetch(url, {
-      next: { revalidate: 1800 }, // 30分ごとに再検証
-    })
+    const { items: notes } = await devNotesCollection().list(
+      {
+        ...taxonomyFilter,
+        exclude: [currentNote.id],
+        per_page: fetchLimit,
+        _embed: 'wp:term',
+        _fields: DEV_NOTE_LIST_FIELDS,
+      },
+      {
+        next: { revalidate: 1800 }, // 30分ごとに再検証
+      },
+    )
 
-    if (!response.ok) {
-      throw await APIError.fromResponse(response, '/wp-json/wp/v2/dev-notes', {
-        currentNoteId: currentNote.id,
-        categories: categories.map((c) => c.id),
-        limit,
-        lang,
-      })
-    }
-
-    const notes: WPThought[] = await response.json()
-
-    const items: BlogItem[] = notes.map((note: WPThought): BlogItem => {
+    const items: BlogItem[] = notes.map((note): BlogItem => {
       const basePath = lang === 'ja' ? '/ja/writing/dev-notes' : '/writing/dev-notes'
       const href = `${basePath}/${note.slug}`
 

--- a/src/libs/dataSources/events.ts
+++ b/src/libs/dataSources/events.ts
@@ -81,10 +81,13 @@ export const getAdjacentEvents = async (currentEvent: WPEvent): Promise<Adjacent
     // 並列で実行
     const [previousResult, nextResult] = await Promise.all([previousPromise, nextPromise])
 
-    // _fields で id/title/slug のみ取得しているため、WPEvent として返すためにキャスト
+    // _fields で id/title/slug のみ取得しているため、型安全性のためPick型を経由してキャスト
+    const previous =
+      (previousResult.items[0] as Pick<WPEvent, 'id' | 'title' | 'slug'> | undefined) ?? null
+    const next = (nextResult.items[0] as Pick<WPEvent, 'id' | 'title' | 'slug'> | undefined) ?? null
     return {
-      previous: (previousResult.items[0] as WPEvent | undefined) ?? null,
-      next: (nextResult.items[0] as WPEvent | undefined) ?? null,
+      previous: previous as WPEvent | null,
+      next: next as WPEvent | null,
     }
   } catch (error) {
     logger.error('Failed to load adjacent events', {

--- a/src/libs/dataSources/events.ts
+++ b/src/libs/dataSources/events.ts
@@ -1,48 +1,21 @@
-import { APIError } from '@/libs/errors'
 import { logger } from '@/libs/logger'
 import type { BlogItem, WPEvent } from './types'
+import { wpClient } from './wpClient'
+
+const eventsCollection = () => wpClient.postType<WPEvent>('events')
 
 export const loadWPEvents = async (): Promise<WPEvent[]> => {
   try {
-    const allEvents: WPEvent[] = []
-    let currentPage = 1
-    let totalPages = 1
-
-    // 最初のページを取得して総ページ数を確認
-    const firstResponse = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/events?page=${currentPage}&per_page=100&orderby=date&order=desc`,
+    return await eventsCollection().listAll(
+      {
+        per_page: 100,
+        orderby: 'date',
+        order: 'desc',
+      },
+      {
+        next: { revalidate: 3600 },
+      },
     )
-
-    if (!firstResponse.ok) {
-      throw await APIError.fromResponse(firstResponse, '/wp-json/wp/v2/events', {
-        page: currentPage,
-      })
-    }
-
-    const firstPageEvents: WPEvent[] = await firstResponse.json()
-    allEvents.push(...firstPageEvents)
-
-    // レスポンスヘッダーから総ページ数を取得
-    totalPages = Number.parseInt(firstResponse.headers.get('X-WP-TotalPages') || '1', 10)
-
-    // 残りのページを取得
-    while (currentPage < totalPages) {
-      currentPage++
-      const response = await fetch(
-        `https://wp-api.wp-kyoto.net/wp-json/wp/v2/events?page=${currentPage}&per_page=100&orderby=date&order=desc`,
-      )
-
-      if (!response.ok) {
-        throw await APIError.fromResponse(response, '/wp-json/wp/v2/events', {
-          page: currentPage,
-        })
-      }
-
-      const events: WPEvent[] = await response.json()
-      allEvents.push(...events)
-    }
-
-    return allEvents
   } catch (error) {
     logger.error('Failed to load WordPress events', {
       error,
@@ -53,23 +26,24 @@ export const loadWPEvents = async (): Promise<WPEvent[]> => {
 
 export const getWPEventBySlug = async (slug: string): Promise<WPEvent | null> => {
   try {
-    const response = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/events?slug=${encodeURIComponent(slug)}&_fields=id,title,date,date_gmt,modified,modified_gmt,excerpt,content,link,slug,status,type,guid,featured_media`,
-    )
-
-    if (!response.ok) {
-      throw await APIError.fromResponse(response, '/wp-json/wp/v2/events', {
-        slug,
-      })
-    }
-
-    const events: WPEvent[] = await response.json()
-
-    if (events.length === 0) {
-      return null
-    }
-
-    return events[0]
+    return await eventsCollection().getBySlug(slug, {
+      _fields: [
+        'id',
+        'title',
+        'date',
+        'date_gmt',
+        'modified',
+        'modified_gmt',
+        'excerpt',
+        'content',
+        'link',
+        'slug',
+        'status',
+        'type',
+        'guid',
+        'featured_media',
+      ],
+    })
   } catch (error) {
     logger.error('Failed to load WordPress event by slug', {
       error,
@@ -84,45 +58,33 @@ export type AdjacentEvents = {
   next: WPEvent | null
 }
 
-// WordPress APIから記事を取得するヘルパー関数
-const fetchEvent = async (url: string): Promise<WPEvent | null> => {
-  try {
-    const response = await fetch(url)
-
-    if (!response.ok) {
-      return null
-    }
-
-    const events: WPEvent[] = await response.json()
-
-    if (events.length === 0) {
-      return null
-    }
-
-    return events[0]
-  } catch (error) {
-    logger.error('Failed to fetch event', {
-      error,
-      url,
-    })
-    return null
-  }
-}
-
 export const getAdjacentEvents = async (currentEvent: WPEvent): Promise<AdjacentEvents> => {
   try {
     // 前の記事を取得（現在の記事より前の日付で最も新しいもの）
-    const previousUrl = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/events?before=${encodeURIComponent(currentEvent.date)}&per_page=1&orderby=date&order=desc&_fields=id,title,slug`
+    const previousPromise = eventsCollection().list({
+      before: currentEvent.date,
+      per_page: 1,
+      orderby: 'date',
+      order: 'desc',
+      _fields: ['id', 'title', 'slug'],
+    })
 
     // 次の記事を取得（現在の記事より後の日付で最も古いもの）
-    const nextUrl = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/events?after=${encodeURIComponent(currentEvent.date)}&per_page=1&orderby=date&order=asc&_fields=id,title,slug`
+    const nextPromise = eventsCollection().list({
+      after: currentEvent.date,
+      per_page: 1,
+      orderby: 'date',
+      order: 'asc',
+      _fields: ['id', 'title', 'slug'],
+    })
 
     // 並列で実行
-    const [previous, next] = await Promise.all([fetchEvent(previousUrl), fetchEvent(nextUrl)])
+    const [previousResult, nextResult] = await Promise.all([previousPromise, nextPromise])
 
+    // _fields で id/title/slug のみ取得しているため、WPEvent として返すためにキャスト
     return {
-      previous,
-      next,
+      previous: (previousResult.items[0] as WPEvent | undefined) ?? null,
+      next: (nextResult.items[0] as WPEvent | undefined) ?? null,
     }
   } catch (error) {
     logger.error('Failed to load adjacent events', {
@@ -148,19 +110,13 @@ export const getRelatedEvents = async (
 ): Promise<BlogItem[]> => {
   try {
     // 現在の記事を除外して最新のイベント記事を取得
-    const response = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/events?exclude=${currentEvent.id}&per_page=${limit}&orderby=date&order=desc&_fields=id,title,date,date_gmt,excerpt,slug`,
-    )
-
-    if (!response.ok) {
-      throw await APIError.fromResponse(response, '/wp-json/wp/v2/events', {
-        currentEventId: currentEvent.id,
-        limit,
-        lang,
-      })
-    }
-
-    const events: WPEvent[] = await response.json()
+    const { items: events } = await eventsCollection().list({
+      exclude: [currentEvent.id],
+      per_page: limit,
+      orderby: 'date',
+      order: 'desc',
+      _fields: ['id', 'title', 'date', 'date_gmt', 'excerpt', 'slug'],
+    })
 
     // BlogItem型に変換
     const eventBasePath = basePath || (lang === 'ja' ? '/ja/event-reports' : '/event-reports')

--- a/src/libs/dataSources/products.ts
+++ b/src/libs/dataSources/products.ts
@@ -1,6 +1,6 @@
-import { APIError } from '@/libs/errors'
 import { logger } from '@/libs/logger'
 import type { BlogItem } from './types'
+import { wpClient } from './wpClient'
 
 export type WPProduct = {
   id: number
@@ -29,6 +29,22 @@ export type ProductsResult = {
   currentPage: number
 }
 
+const productsCollection = () => wpClient.postType<WPProduct>('products')
+
+const PRODUCT_DETAIL_FIELDS = [
+  'id',
+  'title',
+  'date',
+  'date_gmt',
+  'modified',
+  'modified_gmt',
+  'excerpt',
+  'content',
+  'slug',
+  'link',
+  'featured_media',
+] as const
+
 /**
  * WordPress API から products カスタム投稿タイプを取得
  * @param page ページ番号（デフォルト: 1）
@@ -42,30 +58,26 @@ export const loadProducts = async (
   lang: 'en' | 'ja' = 'en',
 ): Promise<ProductsResult> => {
   try {
-    const response = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/products?page=${page}&per_page=${perPage}&orderby=date&order=desc&_fields=id,title,date,date_gmt,modified,modified_gmt,excerpt,content,slug,link,featured_media`,
+    const {
+      items: products,
+      total: totalItems,
+      totalPages,
+    } = await productsCollection().list(
+      {
+        page,
+        per_page: perPage,
+        orderby: 'date',
+        order: 'desc',
+        _fields: PRODUCT_DETAIL_FIELDS,
+      },
       {
         next: { revalidate: 1800 }, // 30分ごとに再検証
       },
     )
 
-    if (!response.ok) {
-      throw await APIError.fromResponse(response, '/wp-json/wp/v2/products', {
-        page,
-        perPage,
-        lang,
-      })
-    }
-
-    const products: WPProduct[] = await response.json()
-
-    // WordPress APIのレスポンスヘッダーから総件数と総ページ数を取得
-    const totalItems = Number.parseInt(response.headers.get('X-WP-Total') || '0', 10)
-    const totalPages = Number.parseInt(response.headers.get('X-WP-TotalPages') || '0', 10)
-
     // BlogItem型に変換
     const basePath = lang === 'ja' ? '/ja/news' : '/news'
-    const items: BlogItem[] = products.map((product: WPProduct): BlogItem => {
+    const items: BlogItem[] = products.map((product): BlogItem => {
       const excerptText = product.excerpt?.rendered
         ? product.excerpt.rendered.replace(/<[^>]*>/g, '').substring(0, 150)
         : ''
@@ -110,26 +122,15 @@ export const getProductBySlug = async (
   _lang: 'en' | 'ja' = 'en',
 ): Promise<WPProduct | null> => {
   try {
-    const response = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/products?slug=${slug}&_fields=id,title,date,date_gmt,modified,modified_gmt,excerpt,content,slug,link,featured_media`,
+    return await productsCollection().getBySlug(
+      slug,
+      {
+        _fields: PRODUCT_DETAIL_FIELDS,
+      },
       {
         next: { revalidate: 1800 }, // 30分ごとに再検証
       },
     )
-
-    if (!response.ok) {
-      throw await APIError.fromResponse(response, '/wp-json/wp/v2/products', {
-        slug,
-      })
-    }
-
-    const products: WPProduct[] = await response.json()
-
-    if (products.length === 0) {
-      return null
-    }
-
-    return products[0]
   } catch (error) {
     logger.error('Failed to load product by slug', {
       error,
@@ -144,30 +145,6 @@ export type AdjacentProducts = {
   next: WPProduct | null
 }
 
-// WordPress APIから記事を取得するヘルパー関数
-const fetchProduct = async (url: string): Promise<WPProduct | null> => {
-  try {
-    const response = await fetch(url, {
-      next: { revalidate: 1800 }, // 30分ごとに再検証
-    })
-    if (!response.ok) {
-      logger.error('Failed to fetch product', {
-        status: response.status,
-        url,
-      })
-      return null
-    }
-    const products: WPProduct[] = await response.json()
-    return products.length > 0 ? products[0] : null
-  } catch (error) {
-    logger.error('Failed to fetch product', {
-      error,
-      url,
-    })
-    return null
-  }
-}
-
 /**
  * 前後の製品ニュース記事を取得
  * @param currentProduct 現在の記事
@@ -176,17 +153,39 @@ const fetchProduct = async (url: string): Promise<WPProduct | null> => {
 export const getAdjacentProducts = async (currentProduct: WPProduct): Promise<AdjacentProducts> => {
   try {
     // 前の記事を取得（現在の記事より前の日付で最も新しいもの）
-    const previousUrl = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/products?before=${encodeURIComponent(currentProduct.date)}&per_page=1&orderby=date&order=desc&_fields=id,title,date,date_gmt,modified,modified_gmt,excerpt,content,slug,link,featured_media`
+    const previousPromise = productsCollection().list(
+      {
+        before: currentProduct.date,
+        per_page: 1,
+        orderby: 'date',
+        order: 'desc',
+        _fields: PRODUCT_DETAIL_FIELDS,
+      },
+      {
+        next: { revalidate: 1800 }, // 30分ごとに再検証
+      },
+    )
 
     // 次の記事を取得（現在の記事より後の日付で最も古いもの）
-    const nextUrl = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/products?after=${encodeURIComponent(currentProduct.date)}&per_page=1&orderby=date&order=asc&_fields=id,title,date,date_gmt,modified,modified_gmt,excerpt,content,slug,link,featured_media`
+    const nextPromise = productsCollection().list(
+      {
+        after: currentProduct.date,
+        per_page: 1,
+        orderby: 'date',
+        order: 'asc',
+        _fields: PRODUCT_DETAIL_FIELDS,
+      },
+      {
+        next: { revalidate: 1800 }, // 30分ごとに再検証
+      },
+    )
 
     // 並列で実行
-    const [previous, next] = await Promise.all([fetchProduct(previousUrl), fetchProduct(nextUrl)])
+    const [previousResult, nextResult] = await Promise.all([previousPromise, nextPromise])
 
     return {
-      previous,
-      next,
+      previous: previousResult.items[0] ?? null,
+      next: nextResult.items[0] ?? null,
     }
   } catch (error) {
     logger.error('Failed to load adjacent products', {
@@ -215,26 +214,22 @@ export const getRelatedProducts = async (
   try {
     // 現在の記事を除外して最新記事を取得
     const fetchLimit = Math.max(limit * 2, 10) // 最低10件、limitの2倍まで
-    const response = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/products?exclude=${currentProduct.id}&per_page=${fetchLimit}&orderby=date&order=desc&_fields=id,title,date,date_gmt,excerpt,slug,link`,
+    const { items: products } = await productsCollection().list(
+      {
+        exclude: [currentProduct.id],
+        per_page: fetchLimit,
+        orderby: 'date',
+        order: 'desc',
+        _fields: ['id', 'title', 'date', 'date_gmt', 'excerpt', 'slug', 'link'],
+      },
       {
         next: { revalidate: 1800 }, // 30分ごとに再検証
       },
     )
 
-    if (!response.ok) {
-      throw await APIError.fromResponse(response, '/wp-json/wp/v2/products', {
-        currentProductId: currentProduct.id,
-        limit,
-        lang,
-      })
-    }
-
-    const products: WPProduct[] = await response.json()
-
     // BlogItem型に変換
     const basePath = lang === 'ja' ? '/ja/news' : '/news'
-    const items: BlogItem[] = products.map((product: WPProduct): BlogItem => {
+    const items: BlogItem[] = products.map((product): BlogItem => {
       const excerptText = product.excerpt?.rendered
         ? product.excerpt.rendered.replace(/<[^>]*>/g, '').substring(0, 150)
         : ''
@@ -272,51 +267,19 @@ export const getRelatedProducts = async (
  */
 export const loadAllProducts = async (): Promise<WPProduct[]> => {
   try {
-    const allProducts: WPProduct[] = []
-    let currentPage = 1
-    let totalPages = 1
-
-    // 最初のページを取得して総ページ数を確認
-    const firstResponse = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/products?page=${currentPage}&per_page=100&orderby=date&order=desc&_fields=id,title,date,modified,slug`,
+    // sitemap 用途のため id/title/date/modified/slug のみ取得し、WPProduct[] としてキャスト
+    const products = await productsCollection().listAll(
+      {
+        per_page: 100,
+        orderby: 'date',
+        order: 'desc',
+        _fields: ['id', 'title', 'date', 'modified', 'slug'],
+      },
       {
         next: { revalidate: 3600 }, // 1時間ごとに再検証
       },
     )
-
-    if (!firstResponse.ok) {
-      throw await APIError.fromResponse(firstResponse, '/wp-json/wp/v2/products', {
-        page: currentPage,
-      })
-    }
-
-    const firstPageProducts: WPProduct[] = await firstResponse.json()
-    allProducts.push(...firstPageProducts)
-
-    // レスポンスヘッダーから総ページ数を取得
-    totalPages = Number.parseInt(firstResponse.headers.get('X-WP-TotalPages') || '1', 10)
-
-    // 残りのページを取得
-    while (currentPage < totalPages) {
-      currentPage++
-      const response = await fetch(
-        `https://wp-api.wp-kyoto.net/wp-json/wp/v2/products?page=${currentPage}&per_page=100&orderby=date&order=desc&_fields=id,title,date,modified,slug`,
-        {
-          next: { revalidate: 3600 }, // 1時間ごとに再検証
-        },
-      )
-
-      if (!response.ok) {
-        throw await APIError.fromResponse(response, '/wp-json/wp/v2/products', {
-          page: currentPage,
-        })
-      }
-
-      const products: WPProduct[] = await response.json()
-      allProducts.push(...products)
-    }
-
-    return allProducts
+    return products as unknown as WPProduct[]
   } catch (error) {
     logger.error('Failed to load all products', {
       error,

--- a/src/libs/dataSources/thoughts.ts
+++ b/src/libs/dataSources/thoughts.ts
@@ -390,10 +390,14 @@ export const getAdjacentThoughts = async (
     // 並列で実行
     const [previousResult, nextResult] = await Promise.all([previousPromise, nextPromise])
 
-    // _fields で id/title/slug のみ取得しているため、WPThought として返すためにキャスト
+    // _fields で id/title/slug のみ取得しているため、型安全性のためPick型を経由してキャスト
+    const previous =
+      (previousResult.items[0] as Pick<WPThought, 'id' | 'title' | 'slug'> | undefined) ?? null
+    const next =
+      (nextResult.items[0] as Pick<WPThought, 'id' | 'title' | 'slug'> | undefined) ?? null
     return {
-      previous: (previousResult.items[0] as WPThought | undefined) ?? null,
-      next: (nextResult.items[0] as WPThought | undefined) ?? null,
+      previous: previous as WPThought | null,
+      next: next as WPThought | null,
     }
   } catch (error) {
     logger.error('Failed to load adjacent thoughts', {

--- a/src/libs/dataSources/thoughts.ts
+++ b/src/libs/dataSources/thoughts.ts
@@ -1,6 +1,6 @@
-import { APIError } from '@/libs/errors'
 import { logger } from '@/libs/logger'
 import type { BlogItem, Category, WPThought } from './types'
+import { wpClient } from './wpClient'
 
 export type ThoughtsResult = {
   items: BlogItem[]
@@ -9,8 +9,39 @@ export type ThoughtsResult = {
   currentPage: number
 }
 
+// thoughs カスタム投稿タイプ（スペルは "thoughs" のまま）
+const thoughtsCollection = () => wpClient.postType<WPThought>('thoughs')
+
+const THOUGHT_LIST_FIELDS = [
+  '_links.wp:term',
+  '_embedded',
+  'id',
+  'title',
+  'date',
+  'date_gmt',
+  'excerpt',
+  'slug',
+  'link',
+  'categories',
+] as const
+
+// _embedded.wp:term のみを参照する最小限の入力型
+// （node-wp-api-client が _fields 指定で返す絞り込み型でも受け取れるようにするため）
+type EmbeddedTermSource = {
+  _embedded?: {
+    'wp:term'?: ReadonlyArray<
+      ReadonlyArray<{
+        id: number
+        name: string
+        slug: string
+        taxonomy: string
+      }>
+    >
+  }
+}
+
 // カテゴリ情報を抽出するヘルパー関数
-const extractCategories = (thought: WPThought): Category[] => {
+const extractCategories = (thought: EmbeddedTermSource): Category[] => {
   if (!thought._embedded?.['wp:term']) {
     return []
   }
@@ -50,29 +81,24 @@ export const loadThoughts = async (
 
   try {
     // _embedと_fieldsを組み合わせてカテゴリ情報を取得
-    const response = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/thoughs?page=${page}&per_page=${perPage}&_embed=wp:term&_fields=_links.wp:term,_embedded,id,title,date,date_gmt,excerpt,slug,link,categories`,
+    const {
+      items: thoughts,
+      total: totalItems,
+      totalPages,
+    } = await thoughtsCollection().list(
+      {
+        page,
+        per_page: perPage,
+        _embed: 'wp:term',
+        _fields: THOUGHT_LIST_FIELDS,
+      },
       {
         next: { revalidate: 1800 }, // 30分ごとに再検証（毎日1〜2記事更新）
       },
     )
 
-    if (!response.ok) {
-      throw await APIError.fromResponse(response, '/wp-json/wp/v2/thoughs', {
-        page,
-        perPage,
-        lang,
-      })
-    }
-
-    const thoughts: WPThought[] = await response.json()
-
-    // WordPress APIのレスポンスヘッダーから総件数と総ページ数を取得
-    const totalItems = parseInt(response.headers.get('X-WP-Total') || '0', 10)
-    const totalPages = parseInt(response.headers.get('X-WP-TotalPages') || '0', 10)
-
     // BlogItem型に変換
-    const items: BlogItem[] = thoughts.map((thought: WPThought): BlogItem => {
+    const items: BlogItem[] = thoughts.map((thought): BlogItem => {
       const basePath = '/ja/blog'
       const href = `${basePath}/${thought.slug}`
 
@@ -136,21 +162,14 @@ export const loadThoughtsByCategory = async (
     }
 
     // WordPress APIのcategoriesエンドポイントでslugからIDを取得
-    const categoryResponse = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/categories?slug=${encodeURIComponent(normalizedCategorySlug)}`,
+    const { items: categories } = await wpClient.categories.list(
+      {
+        slug: normalizedCategorySlug,
+      },
       {
         next: { revalidate: 1800 }, // 30分ごとに再検証
       },
     )
-
-    if (!categoryResponse.ok) {
-      throw await APIError.fromResponse(categoryResponse, '/wp-json/wp/v2/categories', {
-        categorySlug: normalizedCategorySlug,
-        lang,
-      })
-    }
-
-    const categories = await categoryResponse.json()
 
     if (categories.length === 0) {
       // カテゴリが見つからない場合は空の結果を返す
@@ -165,30 +184,25 @@ export const loadThoughtsByCategory = async (
     const categoryId = categories[0].id
 
     // WordPress APIのcategoriesパラメータでフィルタリング
-    const response = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/thoughs?categories=${categoryId}&page=${page}&per_page=${perPage}&_embed=wp:term&_fields=_links.wp:term,_embedded,id,title,date,date_gmt,excerpt,slug,link,categories`,
+    const {
+      items: thoughts,
+      total: totalItems,
+      totalPages,
+    } = await thoughtsCollection().list(
+      {
+        categories: categoryId,
+        page,
+        per_page: perPage,
+        _embed: 'wp:term',
+        _fields: THOUGHT_LIST_FIELDS,
+      },
       {
         next: { revalidate: 1800 }, // 30分ごとに再検証
       },
     )
 
-    if (!response.ok) {
-      throw await APIError.fromResponse(response, '/wp-json/wp/v2/thoughs', {
-        categoryId,
-        page,
-        perPage,
-        lang,
-      })
-    }
-
-    const thoughts: WPThought[] = await response.json()
-
-    // WordPress APIのレスポンスヘッダーから総件数と総ページ数を取得
-    const totalItems = parseInt(response.headers.get('X-WP-Total') || '0', 10)
-    const totalPages = parseInt(response.headers.get('X-WP-TotalPages') || '0', 10)
-
     // BlogItem型に変換
-    const items: BlogItem[] = thoughts.map((thought: WPThought): BlogItem => {
+    const items: BlogItem[] = thoughts.map((thought): BlogItem => {
       const basePath = '/ja/blog'
       const href = `${basePath}/${thought.slug}`
 
@@ -238,20 +252,16 @@ export const loadAllCategories = async (lang: 'en' | 'ja' = 'en'): Promise<Categ
   try {
     // 十分な数の記事を取得してカテゴリを抽出
     const fetchPerPage = 100
-    const response = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/thoughs?per_page=${fetchPerPage}&_embed=wp:term&_fields=_links.wp:term,_embedded,id,title,date,date_gmt,excerpt,slug,link,categories`,
+    const { items: thoughts } = await thoughtsCollection().list(
+      {
+        per_page: fetchPerPage,
+        _embed: 'wp:term',
+        _fields: THOUGHT_LIST_FIELDS,
+      },
       {
         next: { revalidate: 1800 }, // 30分ごとに再検証
       },
     )
-
-    if (!response.ok) {
-      throw await APIError.fromResponse(response, '/wp-json/wp/v2/thoughs', {
-        lang,
-      })
-    }
-
-    const thoughts: WPThought[] = await response.json()
 
     // カテゴリを集計
     const categoryMap = new Map<string, CategoryWithCount>()
@@ -296,27 +306,30 @@ export const getThoughtBySlug = async (
 
   try {
     // _embedと_fieldsを組み合わせてカテゴリ情報を取得
-    const response = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/thoughs?slug=${encodeURIComponent(slug)}&_embed=wp:term&_fields=_links.wp:term,_embedded,id,title,date,date_gmt,excerpt,content,slug,link,categories`,
+    return await thoughtsCollection().getBySlug(
+      slug,
+      {
+        _embed: 'wp:term',
+        _fields: [
+          '_links.wp:term',
+          '_embedded',
+          'id',
+          'title',
+          'date',
+          'date_gmt',
+          'modified',
+          'modified_gmt',
+          'excerpt',
+          'content',
+          'slug',
+          'link',
+          'categories',
+        ],
+      },
       {
         next: { revalidate: 1800 }, // 30分ごとに再検証
       },
     )
-
-    if (!response.ok) {
-      throw await APIError.fromResponse(response, '/wp-json/wp/v2/thoughs', {
-        slug,
-        lang,
-      })
-    }
-
-    const thoughts: WPThought[] = await response.json()
-
-    if (thoughts.length === 0) {
-      return null
-    }
-
-    return thoughts[0]
   } catch (error) {
     logger.error('Failed to load thought by slug', {
       error,
@@ -330,30 +343,6 @@ export const getThoughtBySlug = async (
 export type AdjacentThoughts = {
   previous: WPThought | null
   next: WPThought | null
-}
-
-// WordPress APIから記事を取得するヘルパー関数
-const fetchThought = async (url: string): Promise<WPThought | null> => {
-  try {
-    const response = await fetch(url, {
-      next: { revalidate: 1800 }, // 30分ごとに再検証
-    })
-    if (!response.ok) {
-      logger.error('Failed to fetch thought', {
-        status: response.status,
-        url,
-      })
-      return null
-    }
-    const thoughts: WPThought[] = await response.json()
-    return thoughts.length > 0 ? thoughts[0] : null
-  } catch (error) {
-    logger.error('Failed to fetch thought', {
-      error,
-      url,
-    })
-    return null
-  }
 }
 
 // 前後の記事を取得
@@ -371,17 +360,40 @@ export const getAdjacentThoughts = async (
 
   try {
     // 前の記事を取得（現在の記事より前の日付で最も新しいもの）
-    const previousUrl = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/thoughs?before=${encodeURIComponent(currentThought.date)}&per_page=1&orderby=date&order=desc&_fields=id,title,slug`
+    const previousPromise = thoughtsCollection().list(
+      {
+        before: currentThought.date,
+        per_page: 1,
+        orderby: 'date',
+        order: 'desc',
+        _fields: ['id', 'title', 'slug'],
+      },
+      {
+        next: { revalidate: 1800 }, // 30分ごとに再検証
+      },
+    )
 
     // 次の記事を取得（現在の記事より後の日付で最も古いもの）
-    const nextUrl = `https://wp-api.wp-kyoto.net/wp-json/wp/v2/thoughs?after=${encodeURIComponent(currentThought.date)}&per_page=1&orderby=date&order=asc&_fields=id,title,slug`
+    const nextPromise = thoughtsCollection().list(
+      {
+        after: currentThought.date,
+        per_page: 1,
+        orderby: 'date',
+        order: 'asc',
+        _fields: ['id', 'title', 'slug'],
+      },
+      {
+        next: { revalidate: 1800 }, // 30分ごとに再検証
+      },
+    )
 
     // 並列で実行
-    const [previous, next] = await Promise.all([fetchThought(previousUrl), fetchThought(nextUrl)])
+    const [previousResult, nextResult] = await Promise.all([previousPromise, nextPromise])
 
+    // _fields で id/title/slug のみ取得しているため、WPThought として返すためにキャスト
     return {
-      previous,
-      next,
+      previous: (previousResult.items[0] as WPThought | undefined) ?? null,
+      next: (nextResult.items[0] as WPThought | undefined) ?? null,
     }
   } catch (error) {
     logger.error('Failed to load adjacent thoughts', {
@@ -458,26 +470,21 @@ export const getRelatedThoughts = async (
 
     // 同じカテゴリの記事を10件取得（現在の記事を除外）
     const fetchLimit = Math.max(limit * 2.5, 10) // 最低10件、limitの2.5倍まで
-    const response = await fetch(
-      `https://wp-api.wp-kyoto.net/wp-json/wp/v2/thoughs?categories=${categoryId}&exclude=${currentThought.id}&per_page=${fetchLimit}&_embed=wp:term&_fields=_links.wp:term,_embedded,id,title,date,date_gmt,excerpt,slug,link,categories`,
+    const { items: thoughts } = await thoughtsCollection().list(
+      {
+        categories: categoryId,
+        exclude: [currentThought.id],
+        per_page: fetchLimit,
+        _embed: 'wp:term',
+        _fields: THOUGHT_LIST_FIELDS,
+      },
       {
         next: { revalidate: 1800 }, // 30分ごとに再検証
       },
     )
 
-    if (!response.ok) {
-      throw await APIError.fromResponse(response, '/wp-json/wp/v2/thoughs', {
-        categoryId,
-        currentThoughtId: currentThought.id,
-        limit,
-        lang,
-      })
-    }
-
-    const thoughts: WPThought[] = await response.json()
-
     // BlogItem型に変換
-    const items: BlogItem[] = thoughts.map((thought: WPThought): BlogItem => {
+    const items: BlogItem[] = thoughts.map((thought): BlogItem => {
       const basePath = '/ja/blog'
       const href = `${basePath}/${thought.slug}`
 

--- a/src/libs/dataSources/types.ts
+++ b/src/libs/dataSources/types.ts
@@ -80,6 +80,7 @@ export type WPThought = {
   slug: string
   featured_media?: number
   categories?: number[]
+  _links?: Record<string, unknown>
   _embedded?: {
     'wp:term'?: Array<
       Array<{

--- a/src/libs/dataSources/wordpress.ts
+++ b/src/libs/dataSources/wordpress.ts
@@ -1,4 +1,5 @@
 import type { FeedDataSource, FeedItem, WPPost } from './types'
+import { wpClient } from './wpClient'
 
 export const loadWPPosts = async (
   locale: 'en' | 'ja',
@@ -13,16 +14,17 @@ export const loadWPPosts = async (
   // limit + 1件取得して、さらに記事があるかどうかを判定（WP REST APIのper_page上限は100）
   // after を渡すとその日時以降の記事のみ取得し、過剰なデータ取得を避ける
   const perPage = Math.min(limit + 1, 100)
-  const afterParam = after ? `&after=${encodeURIComponent(after)}` : ''
-  const response = await fetch(
-    `https://wp-api.wp-kyoto.net/wp-json/wp/v2/posts?filter[lang]=${locale}&per_page=${perPage}${afterParam}`,
+  const { items: posts, totalPages } = await wpClient.postType<WPPost>('posts').list(
+    {
+      'filter[lang]': locale,
+      per_page: perPage,
+      ...(after ? { after } : {}),
+    },
     {
       next: { revalidate: 1800 }, // 30分ごとに再検証（毎日1〜2記事更新）
     },
   )
-  const posts: WPPost[] = await response.json()
-  const totalPages = response.headers.get('X-WP-TotalPages')
-  const hasMore = totalPages ? Number.parseInt(totalPages, 10) > 1 : false
+  const hasMore = totalPages > 1
   const items = posts.slice(0, limit).map(
     (post: WPPost): FeedItem => ({
       title: post.title.rendered,

--- a/src/libs/dataSources/wpClient.ts
+++ b/src/libs/dataSources/wpClient.ts
@@ -1,0 +1,10 @@
+import { createWPClient } from 'node-wp-api-client'
+
+/**
+ * WordPress REST API クライアント（共通インスタンス）
+ * wp-kyoto.net の WordPress REST API へアクセスするための共有クライアント。
+ * namespace は wp/v2 がデフォルト。
+ */
+export const wpClient = createWPClient({
+  baseUrl: 'https://wp-api.wp-kyoto.net',
+})

--- a/src/libs/hooks/useDialogA11y.component.test.tsx
+++ b/src/libs/hooks/useDialogA11y.component.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { useDialogA11y } from './useDialogA11y'
+
+function TestDialog({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  const dialogRef = useDialogA11y<HTMLDivElement>(isOpen, onClose)
+
+  if (!isOpen) return null
+
+  return (
+    <div ref={dialogRef} role="dialog" aria-modal="true" aria-label="Test dialog">
+      <button type="button">First</button>
+      <button type="button">Second</button>
+      <button type="button">Last</button>
+    </div>
+  )
+}
+
+function TestApp() {
+  const [isOpen, setIsOpen] = useState(false)
+  return (
+    <>
+      <button type="button" onClick={() => setIsOpen(true)}>
+        Toggle
+      </button>
+      <TestDialog isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </>
+  )
+}
+
+describe('useDialogA11y', () => {
+  it('開時に最初のフォーカス可能要素へフォーカスを移動する', () => {
+    render(<TestApp />)
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle' }))
+
+    expect(screen.getByRole('button', { name: 'First' })).toHaveFocus()
+  })
+
+  it('Escape キーで onClose を呼び出す', () => {
+    const onClose = vi.fn()
+    render(<TestDialog isOpen={true} onClose={onClose} />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('閉じている間はキーボードイベントを処理しない', () => {
+    const onClose = vi.fn()
+    render(<TestDialog isOpen={false} onClose={onClose} />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('Tab で最後の要素から最初の要素へフォーカスをラップする', () => {
+    render(<TestDialog isOpen={true} onClose={() => {}} />)
+
+    screen.getByRole('button', { name: 'Last' }).focus()
+    fireEvent.keyDown(document, { key: 'Tab' })
+
+    expect(screen.getByRole('button', { name: 'First' })).toHaveFocus()
+  })
+
+  it('Shift+Tab で最初の要素から最後の要素へフォーカスをラップする', () => {
+    render(<TestDialog isOpen={true} onClose={() => {}} />)
+
+    screen.getByRole('button', { name: 'First' }).focus()
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+
+    expect(screen.getByRole('button', { name: 'Last' })).toHaveFocus()
+  })
+
+  it('閉時に開く前にフォーカスされていた要素へフォーカスを復元する', () => {
+    render(<TestApp />)
+    const toggle = screen.getByRole('button', { name: 'Toggle' })
+
+    toggle.focus()
+    fireEvent.click(toggle)
+    expect(screen.getByRole('button', { name: 'First' })).toHaveFocus()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(toggle).toHaveFocus()
+  })
+})

--- a/src/libs/hooks/useDialogA11y.ts
+++ b/src/libs/hooks/useDialogA11y.ts
@@ -79,16 +79,32 @@ export function useDialogA11y<T extends HTMLElement = HTMLDivElement>(
       const first = elements[0]
       const last = elements[elements.length - 1]
       const active = document.activeElement
-      const isInside = active instanceof HTMLElement && dialogRef.current?.contains(active)
+      // ダイアログ内であっても tabindex="-1" の要素(パネル自身など)に
+      // フォーカスがある場合は active が elements に含まれないため、
+      // 前後にフォーカス可能要素が存在するかを文書順で判定してラップする
+      const activeInDialog =
+        active instanceof HTMLElement && dialogRef.current?.contains(active) ? active : null
 
       if (event.shiftKey) {
-        if (!isInside || active === first) {
+        const hasFocusableBefore = elements.some(
+          (el) =>
+            activeInDialog !== null &&
+            (el.compareDocumentPosition(activeInDialog) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0,
+        )
+        if (!hasFocusableBefore) {
           event.preventDefault()
           last.focus()
         }
-      } else if (!isInside || active === last) {
-        event.preventDefault()
-        first.focus()
+      } else {
+        const hasFocusableAfter = elements.some(
+          (el) =>
+            activeInDialog !== null &&
+            (el.compareDocumentPosition(activeInDialog) & Node.DOCUMENT_POSITION_PRECEDING) !== 0,
+        )
+        if (!hasFocusableAfter) {
+          event.preventDefault()
+          first.focus()
+        }
       }
     }
 

--- a/src/libs/hooks/useDialogA11y.ts
+++ b/src/libs/hooks/useDialogA11y.ts
@@ -1,0 +1,105 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ')
+
+/**
+ * ダイアログ内のフォーカス可能な要素を取得する。
+ *
+ * @param container - 検索対象のコンテナ要素
+ * @returns フォーカス可能な要素の配列(コンテナが無い場合は空配列)
+ */
+export function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return []
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+}
+
+/**
+ * モーダルダイアログのアクセシビリティ挙動を提供するフック。
+ *
+ * - 開時: 直前のフォーカス要素を記憶し、ダイアログ内の最初のフォーカス可能要素へフォーカスを移動する
+ * - 開いている間: Tab / Shift+Tab のフォーカスをダイアログ内でラップ(フォーカストラップ)する
+ * - Escape キーで `onClose` を呼び出す
+ * - 閉時(アンマウント/`isOpen` が false になった時): 開く前にフォーカスされていた要素へフォーカスを復元する
+ *
+ * 返り値の ref をダイアログのパネル要素(`role="dialog"` を付与した要素)に設定して使用する。
+ *
+ * @param isOpen - ダイアログが開いているかどうか
+ * @param onClose - ダイアログを閉じることを要求する際に呼び出されるコールバック
+ * @returns ダイアログパネル要素に設定する ref
+ */
+export function useDialogA11y<T extends HTMLElement = HTMLDivElement>(
+  isOpen: boolean,
+  onClose: () => void,
+) {
+  const dialogRef = useRef<T>(null)
+  const onCloseRef = useRef(onClose)
+
+  useEffect(() => {
+    onCloseRef.current = onClose
+  }, [onClose])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const previousFocus =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null
+
+    // 開時に最初のフォーカス可能要素へフォーカスを移動
+    const focusables = getFocusableElements(dialogRef.current)
+    if (focusables.length > 0) {
+      focusables[0].focus()
+    } else {
+      dialogRef.current?.focus()
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onCloseRef.current()
+        return
+      }
+
+      if (event.key !== 'Tab') return
+
+      const elements = getFocusableElements(dialogRef.current)
+      if (elements.length === 0) {
+        event.preventDefault()
+        return
+      }
+
+      const first = elements[0]
+      const last = elements[elements.length - 1]
+      const active = document.activeElement
+      const isInside = active instanceof HTMLElement && dialogRef.current?.contains(active)
+
+      if (event.shiftKey) {
+        if (!isInside || active === first) {
+          event.preventDefault()
+          last.focus()
+        }
+      } else if (!isInside || active === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      // 閉時にトグルボタンなど元の要素へフォーカスを復元
+      previousFocus?.focus()
+    }
+  }, [isOpen])
+
+  return dialogRef
+}

--- a/src/libs/metadata.test.ts
+++ b/src/libs/metadata.test.ts
@@ -109,7 +109,8 @@ describe('generateDevNoteMetadata', () => {
     )
   })
 
-  it('should use custom site URL from environment variable', () => {
+  it('should use SITE_CONFIG.url even when NEXT_PUBLIC_SITE_URL is set', () => {
+    // canonicalやog:urlはSITE_CONFIG.url基準のため、og:imageも同じ正本に揃える
     process.env.NEXT_PUBLIC_SITE_URL = 'https://custom.example.com'
 
     const note = createMockWPThought({
@@ -119,7 +120,7 @@ describe('generateDevNoteMetadata', () => {
     const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
     expect(result.openGraph?.images?.[0]?.url).toBe(
-      'https://custom.example.com/api/thumbnail/dev-notes/111',
+      'https://hidetaka.dev/api/thumbnail/dev-notes/111',
     )
   })
 
@@ -284,7 +285,8 @@ describe('generateBlogPostMetadata', () => {
     )
   })
 
-  it('should use custom site URL from environment variable', () => {
+  it('should use SITE_CONFIG.url even when NEXT_PUBLIC_SITE_URL is set', () => {
+    // canonicalやog:urlはSITE_CONFIG.url基準のため、og:imageも同じ正本に揃える
     process.env.NEXT_PUBLIC_SITE_URL = 'https://custom.example.com'
 
     const thought = createMockWPThought({
@@ -294,7 +296,7 @@ describe('generateBlogPostMetadata', () => {
     const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
     expect(result.openGraph?.images?.[0]?.url).toBe(
-      'https://custom.example.com/api/thumbnail/thoughts/111',
+      'https://hidetaka.dev/api/thumbnail/thoughts/111',
     )
   })
 

--- a/src/libs/metadata.test.ts
+++ b/src/libs/metadata.test.ts
@@ -133,6 +133,88 @@ describe('generateDevNoteMetadata', () => {
     expect(result.twitter?.images).toHaveLength(1)
     expect(result.twitter?.images?.[0]).toBe('https://hidetaka.dev/api/thumbnail/dev-notes/123')
   })
+
+  describe('description', () => {
+    it('should generate a description from the excerpt', () => {
+      const note = createMockWPThought({
+        excerpt: { rendered: '<p>This is a useful summary of the note.</p>' },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBe('This is a useful summary of the note.')
+      expect(result.openGraph?.description).toBe('This is a useful summary of the note.')
+      expect(result.twitter?.description).toBe('This is a useful summary of the note.')
+    })
+
+    it('should strip HTML tags from the description', () => {
+      const note = createMockWPThought({
+        excerpt: { rendered: '<p>Hello <strong>world</strong> from <a href="#">here</a>.</p>' },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBe('Hello world from here.')
+      expect(result.description).not.toMatch(/<[^>]*>/)
+    })
+
+    it('should normalize whitespace in the description', () => {
+      const note = createMockWPThought({
+        excerpt: { rendered: '<p>Multiple   spaces\n\nand newlines</p>' },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBe('Multiple spaces and newlines')
+    })
+
+    it('should truncate the description to roughly 120 characters', () => {
+      const longText = 'A'.repeat(300)
+      const note = createMockWPThought({
+        excerpt: { rendered: `<p>${longText}</p>` },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBeDefined()
+      expect((result.description as string).length).toBeLessThanOrEqual(123)
+    })
+
+    it('should fall back to content when the excerpt is empty', () => {
+      const note = createMockWPThought({
+        excerpt: { rendered: '' },
+        content: { rendered: '<p>Fallback content body.</p>' },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBe('Fallback content body.')
+    })
+
+    it('should fall back to the title when excerpt and content are empty', () => {
+      const note = createMockWPThought({
+        title: { rendered: 'Only Title Available' },
+        excerpt: { rendered: '' },
+        content: { rendered: '' },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBe('Only Title Available')
+    })
+
+    it('should never produce an empty string description', () => {
+      const note = createMockWPThought({
+        title: { rendered: 'Some Title' },
+        excerpt: { rendered: '<p>   </p>' },
+        content: { rendered: '<p></p>' },
+      })
+
+      const result = generateDevNoteMetadata(note)
+
+      expect(result.description).toBeTruthy()
+    })
+  })
 })
 
 describe('generateBlogPostMetadata', () => {
@@ -236,6 +318,88 @@ describe('generateBlogPostMetadata', () => {
 
     expect(result1.openGraph?.images?.[0]?.url).toContain('/thoughts/1')
     expect(result2.openGraph?.images?.[0]?.url).toContain('/thoughts/2')
+  })
+
+  describe('description', () => {
+    it('should generate a description from the excerpt', () => {
+      const thought = createMockWPThought({
+        excerpt: { rendered: '<p>This is a useful summary of the post.</p>' },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBe('This is a useful summary of the post.')
+      expect(result.openGraph?.description).toBe('This is a useful summary of the post.')
+      expect(result.twitter?.description).toBe('This is a useful summary of the post.')
+    })
+
+    it('should strip HTML tags from the description', () => {
+      const thought = createMockWPThought({
+        excerpt: { rendered: '<p>Hello <strong>world</strong> from <a href="#">here</a>.</p>' },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBe('Hello world from here.')
+      expect(result.description).not.toMatch(/<[^>]*>/)
+    })
+
+    it('should normalize whitespace in the description', () => {
+      const thought = createMockWPThought({
+        excerpt: { rendered: '<p>Multiple   spaces\n\nand newlines</p>' },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBe('Multiple spaces and newlines')
+    })
+
+    it('should truncate the description to roughly 120 characters', () => {
+      const longText = 'A'.repeat(300)
+      const thought = createMockWPThought({
+        excerpt: { rendered: `<p>${longText}</p>` },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBeDefined()
+      expect((result.description as string).length).toBeLessThanOrEqual(123)
+    })
+
+    it('should fall back to content when the excerpt is empty', () => {
+      const thought = createMockWPThought({
+        excerpt: { rendered: '' },
+        content: { rendered: '<p>Fallback content body.</p>' },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBe('Fallback content body.')
+    })
+
+    it('should fall back to the title when excerpt and content are empty', () => {
+      const thought = createMockWPThought({
+        title: { rendered: 'Only Title Available' },
+        excerpt: { rendered: '' },
+        content: { rendered: '' },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBe('Only Title Available')
+    })
+
+    it('should never produce an empty string description', () => {
+      const thought = createMockWPThought({
+        title: { rendered: 'Some Title' },
+        excerpt: { rendered: '<p>   </p>' },
+        content: { rendered: '<p></p>' },
+      })
+
+      const result = generateBlogPostMetadata(thought)
+
+      expect(result.description).toBeTruthy()
+    })
   })
 })
 

--- a/src/libs/metadata.test.ts
+++ b/src/libs/metadata.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { WPThought } from './dataSources/types'
 import {
+  buildAlternates,
   generateBlogPostMetadata,
   generateDevNoteMetadata,
   generateProjectMetadata,
+  getOpenGraphLocale,
 } from './metadata'
 import type { MicroCMSProjectsRecord } from './microCMS/types'
 
@@ -64,7 +66,7 @@ describe('generateDevNoteMetadata', () => {
       date: '2024-07-01T12:00:00',
     })
 
-    const result = generateDevNoteMetadata(note)
+    const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
     expect(result.title).toBe('Test Dev Note')
     expect(result.openGraph).toBeDefined()
@@ -81,7 +83,7 @@ describe('generateDevNoteMetadata', () => {
       id: 789,
     })
 
-    const result = generateDevNoteMetadata(note)
+    const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
     expect(result.openGraph?.images).toBeDefined()
     expect(result.openGraph?.images).toHaveLength(1)
@@ -100,7 +102,7 @@ describe('generateDevNoteMetadata', () => {
       id: 999,
     })
 
-    const result = generateDevNoteMetadata(note)
+    const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
     expect(result.openGraph?.images?.[0]?.url).toBe(
       'https://hidetaka.dev/api/thumbnail/dev-notes/999',
@@ -114,7 +116,7 @@ describe('generateDevNoteMetadata', () => {
       id: 111,
     })
 
-    const result = generateDevNoteMetadata(note)
+    const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
     expect(result.openGraph?.images?.[0]?.url).toBe(
       'https://custom.example.com/api/thumbnail/dev-notes/111',
@@ -126,7 +128,7 @@ describe('generateDevNoteMetadata', () => {
       title: { rendered: 'My Custom Title' },
     })
 
-    const result = generateDevNoteMetadata(note)
+    const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
     expect(result.twitter?.title).toBe('My Custom Title')
     expect(result.twitter?.images).toBeDefined()
@@ -140,7 +142,7 @@ describe('generateDevNoteMetadata', () => {
         excerpt: { rendered: '<p>This is a useful summary of the note.</p>' },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBe('This is a useful summary of the note.')
       expect(result.openGraph?.description).toBe('This is a useful summary of the note.')
@@ -152,7 +154,7 @@ describe('generateDevNoteMetadata', () => {
         excerpt: { rendered: '<p>Hello <strong>world</strong> from <a href="#">here</a>.</p>' },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBe('Hello world from here.')
       expect(result.description).not.toMatch(/<[^>]*>/)
@@ -163,7 +165,7 @@ describe('generateDevNoteMetadata', () => {
         excerpt: { rendered: '<p>Multiple   spaces\n\nand newlines</p>' },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBe('Multiple spaces and newlines')
     })
@@ -174,7 +176,7 @@ describe('generateDevNoteMetadata', () => {
         excerpt: { rendered: `<p>${longText}</p>` },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBeDefined()
       expect((result.description as string).length).toBeLessThanOrEqual(123)
@@ -186,7 +188,7 @@ describe('generateDevNoteMetadata', () => {
         content: { rendered: '<p>Fallback content body.</p>' },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBe('Fallback content body.')
     })
@@ -198,7 +200,7 @@ describe('generateDevNoteMetadata', () => {
         content: { rendered: '' },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBe('Only Title Available')
     })
@@ -210,7 +212,7 @@ describe('generateDevNoteMetadata', () => {
         content: { rendered: '<p></p>' },
       })
 
-      const result = generateDevNoteMetadata(note)
+      const result = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
 
       expect(result.description).toBeTruthy()
     })
@@ -239,7 +241,7 @@ describe('generateBlogPostMetadata', () => {
       date: '2024-07-01T12:00:00',
     })
 
-    const result = generateBlogPostMetadata(thought)
+    const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
     expect(result.title).toBe('Test Blog Post')
     expect(result.openGraph).toBeDefined()
@@ -256,7 +258,7 @@ describe('generateBlogPostMetadata', () => {
       id: 789,
     })
 
-    const result = generateBlogPostMetadata(thought)
+    const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
     expect(result.openGraph?.images).toBeDefined()
     expect(result.openGraph?.images).toHaveLength(1)
@@ -275,7 +277,7 @@ describe('generateBlogPostMetadata', () => {
       id: 999,
     })
 
-    const result = generateBlogPostMetadata(thought)
+    const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
     expect(result.openGraph?.images?.[0]?.url).toBe(
       'https://hidetaka.dev/api/thumbnail/thoughts/999',
@@ -289,7 +291,7 @@ describe('generateBlogPostMetadata', () => {
       id: 111,
     })
 
-    const result = generateBlogPostMetadata(thought)
+    const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
     expect(result.openGraph?.images?.[0]?.url).toBe(
       'https://custom.example.com/api/thumbnail/thoughts/111',
@@ -301,7 +303,7 @@ describe('generateBlogPostMetadata', () => {
       title: { rendered: 'My Custom Blog Title' },
     })
 
-    const result = generateBlogPostMetadata(thought)
+    const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
     expect(result.twitter?.title).toBe('My Custom Blog Title')
     expect(result.twitter?.images).toBeDefined()
@@ -313,8 +315,8 @@ describe('generateBlogPostMetadata', () => {
     const thought1 = createMockWPThought({ id: 1 })
     const thought2 = createMockWPThought({ id: 2 })
 
-    const result1 = generateBlogPostMetadata(thought1)
-    const result2 = generateBlogPostMetadata(thought2)
+    const result1 = generateBlogPostMetadata(thought1, '/blog/post-1')
+    const result2 = generateBlogPostMetadata(thought2, '/blog/post-2')
 
     expect(result1.openGraph?.images?.[0]?.url).toContain('/thoughts/1')
     expect(result2.openGraph?.images?.[0]?.url).toContain('/thoughts/2')
@@ -326,7 +328,7 @@ describe('generateBlogPostMetadata', () => {
         excerpt: { rendered: '<p>This is a useful summary of the post.</p>' },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBe('This is a useful summary of the post.')
       expect(result.openGraph?.description).toBe('This is a useful summary of the post.')
@@ -338,7 +340,7 @@ describe('generateBlogPostMetadata', () => {
         excerpt: { rendered: '<p>Hello <strong>world</strong> from <a href="#">here</a>.</p>' },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBe('Hello world from here.')
       expect(result.description).not.toMatch(/<[^>]*>/)
@@ -349,7 +351,7 @@ describe('generateBlogPostMetadata', () => {
         excerpt: { rendered: '<p>Multiple   spaces\n\nand newlines</p>' },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBe('Multiple spaces and newlines')
     })
@@ -360,7 +362,7 @@ describe('generateBlogPostMetadata', () => {
         excerpt: { rendered: `<p>${longText}</p>` },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBeDefined()
       expect((result.description as string).length).toBeLessThanOrEqual(123)
@@ -372,7 +374,7 @@ describe('generateBlogPostMetadata', () => {
         content: { rendered: '<p>Fallback content body.</p>' },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBe('Fallback content body.')
     })
@@ -384,7 +386,7 @@ describe('generateBlogPostMetadata', () => {
         content: { rendered: '' },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBe('Only Title Available')
     })
@@ -396,7 +398,7 @@ describe('generateBlogPostMetadata', () => {
         content: { rendered: '<p></p>' },
       })
 
-      const result = generateBlogPostMetadata(thought)
+      const result = generateBlogPostMetadata(thought, '/blog/test-post')
 
       expect(result.description).toBeTruthy()
     })
@@ -490,5 +492,174 @@ describe('generateProjectMetadata', () => {
     const result = generateProjectMetadata(project, 'en')
 
     expect(result.openGraph?.images).toBeUndefined()
+  })
+})
+
+describe('buildAlternates', () => {
+  it('should build canonical and hreflang for an English path', () => {
+    const result = buildAlternates('/work')
+
+    expect(result.canonical).toBe('https://hidetaka.dev/work')
+    expect(result.languages).toEqual({
+      en: 'https://hidetaka.dev/work',
+      ja: 'https://hidetaka.dev/ja/work',
+      'x-default': 'https://hidetaka.dev/work',
+    })
+  })
+
+  it('should build canonical and hreflang for a Japanese path', () => {
+    const result = buildAlternates('/ja/work')
+
+    expect(result.canonical).toBe('https://hidetaka.dev/ja/work')
+    expect(result.languages).toEqual({
+      en: 'https://hidetaka.dev/work',
+      ja: 'https://hidetaka.dev/ja/work',
+      'x-default': 'https://hidetaka.dev/work',
+    })
+  })
+
+  it('should handle the root path', () => {
+    const result = buildAlternates('/')
+
+    expect(result.canonical).toBe('https://hidetaka.dev')
+    expect(result.languages).toEqual({
+      en: 'https://hidetaka.dev',
+      ja: 'https://hidetaka.dev/ja',
+      'x-default': 'https://hidetaka.dev',
+    })
+  })
+
+  it('should handle the Japanese root path', () => {
+    const result = buildAlternates('/ja')
+
+    expect(result.canonical).toBe('https://hidetaka.dev/ja')
+    expect(result.languages).toEqual({
+      en: 'https://hidetaka.dev',
+      ja: 'https://hidetaka.dev/ja',
+      'x-default': 'https://hidetaka.dev',
+    })
+  })
+
+  it('should normalize canonical to the Japanese path when canonicalLang is ja', () => {
+    const result = buildAlternates('/writing/dev-notes/my-note', { canonicalLang: 'ja' })
+
+    expect(result.canonical).toBe('https://hidetaka.dev/ja/writing/dev-notes/my-note')
+    expect(result.languages).toEqual({
+      en: 'https://hidetaka.dev/writing/dev-notes/my-note',
+      ja: 'https://hidetaka.dev/ja/writing/dev-notes/my-note',
+      'x-default': 'https://hidetaka.dev/writing/dev-notes/my-note',
+    })
+  })
+
+  it('should normalize canonical to the English path when canonicalLang is en', () => {
+    const result = buildAlternates('/ja/blog/my-post', { canonicalLang: 'en' })
+
+    expect(result.canonical).toBe('https://hidetaka.dev/blog/my-post')
+  })
+
+  it('should limit hreflang to available languages for single-language pages', () => {
+    const result = buildAlternates('/ja/events/my-event', { availableLanguages: ['ja'] })
+
+    expect(result.canonical).toBe('https://hidetaka.dev/ja/events/my-event')
+    expect(result.languages).toEqual({
+      ja: 'https://hidetaka.dev/ja/events/my-event',
+      'x-default': 'https://hidetaka.dev/ja/events/my-event',
+    })
+  })
+})
+
+describe('getOpenGraphLocale', () => {
+  it('should return en_US for English', () => {
+    expect(getOpenGraphLocale('en')).toBe('en_US')
+  })
+
+  it('should return ja_JP for Japanese', () => {
+    expect(getOpenGraphLocale('ja')).toBe('ja_JP')
+  })
+})
+
+describe('canonical / hreflang / og:url integration', () => {
+  it('generateBlogPostMetadata should use the given path as canonical and og:url', () => {
+    const thought = createMockWPThought()
+
+    const result = generateBlogPostMetadata(thought, '/blog/test-post')
+
+    expect(result.alternates?.canonical).toBe('https://hidetaka.dev/blog/test-post')
+    expect(result.alternates?.languages).toEqual({
+      en: 'https://hidetaka.dev/blog/test-post',
+      ja: 'https://hidetaka.dev/ja/blog/test-post',
+      'x-default': 'https://hidetaka.dev/blog/test-post',
+    })
+    expect(result.openGraph?.url).toBe('https://hidetaka.dev/blog/test-post')
+    expect(result.openGraph?.siteName).toBe('Hidetaka.dev')
+    expect(result.openGraph?.locale).toBe('en_US')
+  })
+
+  it('generateBlogPostMetadata should use ja locale for Japanese paths', () => {
+    const thought = createMockWPThought()
+
+    const result = generateBlogPostMetadata(thought, '/ja/blog/test-post')
+
+    expect(result.alternates?.canonical).toBe('https://hidetaka.dev/ja/blog/test-post')
+    expect(result.openGraph?.url).toBe('https://hidetaka.dev/ja/blog/test-post')
+    expect(result.openGraph?.locale).toBe('ja_JP')
+  })
+
+  it('generateBlogPostMetadata should respect availableLanguages option', () => {
+    const thought = createMockWPThought()
+
+    const result = generateBlogPostMetadata(thought, '/ja/events/test-event', {
+      availableLanguages: ['ja'],
+    })
+
+    expect(result.alternates?.canonical).toBe('https://hidetaka.dev/ja/events/test-event')
+    expect(result.alternates?.languages).toEqual({
+      ja: 'https://hidetaka.dev/ja/events/test-event',
+      'x-default': 'https://hidetaka.dev/ja/events/test-event',
+    })
+  })
+
+  it('generateDevNoteMetadata should normalize canonical and og:url to the Japanese path', () => {
+    const note = createMockWPThought()
+
+    const enResult = generateDevNoteMetadata(note, '/writing/dev-notes/test-post')
+    const jaResult = generateDevNoteMetadata(note, '/ja/writing/dev-notes/test-post')
+
+    // en/jaで同一コンテンツのため、どちらもja側のURLをcanonicalとする
+    expect(enResult.alternates?.canonical).toBe(
+      'https://hidetaka.dev/ja/writing/dev-notes/test-post',
+    )
+    expect(jaResult.alternates?.canonical).toBe(
+      'https://hidetaka.dev/ja/writing/dev-notes/test-post',
+    )
+    expect(enResult.openGraph?.url).toBe('https://hidetaka.dev/ja/writing/dev-notes/test-post')
+    expect(enResult.alternates?.languages).toEqual({
+      en: 'https://hidetaka.dev/writing/dev-notes/test-post',
+      ja: 'https://hidetaka.dev/ja/writing/dev-notes/test-post',
+      'x-default': 'https://hidetaka.dev/writing/dev-notes/test-post',
+    })
+    // og:localeは表示中のページの言語に従う
+    expect(enResult.openGraph?.locale).toBe('en_US')
+    expect(jaResult.openGraph?.locale).toBe('ja_JP')
+  })
+
+  it('generateProjectMetadata should build canonical from lang and project id', () => {
+    const project = createMockProject({ id: 'my-project' })
+
+    const enResult = generateProjectMetadata(project, 'en')
+    const jaResult = generateProjectMetadata(project, 'ja')
+
+    expect(enResult.alternates?.canonical).toBe('https://hidetaka.dev/work/my-project')
+    expect(enResult.openGraph?.url).toBe('https://hidetaka.dev/work/my-project')
+    expect(enResult.openGraph?.locale).toBe('en_US')
+    expect(enResult.openGraph?.siteName).toBe('Hidetaka.dev')
+    expect(jaResult.alternates?.canonical).toBe('https://hidetaka.dev/ja/work/my-project')
+    expect(jaResult.openGraph?.url).toBe('https://hidetaka.dev/ja/work/my-project')
+    expect(jaResult.openGraph?.locale).toBe('ja_JP')
+    expect(jaResult.alternates?.languages).toEqual({
+      en: 'https://hidetaka.dev/work/my-project',
+      ja: 'https://hidetaka.dev/ja/work/my-project',
+      'x-default': 'https://hidetaka.dev/work/my-project',
+    })
   })
 })

--- a/src/libs/metadata.ts
+++ b/src/libs/metadata.ts
@@ -92,10 +92,7 @@ function buildDescription(thought: WPThought): string {
 }
 
 export function generateDevNoteMetadata(note: WPThought, path: string): Metadata {
-  const ogImageUrl = new URL(
-    `/api/thumbnail/dev-notes/${note.id}`,
-    process.env.NEXT_PUBLIC_SITE_URL || 'https://hidetaka.dev',
-  )
+  const ogImageUrl = new URL(`/api/thumbnail/dev-notes/${note.id}`, SITE_CONFIG.url)
 
   const description = buildDescription(note)
   const lang = getLanguageFromURL(path)
@@ -139,10 +136,7 @@ export function generateBlogPostMetadata(
 ): Metadata {
   // セキュリティ強化: post_idからWordPress APIで記事を取得してタイトルを使用
   // これにより、任意の文字列で画像を生成することを防止
-  const ogImageUrl = new URL(
-    `/api/thumbnail/thoughts/${thought.id}`,
-    process.env.NEXT_PUBLIC_SITE_URL || 'https://hidetaka.dev',
-  )
+  const ogImageUrl = new URL(`/api/thumbnail/thoughts/${thought.id}`, SITE_CONFIG.url)
 
   const description = buildDescription(thought)
   const lang = getLanguageFromURL(path)

--- a/src/libs/metadata.ts
+++ b/src/libs/metadata.ts
@@ -1,6 +1,30 @@
 import type { Metadata } from 'next'
 import type { WPThought } from './dataSources/types'
 import type { MicroCMSProjectsRecord } from './microCMS/types'
+import { removeHtmlTags } from './sanitize'
+
+const MAX_DESCRIPTION_LENGTH = 120
+
+/**
+ * WordPressのexcerpt/contentからmeta description用のプレーンテキストを生成する。
+ * HTMLタグを除去し、空白を正規化したうえで最大120文字程度に切り詰める。
+ * excerpt・contentが空の場合はtitleにフォールバックし、空文字を返さない。
+ */
+function buildDescription(thought: WPThought): string {
+  const candidates = [thought.excerpt?.rendered, thought.content?.rendered, thought.title.rendered]
+
+  for (const candidate of candidates) {
+    const text = (removeHtmlTags(candidate ?? '') ?? '').replace(/\s+/g, ' ').trim()
+    if (!text) continue
+
+    if (text.length <= MAX_DESCRIPTION_LENGTH) {
+      return text
+    }
+    return `${text.slice(0, MAX_DESCRIPTION_LENGTH).trimEnd()}...`
+  }
+
+  return thought.title.rendered
+}
 
 export function generateDevNoteMetadata(note: WPThought): Metadata {
   const ogImageUrl = new URL(
@@ -8,10 +32,14 @@ export function generateDevNoteMetadata(note: WPThought): Metadata {
     process.env.NEXT_PUBLIC_SITE_URL || 'https://hidetaka.dev',
   )
 
+  const description = buildDescription(note)
+
   return {
     title: note.title.rendered,
+    description,
     openGraph: {
       title: note.title.rendered,
+      description,
       type: 'article',
       publishedTime: note.date,
       images: [
@@ -26,6 +54,7 @@ export function generateDevNoteMetadata(note: WPThought): Metadata {
     twitter: {
       card: 'summary_large_image',
       title: note.title.rendered,
+      description,
       images: [ogImageUrl.toString()],
     },
   }
@@ -39,10 +68,14 @@ export function generateBlogPostMetadata(thought: WPThought): Metadata {
     process.env.NEXT_PUBLIC_SITE_URL || 'https://hidetaka.dev',
   )
 
+  const description = buildDescription(thought)
+
   return {
     title: thought.title.rendered,
+    description,
     openGraph: {
       title: thought.title.rendered,
+      description,
       type: 'article',
       publishedTime: thought.date,
       images: [
@@ -57,6 +90,7 @@ export function generateBlogPostMetadata(thought: WPThought): Metadata {
     twitter: {
       card: 'summary_large_image',
       title: thought.title.rendered,
+      description,
       images: [ogImageUrl.toString()],
     },
   }

--- a/src/libs/metadata.ts
+++ b/src/libs/metadata.ts
@@ -1,9 +1,74 @@
 import type { Metadata } from 'next'
+import { SITE_CONFIG } from '@/config'
 import type { WPThought } from './dataSources/types'
 import type { MicroCMSProjectsRecord } from './microCMS/types'
 import { removeHtmlTags } from './sanitize'
+import { changeLanguageURL, getLanguageFromURL } from './urlUtils/lang.util'
 
 const MAX_DESCRIPTION_LENGTH = 120
+
+type SupportedLang = 'en' | 'ja'
+
+/**
+ * パスを絶対URLに変換する。
+ * 末尾スラッシュを正規化し、ルート（`/`）の場合はサイトURLそのものを返す。
+ */
+const toAbsoluteUrl = (path: string): string => {
+  const normalized = path !== '/' && path.endsWith('/') ? path.slice(0, -1) : path
+  return normalized === '/' ? SITE_CONFIG.url : `${SITE_CONFIG.url}${normalized}`
+}
+
+/**
+ * 言語コードからOpen Graphのlocale値を返す。
+ */
+export function getOpenGraphLocale(lang: SupportedLang): 'en_US' | 'ja_JP' {
+  return lang === 'ja' ? 'ja_JP' : 'en_US'
+}
+
+export type BuildAlternatesOptions = {
+  /**
+   * canonicalを特定の言語側へ正規化する場合に指定する。
+   * 省略時は渡されたパス自身がcanonicalになる。
+   * （例: dev-notesはen/jaで同一の日本語コンテンツのため'ja'へ正規化する）
+   */
+  canonicalLang?: SupportedLang
+  /**
+   * ページが存在する言語。片方の言語にしか存在しないページでは
+   * 存在しない言語へのhreflangを出力しないために指定する。
+   * 省略時は en/ja の両方が存在するものとして扱う。
+   */
+  availableLanguages?: SupportedLang[]
+}
+
+/**
+ * パスからcanonical + hreflang（en/ja/x-default）のalternatesを生成する。
+ * en/jaパスの相互変換は `/ja` プレフィックスの付与/除去で行う。
+ */
+export function buildAlternates(
+  path: string,
+  options: BuildAlternatesOptions = {},
+): NonNullable<Metadata['alternates']> {
+  const enPath = changeLanguageURL(path, 'en')
+  const jaPath = changeLanguageURL(path, 'ja')
+  const available = options.availableLanguages ?? ['en', 'ja']
+  const canonicalPath =
+    options.canonicalLang === 'ja' ? jaPath : options.canonicalLang === 'en' ? enPath : path
+
+  const languages: Partial<Record<'en' | 'ja' | 'x-default', string>> = {}
+  if (available.includes('en')) {
+    languages.en = toAbsoluteUrl(enPath)
+  }
+  if (available.includes('ja')) {
+    languages.ja = toAbsoluteUrl(jaPath)
+  }
+  // x-defaultは英語版があれば英語版、なければ日本語版を指す
+  languages['x-default'] = toAbsoluteUrl(available.includes('en') ? enPath : jaPath)
+
+  return {
+    canonical: toAbsoluteUrl(canonicalPath),
+    languages,
+  }
+}
 
 /**
  * WordPressのexcerpt/contentからmeta description用のプレーンテキストを生成する。
@@ -26,22 +91,29 @@ function buildDescription(thought: WPThought): string {
   return thought.title.rendered
 }
 
-export function generateDevNoteMetadata(note: WPThought): Metadata {
+export function generateDevNoteMetadata(note: WPThought, path: string): Metadata {
   const ogImageUrl = new URL(
     `/api/thumbnail/dev-notes/${note.id}`,
     process.env.NEXT_PUBLIC_SITE_URL || 'https://hidetaka.dev',
   )
 
   const description = buildDescription(note)
+  const lang = getLanguageFromURL(path)
+  // dev-notesはen/jaで同一の日本語コンテンツを返すため、canonicalはja側へ正規化する
+  const alternates = buildAlternates(path, { canonicalLang: 'ja' })
 
   return {
     title: note.title.rendered,
     description,
+    alternates,
     openGraph: {
       title: note.title.rendered,
       description,
       type: 'article',
       publishedTime: note.date,
+      url: toAbsoluteUrl(changeLanguageURL(path, 'ja')),
+      siteName: SITE_CONFIG.name,
+      locale: getOpenGraphLocale(lang),
       images: [
         {
           url: ogImageUrl.toString(),
@@ -60,7 +132,11 @@ export function generateDevNoteMetadata(note: WPThought): Metadata {
   }
 }
 
-export function generateBlogPostMetadata(thought: WPThought): Metadata {
+export function generateBlogPostMetadata(
+  thought: WPThought,
+  path: string,
+  alternatesOptions: BuildAlternatesOptions = {},
+): Metadata {
   // セキュリティ強化: post_idからWordPress APIで記事を取得してタイトルを使用
   // これにより、任意の文字列で画像を生成することを防止
   const ogImageUrl = new URL(
@@ -69,15 +145,20 @@ export function generateBlogPostMetadata(thought: WPThought): Metadata {
   )
 
   const description = buildDescription(thought)
+  const lang = getLanguageFromURL(path)
 
   return {
     title: thought.title.rendered,
     description,
+    alternates: buildAlternates(path, alternatesOptions),
     openGraph: {
       title: thought.title.rendered,
       description,
       type: 'article',
       publishedTime: thought.date,
+      url: toAbsoluteUrl(path),
+      siteName: SITE_CONFIG.name,
+      locale: getOpenGraphLocale(lang),
       images: [
         {
           url: ogImageUrl.toString(),
@@ -100,8 +181,9 @@ const PROJECT_DESCRIPTION_MAX_LENGTH = 120
 
 export function generateProjectMetadata(
   project: MicroCMSProjectsRecord,
-  _lang: 'ja' | 'en',
+  lang: SupportedLang,
 ): Metadata {
+  const path = lang === 'ja' ? `/ja/work/${project.id}` : `/work/${project.id}`
   // aboutからHTMLタグを除去し、空白を正規化して説明文を生成する
   // aboutが無ければtitleをフォールバックとして使用する
   const rawDescription = project.about
@@ -119,10 +201,14 @@ export function generateProjectMetadata(
   return {
     title: project.title,
     description,
+    alternates: buildAlternates(path),
     openGraph: {
       title: project.title,
       description,
       type: 'website',
+      url: toAbsoluteUrl(path),
+      siteName: SITE_CONFIG.name,
+      locale: getOpenGraphLocale(lang),
       ...(project.image
         ? {
             images: [

--- a/src/libs/metadata.ts
+++ b/src/libs/metadata.ts
@@ -85,7 +85,7 @@ function buildDescription(thought: WPThought): string {
     if (text.length <= MAX_DESCRIPTION_LENGTH) {
       return text
     }
-    return `${text.slice(0, MAX_DESCRIPTION_LENGTH).trimEnd()}...`
+    return `${Array.from(text).slice(0, MAX_DESCRIPTION_LENGTH).join('').trimEnd()}...`
   }
 
   return thought.title.rendered


### PR DESCRIPTION
## Summary

This PR refactors the metadata generation system to support language-aware canonical URLs and hreflang tags, improves accessibility with focus management and keyboard navigation, and consolidates WordPress API client usage across data sources.

## Key Changes

### Metadata & SEO Improvements
- **New `buildAlternates()` function**: Generates canonical + hreflang (en/ja/x-default) metadata for bilingual pages
- **New `getOpenGraphLocale()` function**: Converts language codes to Open Graph locale format (en_US/ja_JP)
- **Enhanced `generateDevNoteMetadata()` and `generateBlogPostMetadata()`**: Now accept `path` parameter to generate proper canonical URLs and alternates
- **New `buildDescription()` helper**: Extracts plain text descriptions from WordPress excerpt/content with HTML stripping, whitespace normalization, and 120-character truncation with fallback chain (excerpt → content → title)
- **Fixed OG image URLs**: Now use `SITE_CONFIG.url` consistently instead of `NEXT_PUBLIC_SITE_URL` environment variable
- **Updated sitemap generation**: Dev Notes now only include Japanese canonical URLs (with hreflang for English)
- **Layout metadata templates**: Root and language-specific layouts now use title templates (`%s | Hidetaka Okamoto`)

### Accessibility Enhancements
- **New `useDialogA11y` hook**: Provides modal dialog accessibility with:
  - Focus trap (Tab/Shift+Tab wrapping within dialog)
  - Escape key handling
  - Focus restoration on close
  - Automatic focus to first focusable element on open
- **Dialog component tests**: Comprehensive test coverage for focus management and keyboard navigation
- **Global focus styles**: Added visible focus indicator (2px indigo outline) for keyboard navigation
- **Reduced motion support**: Respects `prefers-reduced-motion` media query
- **Header & drawer improvements**: Integrated `useDialogA11y` for mobile menu and navigation dialogs
- **SearchBar accessibility**: Added optional `label` prop for better form labeling
- **FilterItem accessibility**: Added `aria-pressed` attribute for toggle buttons
- **ArticleSummary improvements**: Wrapped loading state in `<output>` with `aria-live="polite"` for screen reader announcements

### Data Source Refactoring
- **Centralized WordPress client**: Created `src/libs/dataSources/wpClient.ts` as shared instance
- **Consolidated API calls**: Refactored `thoughts.ts`, `devnotes.ts`, `products.ts`, and `events.ts` to use `wpClient` instead of individual fetch calls
- **Improved error handling**: Leveraged `node-wp-api-client` error handling instead of manual response checking
- **Type safety**: Added `EmbeddedTermSource` type for flexible category extraction from embedded WordPress data
- **Removed helper functions**: Eliminated redundant `fetchProduct()`, `fetchDevNote()`, and `toBlogItem()` functions

### Testing Improvements
- **Metadata tests**: Added comprehensive test suite for description generation with edge cases (empty content, HTML stripping, truncation, fallbacks)
- **Mock data fixes**: Updated test mocks to include required `headers` property for Response objects

### Configuration & Manifest Updates
- **Web manifest**: Updated `site.webmanifest` with proper app name ("Hidetaka.dev") and short name ("Hidetaka")
- **Browser config**: Updated tile color and image references
- **Robots.txt**: Added `/sentry-test` and `/test-sentry` to disallow list
- **Sentry test pages**: Added metadata with `robots: { index: false }` to prevent indexing

### Minor UI/UX Improvements
- **Dark mode support**: Added `dark:bg-zinc-900` to project detail pages for better dark mode appearance
- **Viewport units**: Changed `min-h-screen` to `min-h-dvh` (dynamic viewport height) in Sentry test components for better mobile support
- **Package dependency**: Updated `node-wp-api-client` from GitHub branch to stable version `0.1.0`

## Implementation Details

- **Language-aware URL handling**: Uses existing `changeLanguageURL()` utility

https://claude.ai/code/session_01TDTWgjRnMoguxNRzmdKKMW