### PR TITLE
feat: StackShowcaseを6カテゴリ化・CapabilitiesをDX4軸に刷新 (HID-20)

### DIFF
--- a/src/components/home/Capabilities.component.test.tsx
+++ b/src/components/home/Capabilities.component.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * Capabilities コンポーネントのテスト
+ *
+ * Developer Experience 4軸への刷新内容を検証します。
+ */
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Capabilities from '@/components/home/Capabilities'
+
+const EN_TITLES = [
+  'Serverless Development',
+  'Frontend Development',
+  'Developer Tools & Automation',
+  'Community & Content',
+]
+
+const JA_TITLES = [
+  'サーバーレス開発',
+  'フロントエンド開発',
+  '開発者ツールと自動化',
+  'コミュニティとコンテンツ',
+]
+
+describe('Capabilities', () => {
+  it('英語版で Developer Experience 4軸のカードを描画する', () => {
+    render(<Capabilities lang="en" />)
+    for (const title of EN_TITLES) {
+      expect(screen.getByText(title)).toBeInTheDocument()
+    }
+    // 代表的な highlight
+    expect(screen.getByText('CircleCI pipeline optimization')).toBeInTheDocument()
+    expect(screen.getByText('1000+ technical articles')).toBeInTheDocument()
+  })
+
+  it('日本語版で4軸のカードを描画する', () => {
+    render(<Capabilities lang="ja" />)
+    for (const title of JA_TITLES) {
+      expect(screen.getByText(title)).toBeInTheDocument()
+    }
+  })
+})

--- a/src/components/home/Capabilities.tsx
+++ b/src/components/home/Capabilities.tsx
@@ -2,6 +2,7 @@ import Container from '@/components/tailwindui/Container'
 import SectionHeader from '@/components/ui/SectionHeader'
 
 type Capability = {
+  icon?: string
   title: string
   description: string
   highlights: string[]
@@ -10,7 +11,12 @@ type Capability = {
 function CapabilityCard({ capability }: { capability: Capability }) {
   return (
     <article className="group relative flex h-full flex-col rounded-2xl border border-zinc-200 bg-white p-10 transition-all hover:shadow-lg hover:border-indigo-200 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-800">
-      <h3 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-white">
+      {capability.icon && (
+        <span className="text-3xl" aria-hidden="true">
+          {capability.icon}
+        </span>
+      )}
+      <h3 className="mt-4 text-xl font-semibold tracking-tight text-slate-900 dark:text-white">
         {capability.title}
       </h3>
       <p className="mt-6 text-base leading-relaxed text-slate-700 dark:text-slate-400">
@@ -29,98 +35,108 @@ function CapabilityCard({ capability }: { capability: Capability }) {
 }
 
 export default function Capabilities({ lang }: { lang: string }) {
-  const sectionTitle = lang === 'ja' ? '私ができること' : 'What I Bring to the Table'
-  const sectionDescription =
-    lang === 'ja'
-      ? 'Stripeの決済導線設計からAWS/Lambdaによるサーバーレス構築、WordPressによるメディア・マーケティング基盤まで。プロダクトの継続的な収益化と高速な実験を支援します。'
-      : 'From Stripe monetization flows to AWS serverless architecture and WordPress-powered marketing platforms. I help teams unlock recurring revenue and ship experiments faster.'
+  const isJa = lang === 'ja'
 
-  const capabilities: Capability[] =
-    lang === 'ja'
-      ? [
-          {
-            title: 'Stripeで収益を最大化',
-            description:
-              'プロダクトのLTV向上に向けて料金プランや請求オートメーションを設計。Billing・Connect・Radarを活用し、SaaS/マーケットプレイスの成長を伴走します。',
-            highlights: [
-              '従量課金・年額契約など柔軟なプライシング設計',
-              'SaaS指標を可視化するダッシュボードと分析環境',
-              'Revenue Recognitionや自動請求オペレーションの整備',
-            ],
-          },
-          {
-            title: 'AWS Serverless × Cloudflareでスケール',
-            description:
-              'Lambda、Step Functions、Cloudflare Workersを組み合わせ、負荷に応じてシームレスにスケールするバックエンドを構築。グローバルユーザーにも高速な体験を提供します。',
-            highlights: [
-              'マルチリージョン対応のAPIとジョブパイプライン',
-              'IaC・CI/CDを用いた運用負担の最小化',
-              'Observabilityとセキュリティベストプラクティスの実装',
-            ],
-          },
-          {
-            title: 'WordPressでマーケ&コンテンツを加速',
-            description:
-              'WordPressサイトやHeadlessサイトを設計。リード獲得やコミュニティ施策と連携し、開発とマーケが並走できる仕組みを整えます。',
-            highlights: [
-              'WordPress / Headless WordPress / Cloudflare Pagesの運用',
-              'MicroCMSや外部SaaSとのハイブリッドな連携',
-              '編集体験と高速表示を両立するユーザー体験',
-            ],
-          },
-          {
-            title: 'システムデザインでスケーラブルなアーキテクチャを構築',
-            description:
-              '堅牢で保守性の高いシステムを設計。マイクロサービスやイベント駆動型アーキテクチャで、製品の成長に合わせたバックエンドを構築します。',
-            highlights: [
-              'マイクロサービス・API・イベント駆動型アーキテクチャ設計',
-              '成長に対応するデータベース設計と最適化',
-              'レジリエント設計とフェイルオーバー戦略',
-            ],
-          },
-        ]
-      : [
-          {
-            title: 'Monetize with Stripe confidence',
-            description:
-              'Design pricing strategies, billing automation, and compliant payment flows that increase LTV. I partner with founders to implement Billing, Connect, and Radar for SaaS and marketplaces.',
-            highlights: [
-              'Flexible pricing with usage-based or annual plans',
-              'Growth dashboards to illuminate core SaaS metrics',
-              'Revenue Recognition and automated billing operations',
-            ],
-          },
-          {
-            title: 'Scale on AWS Serverless & Cloudflare',
-            description:
-              'Combine Lambda, Step Functions, and Cloudflare Workers to deliver resilient, globally distributed backend experiences. Built for cost efficiency, observability, and rapid experimentation.',
-            highlights: [
-              'Multi-region APIs and asynchronous job pipelines',
-              'Infrastructure-as-code with frictionless CI/CD',
-              'Embedded security and runtime insights by default',
-            ],
-          },
-          {
-            title: 'Accelerate content with WordPress',
-            description:
-              'Design WordPress sites and headless sites. Integrate with lead generation and community initiatives, enabling development and marketing to work in parallel.',
-            highlights: [
-              'WordPress / Headless WordPress / Cloudflare Pages operations',
-              'Hybrid integrations with MicroCMS and existing SaaS',
-              'User experience balancing editing UX and speed',
-            ],
-          },
-          {
-            title: 'Design scalable architectures with System Design expertise',
-            description:
-              'Craft robust, maintainable systems that grow with your product. I design distributed architectures that balance scalability, reliability, and developer productivity for long-term success.',
-            highlights: [
-              'Microservices, APIs, and event-driven architectures',
-              'Database design and optimization for growth',
-              'System resilience and failover strategies',
-            ],
-          },
-        ]
+  const sectionTitle = isJa
+    ? '開発者体験を高めるツールとアーキテクチャ'
+    : 'Empowering developers through better tools and architecture'
+  const sectionDescription = isJa
+    ? 'サーバーレス開発からフロントエンド、開発者ツールの整備、コミュニティ活動まで。マルチスキルなエンジニアリングで開発者体験を高め、プロダクトの成長を支援します。'
+    : 'From serverless development and frontend engineering to developer tooling and community work. I improve developer experience across the stack to help products grow.'
+
+  const capabilities: Capability[] = isJa
+    ? [
+        {
+          icon: '⚡',
+          title: 'サーバーレス開発',
+          description:
+            'AWS Lambda や Cloudflare Workers を活用し、負荷に応じてスケールするアプリケーションを構築します。',
+          highlights: [
+            'イベント駆動型アーキテクチャの設計',
+            'マイクロサービスの実装',
+            'コスト最適化とObservability',
+          ],
+        },
+        {
+          icon: '🎨',
+          title: 'フロントエンド開発',
+          description:
+            'React と Next.js でモダンでアクセシブルな Web UI を開発します。型安全性とパフォーマンスを重視します。',
+          highlights: [
+            'TypeScript による型安全な実装',
+            'パフォーマンス最適化',
+            'レスポンシブ・アクセシブルなUI',
+          ],
+        },
+        {
+          icon: '🛠️',
+          title: '開発者ツールと自動化',
+          description:
+            'CI/CD、テスト、開発者体験(DX)の改善に取り組みます。チームの生産性を底上げする仕組みを整えます。',
+          highlights: [
+            'CircleCI パイプラインの最適化',
+            'GitHub Actions による自動化',
+            'MCP サーバー開発・AI活用',
+          ],
+        },
+        {
+          icon: '🌐',
+          title: 'コミュニティとコンテンツ',
+          description:
+            '技術記事の執筆、登壇、コミュニティ運営を通じて、開発者同士の学びと交流を支えます。',
+          highlights: [
+            '1000本以上の技術記事',
+            'カンファレンスでの登壇',
+            '10年以上のコミュニティ運営',
+          ],
+        },
+      ]
+    : [
+        {
+          icon: '⚡',
+          title: 'Serverless Development',
+          description:
+            'Build applications that scale with demand using AWS Lambda and Cloudflare Workers.',
+          highlights: [
+            'Event-driven architecture design',
+            'Microservices implementation',
+            'Cost optimization and observability',
+          ],
+        },
+        {
+          icon: '🎨',
+          title: 'Frontend Development',
+          description:
+            'Develop modern, accessible web UIs with React and Next.js, with a focus on type safety and performance.',
+          highlights: [
+            'Type-safe implementation with TypeScript',
+            'Performance optimization',
+            'Responsive and accessible UI',
+          ],
+        },
+        {
+          icon: '🛠️',
+          title: 'Developer Tools & Automation',
+          description:
+            'Improve CI/CD, testing, and developer experience (DX) to boost team productivity.',
+          highlights: [
+            'CircleCI pipeline optimization',
+            'GitHub Actions automation',
+            'MCP server development and AI tooling',
+          ],
+        },
+        {
+          icon: '🌐',
+          title: 'Community & Content',
+          description:
+            'Support developer learning and connection through technical writing, speaking, and community building.',
+          highlights: [
+            '1000+ technical articles',
+            'Conference speaking',
+            'Community building (10+ years)',
+          ],
+        },
+      ]
 
   return (
     <section className="relative py-24 sm:py-32">

--- a/src/components/home/StackShowcase.component.test.tsx
+++ b/src/components/home/StackShowcase.component.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * StackShowcase コンポーネントのテスト
+ *
+ * 6カテゴリ階層表示と、Stripe の revtrona.com 外部リンクを検証します。
+ */
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import StackShowcase from '@/components/home/StackShowcase'
+
+const EN_CATEGORIES = [
+  'Backend & Infrastructure',
+  'Frontend',
+  'Payment & SaaS',
+  'CMS & Content',
+  'DevOps & CI/CD',
+  'AI Development',
+]
+
+const JA_CATEGORIES = [
+  'バックエンド・インフラ',
+  'フロントエンド',
+  '決済・SaaS',
+  'CMS・コンテンツ',
+  'DevOps・CI/CD',
+  'AI開発',
+]
+
+const TECH_NAMES = [
+  'AWS Serverless',
+  'Cloudflare',
+  'Next.js',
+  'React',
+  'Stripe',
+  'WordPress',
+  'CircleCI',
+  'GitHub Actions',
+  'MCP',
+  'Claude Code',
+]
+
+describe('StackShowcase', () => {
+  it('英語版で6カテゴリの見出しを描画する', () => {
+    render(<StackShowcase lang="en" />)
+    for (const category of EN_CATEGORIES) {
+      expect(screen.getByText(category)).toBeInTheDocument()
+    }
+  })
+
+  it('日本語版で6カテゴリの見出しを描画する', () => {
+    render(<StackShowcase lang="ja" />)
+    for (const category of JA_CATEGORIES) {
+      expect(screen.getByText(category)).toBeInTheDocument()
+    }
+  })
+
+  it('全ての技術名を描画する', () => {
+    render(<StackShowcase lang="en" />)
+    for (const name of TECH_NAMES) {
+      expect(screen.getByText(name)).toBeInTheDocument()
+    }
+  })
+
+  it('Stripe カードが revtrona.com への外部リンクになっている', () => {
+    render(<StackShowcase lang="en" />)
+    const link = screen.getByRole('link', { name: /Stripe/ })
+    expect(link).toHaveAttribute('href', 'https://revtrona.com')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+})

--- a/src/components/home/StackShowcase.tsx
+++ b/src/components/home/StackShowcase.tsx
@@ -6,61 +6,196 @@ type StackItem = {
   name: string
   description: string
   gradient: string
+  href?: string
+  linkLabel?: string
 }
 
-export default function StackShowcase({ lang }: { lang: string }) {
-  const items: StackItem[] = [
-    {
-      name: 'Stripe',
-      description: lang === 'ja' ? 'Billing / Connect / Radar' : 'Billing · Connect · Radar',
-      gradient: 'from-[#635bff] via-[#7f7bff] to-[#35b5ff]',
-    },
-    {
-      name: 'AWS Serverless',
-      description:
-        lang === 'ja' ? 'Lambda / Step Functions / DynamoDB' : 'Lambda · Step Functions · DynamoDB',
-      gradient: 'from-[#fbbf24] via-[#f97316] to-[#ef4444]',
-    },
-    {
-      name: 'Cloudflare',
-      description: lang === 'ja' ? 'Workers / Pages / Zero Trust' : 'Workers · Pages · Zero Trust',
-      gradient: 'from-[#f97316] via-[#fb923c] to-[#facc15]',
-    },
-    {
-      name: 'WordPress',
-      description: lang === 'ja' ? 'Enterprise / Headless / VIP' : 'Enterprise · Headless · VIP',
-      gradient: 'from-[#21759b] via-[#2dd4bf] to-[#60a5fa]',
-    },
-    {
-      name: 'Next.js',
-      description: lang === 'ja' ? 'App Router / ISR / Edge' : 'App Router · ISR · Edge',
-      gradient: 'from-[#6366f1] via-[#14b8a6] to-[#06b6d4]',
-    },
-  ]
+type StackCategory = {
+  category: string
+  items: StackItem[]
+}
 
-  const title =
-    lang === 'ja'
-      ? '信頼するスタックで、事業のスピードを最大化'
-      : 'Move faster on a trusted platform stack'
-  const subtitle =
-    lang === 'ja'
-      ? 'パートナー企業との共創やエコシステム構築を前提に、開発から運用までをシームレスに繋ぎます。'
-      : 'Built for collaborative ecosystems—seamless from development to operations.'
+// gradient はブランドカラーに合わせて割当（ja/en 共通）
+const GRADIENTS = {
+  aws: 'from-[#fbbf24] via-[#f97316] to-[#ef4444]',
+  cloudflare: 'from-[#f97316] via-[#fb923c] to-[#facc15]',
+  next: 'from-[#6366f1] via-[#14b8a6] to-[#06b6d4]',
+  react: 'from-[#06b6d4] via-[#22d3ee] to-[#38bdf8]',
+  stripe: 'from-[#635bff] via-[#7f7bff] to-[#35b5ff]',
+  wordpress: 'from-[#21759b] via-[#2dd4bf] to-[#60a5fa]',
+  circleci: 'from-[#10b981] via-[#34d399] to-[#6ee7b7]',
+  ghActions: 'from-[#2088ff] via-[#6366f1] to-[#8b5cf6]',
+  mcp: 'from-[#7c3aed] via-[#a855f7] to-[#d946ef]',
+  claude: 'from-[#d97757] via-[#e0855f] to-[#eaa07f]',
+} as const
+
+const CATEGORIES_EN: StackCategory[] = [
+  {
+    category: 'Backend & Infrastructure',
+    items: [
+      {
+        name: 'AWS Serverless',
+        description: 'Lambda · Step Functions · DynamoDB',
+        gradient: GRADIENTS.aws,
+      },
+      { name: 'Cloudflare', description: 'Workers · Pages · R2', gradient: GRADIENTS.cloudflare },
+    ],
+  },
+  {
+    category: 'Frontend',
+    items: [
+      { name: 'Next.js', description: 'App Router · ISR · Edge', gradient: GRADIENTS.next },
+      {
+        name: 'React',
+        description: 'TypeScript · Hooks · Server Components',
+        gradient: GRADIENTS.react,
+      },
+    ],
+  },
+  {
+    category: 'Payment & SaaS',
+    items: [
+      {
+        name: 'Stripe',
+        description: 'Billing · Connect · Radar',
+        gradient: GRADIENTS.stripe,
+        href: 'https://revtrona.com',
+        linkLabel: 'Details at Revtrona.com',
+      },
+    ],
+  },
+  {
+    category: 'CMS & Content',
+    items: [
+      {
+        name: 'WordPress',
+        description: 'Enterprise · Headless · VIP',
+        gradient: GRADIENTS.wordpress,
+      },
+    ],
+  },
+  {
+    category: 'DevOps & CI/CD',
+    items: [
+      { name: 'CircleCI', description: 'Orbs · Workflows · Config', gradient: GRADIENTS.circleci },
+      {
+        name: 'GitHub Actions',
+        description: 'Automation · Testing',
+        gradient: GRADIENTS.ghActions,
+      },
+    ],
+  },
+  {
+    category: 'AI Development',
+    items: [
+      { name: 'MCP', description: 'Server Development · Integration', gradient: GRADIENTS.mcp },
+      { name: 'Claude Code', description: 'AI-assisted Development', gradient: GRADIENTS.claude },
+    ],
+  },
+]
+
+const CATEGORIES_JA: StackCategory[] = [
+  {
+    category: 'バックエンド・インフラ',
+    items: [
+      {
+        name: 'AWS Serverless',
+        description: 'Lambda / Step Functions / DynamoDB',
+        gradient: GRADIENTS.aws,
+      },
+      { name: 'Cloudflare', description: 'Workers / Pages / R2', gradient: GRADIENTS.cloudflare },
+    ],
+  },
+  {
+    category: 'フロントエンド',
+    items: [
+      { name: 'Next.js', description: 'App Router / ISR / Edge', gradient: GRADIENTS.next },
+      {
+        name: 'React',
+        description: 'TypeScript / Hooks / Server Components',
+        gradient: GRADIENTS.react,
+      },
+    ],
+  },
+  {
+    category: '決済・SaaS',
+    items: [
+      {
+        name: 'Stripe',
+        description: 'Billing / Connect / Radar',
+        gradient: GRADIENTS.stripe,
+        href: 'https://revtrona.com',
+        linkLabel: 'Revtronaで詳しく',
+      },
+    ],
+  },
+  {
+    category: 'CMS・コンテンツ',
+    items: [
+      {
+        name: 'WordPress',
+        description: 'Enterprise / Headless / VIP',
+        gradient: GRADIENTS.wordpress,
+      },
+    ],
+  },
+  {
+    category: 'DevOps・CI/CD',
+    items: [
+      { name: 'CircleCI', description: 'Orbs / Workflows / Config', gradient: GRADIENTS.circleci },
+      {
+        name: 'GitHub Actions',
+        description: 'Automation / Testing',
+        gradient: GRADIENTS.ghActions,
+      },
+    ],
+  },
+  {
+    category: 'AI開発',
+    items: [
+      { name: 'MCP', description: 'Server Development / Integration', gradient: GRADIENTS.mcp },
+      { name: 'Claude Code', description: 'AI-assisted Development', gradient: GRADIENTS.claude },
+    ],
+  },
+]
+
+export default function StackShowcase({ lang }: { lang: string }) {
+  const isJa = lang === 'ja'
+  const categories = isJa ? CATEGORIES_JA : CATEGORIES_EN
+
+  const title = isJa
+    ? '信頼するスタックで、事業のスピードを最大化'
+    : 'Move faster on a trusted platform stack'
+  const subtitle = isJa
+    ? 'バックエンドからフロントエンド、CI/CD、AI開発まで。役割ごとに整理した技術スタックで、開発から運用までをシームレスに繋ぎます。'
+    : 'From backend to frontend, CI/CD, and AI development—an organized stack that connects everything from development to operations.'
+  const focusLabel = isJa ? '専門領域' : 'Focus'
 
   return (
     <section className="relative py-24 sm:py-32">
       <Container>
         <SectionHeader title={title} description={subtitle} align="center" />
 
-        <div className="mt-20 grid gap-6 sm:grid-cols-2 lg:grid-cols-5">
-          {items.map((item) => (
-            <StackItemCard
-              key={item.name}
-              name={item.name}
-              description={item.description}
-              gradient={item.gradient}
-              focusLabel={lang === 'ja' ? '専門領域' : 'Focus'}
-            />
+        <div className="mt-20 space-y-16 lg:space-y-20">
+          {categories.map((category) => (
+            <div key={category.category}>
+              <h3 className="text-xl font-semibold tracking-tight text-slate-900 dark:text-white">
+                {category.category}
+              </h3>
+              <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {category.items.map((item) => (
+                  <StackItemCard
+                    key={item.name}
+                    name={item.name}
+                    description={item.description}
+                    gradient={item.gradient}
+                    href={item.href}
+                    linkLabel={item.linkLabel}
+                    focusLabel={focusLabel}
+                  />
+                ))}
+              </div>
+            </div>
           ))}
         </div>
       </Container>

--- a/src/components/ui/StackItemCard.component.test.tsx
+++ b/src/components/ui/StackItemCard.component.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * StackItemCard コンポーネントのテスト
+ *
+ * href の有無によるレンダリング分岐（div / a）を検証します。
+ */
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import StackItemCard from '@/components/ui/StackItemCard'
+
+describe('StackItemCard', () => {
+  it('href が無い場合はリンクを描画しない', () => {
+    render(<StackItemCard name="WordPress" description="Enterprise · Headless · VIP" gradient="" />)
+
+    expect(screen.getByText('WordPress')).toBeInTheDocument()
+    expect(screen.getByText('Enterprise · Headless · VIP')).toBeInTheDocument()
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+
+  it('href がある場合は外部リンク属性付きの a 要素を描画する', () => {
+    render(
+      <StackItemCard
+        name="Stripe"
+        description="Billing · Connect · Radar"
+        gradient=""
+        href="https://revtrona.com"
+        linkLabel="Details at Revtrona.com"
+      />,
+    )
+
+    const link = screen.getByRole('link', { name: /Stripe/ })
+    expect(link).toHaveAttribute('href', 'https://revtrona.com')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(link).toHaveAttribute('aria-label', 'Stripe — Details at Revtrona.com')
+    expect(screen.getByText('Details at Revtrona.com')).toBeInTheDocument()
+  })
+
+  it('focusLabel を指定すると表示される', () => {
+    render(<StackItemCard name="React" description="Hooks" gradient="" focusLabel="Focus" />)
+
+    expect(screen.getByText('Focus')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/StackItemCard.tsx
+++ b/src/components/ui/StackItemCard.tsx
@@ -5,6 +5,8 @@ type StackItemCardProps = {
   description: string
   gradient: string
   focusLabel?: string
+  href?: string
+  linkLabel?: string
   className?: string
 }
 
@@ -13,12 +15,14 @@ export default function StackItemCard({
   description,
   gradient,
   focusLabel,
+  href,
+  linkLabel,
   className = '',
 }: StackItemCardProps) {
-  return (
-    <div
-      className={`group flex flex-col items-center justify-center rounded-2xl border border-zinc-200 bg-white p-8 text-center transition-all hover:shadow-lg hover:border-indigo-200 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-800 ${className}`}
-    >
+  const baseClassName = `group flex flex-col items-center justify-center rounded-2xl border border-zinc-200 bg-white p-8 text-center transition-all hover:shadow-lg hover:border-indigo-200 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-indigo-800 ${className}`
+
+  const content = (
+    <>
       <GradientBadge gradient={gradient}>{name}</GradientBadge>
       {focusLabel && (
         <p className="mt-6 text-xs font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-400">
@@ -28,6 +32,28 @@ export default function StackItemCard({
       <p className="mt-3 text-sm font-medium leading-relaxed text-slate-700 dark:text-slate-300">
         {description}
       </p>
-    </div>
+      {href && linkLabel && (
+        <p className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-indigo-600 group-hover:text-indigo-700 dark:text-indigo-400 dark:group-hover:text-indigo-300">
+          {linkLabel}
+          <span aria-hidden="true">↗</span>
+        </p>
+      )}
+    </>
   )
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={linkLabel ? `${name} — ${linkLabel}` : name}
+        className={baseClassName}
+      >
+        {content}
+      </a>
+    )
+  }
+
+  return <div className={baseClassName}>{content}</div>
 }


### PR DESCRIPTION
## Summary

- **StackShowcase**: フラットな技術リストから6カテゴリ階層表示に再編（Backend & Infrastructure / Frontend / Payment & SaaS / CMS & Content / DevOps & CI/CD / AI Development）
- **StackItemCard**: `href` / `linkLabel` props を追加し、Stripe → revtrona.com 外部リンク（`target="_blank"`, `rel="noopener noreferrer"`, `aria-label`）対応
- **Capabilities**: 収益/技術寄りの4カードをDeveloper Experience 4軸（Serverless / Frontend / Developer Tools / Community）に刷新し、Hero の "Developer Experience Engineer" ポジショニングと整合

## Changes

### `src/components/ui/StackItemCard.tsx`
- `href?: string` / `linkLabel?: string` props 追加
- `href` がある場合は `<a target="_blank" rel="noopener noreferrer">` でラップ、ない場合は `<div>`
- リンク時のみ `linkLabel` + 外部リンク矢印 `↗` を表示

### `src/components/home/StackShowcase.tsx`（全面書き換え）
- `GRADIENTS` 定数（ブランドカラー10種）
- `CATEGORIES_EN` / `CATEGORIES_JA` をモジュールレベルの定数として定義（Biome複雑度ルール対応）
- 6カテゴリ × 最大2技術カードのグリッドレイアウト（`sm:grid-cols-2 lg:grid-cols-3`）
- Stripe に `href: 'https://revtrona.com'` 追加（ja/en 両対応）

### `src/components/home/Capabilities.tsx`
- `icon?: string` フィールド追加（絵文字アイコン表示）
- 4カード刷新: ⚡Serverless / 🎨Frontend / 🛠️Developer Tools & Automation / 🌐Community & Content
- セクションヘッダーを DX 軸訴求に更新

### 新規テスト（3ファイル・9テスト）
- `src/components/ui/StackItemCard.component.test.tsx`
- `src/components/home/StackShowcase.component.test.tsx`
- `src/components/home/Capabilities.component.test.tsx`

## Test plan
- [x] `pnpm lint:check` — pass
- [x] `pnpm test` — 既存ユニットテスト維持
- [x] `pnpm test:component` — 新規コンポーネントテスト9件 pass
- [x] `pnpm build` — TypeScript コンパイル pass
- [ ] 手動: `/` および `/ja` で StackShowcase 6カテゴリ表示を確認
- [ ] 手動: Stripe カードが revtrona.com に新規タブで開くことを確認
- [ ] 手動: Capabilities が新4カード（アイコン付き）で表示されることを確認

Closes HID-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBeKe3QjNmQrZCnNj6a1V9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBeKe3QjNmQrZCnNj6a1V9)_