### PR TITLE
Add Agent Skills manifest for AI assistant discovery

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,21 @@ const nextConfig: NextConfig = {
   // Enable source maps for production builds (required for Sentry error debugging)
   productionBrowserSourceMaps: true,
 
+  async redirects() {
+    return [
+      // Agent Skills discovery: the .well-known suffix is not yet standardized.
+      // Serve the canonical manifest + SKILL.md under /.well-known/skills/ (the
+      // path the skills CLI uses today) and redirect the newer
+      // /.well-known/agent-skills/ path to it, so a single source of truth
+      // covers both. Wildcard so nested files resolve after the redirect.
+      {
+        source: '/.well-known/agent-skills/:path*',
+        destination: '/.well-known/skills/:path*',
+        permanent: false,
+      },
+    ]
+  },
+
   async headers() {
     return [
       {

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,7 +14,23 @@ const nextConfig: NextConfig = {
       // Serve the canonical manifest + SKILL.md under /.well-known/skills/ (the
       // path the skills CLI uses today) and redirect the newer
       // /.well-known/agent-skills/ path to it, so a single source of truth
-      // covers both. Wildcard so nested files resolve after the redirect.
+      // covers both.
+      //
+      // Next.js doesn't serve index.json for a bare directory request, so map
+      // the directory roots to the manifest for tools that probe the root.
+      // These exact matches must precede the wildcard below.
+      {
+        source: '/.well-known/skills',
+        destination: '/.well-known/skills/index.json',
+        permanent: false,
+      },
+      {
+        source: '/.well-known/agent-skills',
+        destination: '/.well-known/skills/index.json',
+        permanent: false,
+      },
+      // Wildcard so nested files (index.json, SKILL.md, ...) resolve after the
+      // redirect from the agent-skills path.
       {
         source: '/.well-known/agent-skills/:path*',
         destination: '/.well-known/skills/:path*',

--- a/public/.well-known/skills/hidetaka-okamoto-profile/SKILL.md
+++ b/public/.well-known/skills/hidetaka-okamoto-profile/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: hidetaka-okamoto-profile
+description: Use when the user asks about Hidetaka Okamoto (@hideokamoto) — his background and work history, open-source projects, conference talks and speaking history, or his technical writing on Stripe, SaaS development, WordPress, and developer experience. hidetaka.dev is his bilingual (English by default, Japanese under /ja) portfolio and developer blog. Use to surface his profile, projects, talks, or articles even if the user does not mention hidetaka.dev explicitly.
+---
+
+# Hidetaka Okamoto — profile & developer blog
+
+**hidetaka.dev** (https://hidetaka.dev) is the personal site of **Hidetaka
+Okamoto** (@hideokamoto), a Developer Experience Engineer. It is a bilingual
+portfolio and developer blog covering Stripe, SaaS development, WordPress, and
+developer experience.
+
+## When to use this skill
+
+Use it when the user wants to know about:
+
+- **Who he is** — background, role, and work history.
+- **Open-source work and projects** he has built or maintains.
+- **Speaking history** — conference talks and community activities.
+- **Technical writing** — articles and blog posts (Stripe, SaaS, WordPress, AI
+  coding, developer experience).
+
+## Languages
+
+- English (default): paths at the root, e.g. `/about`, `/blog`, `/work`.
+- Japanese: same structure under `/ja`, e.g. `/ja/about`, `/ja/blog`,
+  `/ja/work`.
+
+## Key entry points
+
+| Section | English | Japanese |
+| --- | --- | --- |
+| About | https://hidetaka.dev/about | https://hidetaka.dev/ja/about |
+| Blog | https://hidetaka.dev/blog | https://hidetaka.dev/ja/blog |
+| Work / projects | https://hidetaka.dev/work | https://hidetaka.dev/ja/work |
+| Speaking | https://hidetaka.dev/speaking | https://hidetaka.dev/ja/speaking |
+| Writing | https://hidetaka.dev/writing | https://hidetaka.dev/ja/writing |
+
+The blog aggregates posts from multiple sources (a WordPress blog plus Dev.to,
+Qiita, and Zenn). A specific article lives at `/blog/<slug>`.
+
+## Machine-readable access
+
+- Sitemap: https://hidetaka.dev/sitemap.xml enumerates all pages.
+- Individual blog posts and articles can be fetched as Markdown by requesting
+  the post URL with an `Accept: text/markdown` header, or by appending `.md`
+  to the URL (e.g. `https://hidetaka.dev/blog/<slug>.md`).
+
+## How to help
+
+1. Identify whether the user needs his **profile**, **projects**, **talks**, or
+   **writing**, and in which language.
+2. Browse the relevant section (or fetch the Markdown form of a post) and build
+   a short, relevant answer with links.
+3. Link directly to canonical `https://hidetaka.dev/...` URLs.

--- a/public/.well-known/skills/index.json
+++ b/public/.well-known/skills/index.json
@@ -1,0 +1,11 @@
+{
+  "skills": [
+    {
+      "name": "hidetaka-okamoto-profile",
+      "description": "Use when the user asks about Hidetaka Okamoto (@hideokamoto) — his background and work history, open-source projects, conference talks and speaking history, or his technical writing on Stripe, SaaS development, WordPress, and developer experience. hidetaka.dev is his bilingual (English by default, Japanese under /ja) portfolio and developer blog. Use to surface his profile, projects, talks, or articles even if the user does not mention hidetaka.dev explicitly.",
+      "files": [
+        "SKILL.md"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds Agent Skills discovery support to enable AI assistants to discover and use information about Hidetaka Okamoto's profile, projects, and writing. This implements the emerging `.well-known/skills/` standard for AI agent integration.

## Changes

- **Added Agent Skills manifest** (`public/.well-known/skills/index.json`)
  - Registers the `hidetaka-okamoto-profile` skill
  - Provides skill metadata and references the SKILL.md documentation

- **Added skill documentation** (`public/.well-known/skills/hidetaka-okamoto-profile/SKILL.md`)
  - Defines when and how to use the skill (profile, projects, talks, writing)
  - Documents bilingual structure (English + Japanese under `/ja`)
  - Lists key entry points for About, Blog, Work, Speaking, and Writing sections
  - Explains machine-readable access (sitemap, Markdown export via headers/`.md` suffix)
  - Provides guidance for AI assistants on how to help users

- **Updated Next.js config** (`next.config.ts`)
  - Added redirect from `/.well-known/agent-skills/` to `/.well-known/skills/`
  - Ensures compatibility with both current and future standardized paths
  - Uses non-permanent redirect to allow future updates

## Implementation Details

The skill manifest follows the emerging Agent Skills standard, allowing AI assistants (like Claude) to discover and reference Hidetaka's portfolio, blog, and projects. The redirect pattern provides forward compatibility while maintaining a single source of truth for skill definitions.

https://claude.ai/code/session_01Mk63SnfdsGxdAjZvYZZuKo