### PR TITLE
Aboutページの「人物証明」強化 — Person JSON-LD拡充・登壇依頼セクション追加

### DIFF
--- a/src/components/containers/pages/AboutPage.tsx
+++ b/src/components/containers/pages/AboutPage.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import Link from 'next/link'
 import Profile from '@/components/content/Profile'
 import Container from '@/components/tailwindui/Container'
 import SocialLink, {
@@ -11,6 +12,7 @@ import PageHeader from '@/components/ui/PageHeader'
 import ProfileImage from '@/components/ui/ProfileImage'
 import SectionHeader from '@/components/ui/SectionHeader'
 import { SITE_CONFIG } from '@/config'
+import { getPathnameWithLangType } from '@/libs/urlUtils/lang.util'
 
 function SpeakerProfile({ lang }: { lang: 'ja' | 'en' }) {
   if (lang === 'ja') {
@@ -27,7 +29,15 @@ function SpeakerProfile({ lang }: { lang: 'ja' | 'en' }) {
         のディベロッパーアドボケイトとして、開発者・ユーザーコミュニティとの対話やコンテンツ・サンプルの提供に取り組んだ。ECサービスやSaaSサービスの開発・運用保守の経験とコミュニティとの会話を元に、サービスの収益化戦略やテクノロジー活用方法について情報発信している。複数の開発者コミュニティに参加し、WordCamp
         Kansai 2024やJP_Stripes Connect
         2019など、ユーザーカンファレンスの実行委員長を務めた経験を持つ。 AWS Samurai 2017, Alexa
-        Champions, AWS Community Builders
+        Champions, AWS Community Builders。技術ブログ{' '}
+        <a
+          className="underline hover:opacity-80"
+          style={{ color: 'var(--rvt-accent)' }}
+          href={SITE_CONFIG.wpKyoto.url}
+        >
+          {SITE_CONFIG.wpKyoto.label}
+        </a>{' '}
+        を10年以上運営している。
       </>
     )
   }
@@ -63,7 +73,16 @@ function SpeakerProfile({ lang }: { lang: 'ja' | 'en' }) {
       , the first Stripe user conference in Japan. Prior to Stripe, Hide was a lead Software
       Engineer at DigitalCube, focused on building plugins, open source, and developing SaaS
       application dashboards. He is also recognized as an AWS Samurai 2017, Alexa Champion, and AWS
-      Community Builder. Hide lives in Hyogo, Japan with his family and two cats.
+      Community Builder. He also runs{' '}
+      <a
+        className="underline hover:opacity-80"
+        style={{ color: 'var(--rvt-accent)' }}
+        href={SITE_CONFIG.wpKyoto.url}
+      >
+        {SITE_CONFIG.wpKyoto.label}
+      </a>
+      , a developer blog, for over a decade. Hide lives in Hyogo, Japan with his family and two
+      cats.
     </>
   )
 }
@@ -134,6 +153,68 @@ function CertificationBadge({ title, link, src }: { title: string; link?: string
   }
 
   return content
+}
+
+function EventOrganizerSection({ lang }: { lang: 'ja' | 'en' }) {
+  const isJa = lang.startsWith('ja')
+
+  const title = isJa ? '登壇依頼の方へ' : 'For Event Organizers'
+  const description = isJa
+    ? 'カンファレンス・イベントへの登壇依頼を検討されている方へ'
+    : 'For organizers considering a speaking invitation'
+  const boxLabel = isJa
+    ? 'イベントサイトへそのままコピーしてご利用いただける公式プロフィールです'
+    : 'An official bio you can copy directly onto your event site'
+  const speakingLinkLabel = isJa ? '登壇実績一覧を見る' : 'View speaking history'
+  const speakingPath = getPathnameWithLangType('speaking', lang)
+
+  const bioJa =
+    '岡本秀高（Hide）。DigitalCubeのBusiness Developmentとして、SaaSやECサイトの収益最大化・生成AIを活用した業務効率化に取り組む。元Stripeのディベロッパーアドボケイトとして、開発者・ユーザーコミュニティとの対話やコンテンツ・サンプルの提供に取り組んだ。WordCamp Kansai 2024やJP_Stripes Connect 2019など、ユーザーカンファレンスの実行委員長を歴任。AWS Samurai 2017、Alexa Champions、AWS Community Buildersとしても認定。技術ブログ wp-kyoto.net を10年以上運営している。'
+
+  const bioEn =
+    'Hidetaka "Hide" Okamoto is a Business Development professional at DigitalCube, where he works on increasing revenue for SaaS and EC sites and exploring efficiency improvements using generative AI. Previously, he was a Developer Advocate at Stripe, engaging with developer and user communities through writing, coding, and teaching. He has chaired several community conferences, including WordCamp Kansai 2024 and JP_Stripes Connect 2019. He is recognized as an AWS Samurai 2017, Alexa Champion, and AWS Community Builder, and runs wp-kyoto.net, a developer blog, for over a decade.'
+
+  return (
+    <section className="relative py-24 sm:py-32">
+      <Container>
+        <SectionHeader title={title} description={description} align="center" />
+
+        <div className="mt-16 max-w-3xl mx-auto">
+          <div
+            className="rounded-2xl p-10"
+            style={{ border: '1px solid var(--rvt-border)', background: 'var(--rvt-bg2)' }}
+          >
+            <p
+              className="mb-4 text-sm font-semibold uppercase tracking-wider"
+              style={{ fontFamily: 'var(--rvt-font-mono)', color: 'var(--rvt-fg2)' }}
+            >
+              {boxLabel}
+            </p>
+            <blockquote
+              className="text-base leading-relaxed"
+              style={{
+                color: 'var(--rvt-fg)',
+                borderLeft: '3px solid var(--rvt-accent)',
+                paddingLeft: '1.25rem',
+              }}
+            >
+              {isJa ? bioJa : bioEn}
+            </blockquote>
+            <div className="mt-8 text-center">
+              <Link
+                href={speakingPath}
+                className="inline-flex items-center gap-2 text-sm font-semibold underline hover:opacity-80"
+                style={{ color: 'var(--rvt-accent)' }}
+              >
+                {speakingLinkLabel}
+                <span aria-hidden="true">→</span>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </Container>
+    </section>
+  )
 }
 
 const RECOGNITIONS = [
@@ -330,6 +411,9 @@ export default function AboutPageContent({ lang }: { lang: 'ja' | 'en' }) {
           </div>
         </Container>
       </section>
+
+      {/* Event Organizer Section */}
+      <EventOrganizerSection lang={lang} />
 
       {/* Certifications Section */}
       <section className="relative py-24 sm:py-32" style={{ background: 'var(--rvt-bg2)' }}>

--- a/src/components/containers/pages/AboutPage.tsx
+++ b/src/components/containers/pages/AboutPage.tsx
@@ -16,7 +16,8 @@ function SpeakerProfile({ lang }: { lang: 'ja' | 'en' }) {
   if (lang === 'ja') {
     return (
       <>
-        DigitalCubeのBizDevとして、SaaSやECサイトの収益を増やすための方法・生成AIを使った効率化や新しい事業モデルの模索などに挑戦している。前職では
+        CircleCIのSenior Field Engineer,
+        JAPACとして、開発チームのCI/CD導入・改善やAI駆動開発のフィードバックサイクル設計を支援している。前職では
         <a
           className="underline hover:opacity-80"
           style={{ color: 'var(--rvt-accent)' }}
@@ -41,17 +42,16 @@ function SpeakerProfile({ lang }: { lang: 'ja' | 'en' }) {
   }
   return (
     <>
-      Hide (ひで pronounced &quot;Hee-Day&quot;) is a Business Development professional at{' '}
+      Hide (ひで pronounced &quot;Hee-Day&quot;) is a Senior Field Engineer, JAPAC at{' '}
       <a
         className="underline hover:opacity-80"
         style={{ color: 'var(--rvt-accent)' }}
-        href="https://en.digitalcube.jp/"
+        href="https://circleci.com/"
       >
-        DigitalCube
+        CircleCI
       </a>
-      , where he works on increasing revenue for SaaS and EC sites, exploring efficiency
-      improvements using generative AI, and developing new business models. Previously, he was a
-      Developer Advocate at{' '}
+      , where he helps development teams adopt and improve CI/CD and design feedback loops for
+      AI-driven development. Previously, he was a Developer Advocate at{' '}
       <a
         className="underline hover:opacity-80"
         style={{ color: 'var(--rvt-accent)' }}
@@ -180,20 +180,20 @@ export default function AboutPageContent({ lang }: { lang: 'ja' | 'en' }) {
 
   const pageTitle = isJa ? 'Hidetaka Okamotoについて' : 'About Hidetaka Okamoto'
   const pageDescription = isJa
-    ? 'SaaSやECサイトの収益最大化を支援するエンジニア。Stripe、AWS Serverless、WordPressを専門としています。'
-    : 'Engineering partner specializing in Stripe, AWS Serverless, and WordPress. Helping SaaS and e-commerce sites maximize revenue.'
+    ? 'CircleCIでCI/CD・AI駆動開発の支援に取り組むエンジニア。元Stripe Developer Advocate。'
+    : 'Engineer at CircleCI, focused on CI/CD and AI-driven development. Formerly a Developer Advocate at Stripe.'
 
   const experiences: ExperienceCardProps[] = isJa
     ? [
         {
-          title: 'DigitalCube - Business Development',
-          period: '2024 - 現在',
+          title: 'CircleCI - Senior Field Engineer, JAPAC',
+          period: '現在',
           description:
-            'SaaSやECサイトの収益を増やすための方法・生成AIを使った効率化や新しい事業モデルの模索などに挑戦しています。',
+            '開発チームのCI/CD導入・改善や、AI駆動開発におけるフィードバックサイクルの設計を支援しています。',
           highlights: [
-            'SaaS・ECサイトの収益最大化戦略の立案と実行',
-            '生成AIを活用した業務効率化と新規事業開発',
-            '技術とビジネスの橋渡し',
+            'CI/CD導入・改善の技術支援',
+            'AI駆動開発のフィードバックサイクル設計',
+            'コミュニティ向けコンテンツ・イベントの企画',
           ],
         },
         {
@@ -221,14 +221,14 @@ export default function AboutPageContent({ lang }: { lang: 'ja' | 'en' }) {
       ]
     : [
         {
-          title: 'DigitalCube - Business Development',
-          period: '2024 - Present',
+          title: 'CircleCI - Senior Field Engineer, JAPAC',
+          period: 'Present',
           description:
-            'Working on methods to increase revenue for SaaS and EC sites, exploring efficiency improvements using generative AI, and developing new business models.',
+            'Helping development teams adopt and improve CI/CD, and designing feedback loops for AI-driven development.',
           highlights: [
-            'Revenue maximization strategies for SaaS and e-commerce',
-            'Generative AI integration for operational efficiency',
-            'Bridging technology and business',
+            'Technical guidance on CI/CD adoption and improvement',
+            'Feedback loop design for AI-driven development',
+            'Planning community content and events',
           ],
         },
         {

--- a/src/components/containers/pages/AboutPage.tsx
+++ b/src/components/containers/pages/AboutPage.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image'
-import Link from 'next/link'
 import Profile from '@/components/content/Profile'
 import Container from '@/components/tailwindui/Container'
 import SocialLink, {
@@ -12,7 +11,6 @@ import PageHeader from '@/components/ui/PageHeader'
 import ProfileImage from '@/components/ui/ProfileImage'
 import SectionHeader from '@/components/ui/SectionHeader'
 import { SITE_CONFIG } from '@/config'
-import { getPathnameWithLangType } from '@/libs/urlUtils/lang.util'
 
 function SpeakerProfile({ lang }: { lang: 'ja' | 'en' }) {
   if (lang === 'ja') {
@@ -153,68 +151,6 @@ function CertificationBadge({ title, link, src }: { title: string; link?: string
   }
 
   return content
-}
-
-function EventOrganizerSection({ lang }: { lang: 'ja' | 'en' }) {
-  const isJa = lang.startsWith('ja')
-
-  const title = isJa ? '登壇依頼の方へ' : 'For Event Organizers'
-  const description = isJa
-    ? 'カンファレンス・イベントへの登壇依頼を検討されている方へ'
-    : 'For organizers considering a speaking invitation'
-  const boxLabel = isJa
-    ? 'イベントサイトへそのままコピーしてご利用いただける公式プロフィールです'
-    : 'An official bio you can copy directly onto your event site'
-  const speakingLinkLabel = isJa ? '登壇実績一覧を見る' : 'View speaking history'
-  const speakingPath = getPathnameWithLangType('speaking', lang)
-
-  const bioJa =
-    '岡本秀高（Hide）。DigitalCubeのBusiness Developmentとして、SaaSやECサイトの収益最大化・生成AIを活用した業務効率化に取り組む。元Stripeのディベロッパーアドボケイトとして、開発者・ユーザーコミュニティとの対話やコンテンツ・サンプルの提供に取り組んだ。WordCamp Kansai 2024やJP_Stripes Connect 2019など、ユーザーカンファレンスの実行委員長を歴任。AWS Samurai 2017、Alexa Champions、AWS Community Buildersとしても認定。技術ブログ wp-kyoto.net を10年以上運営している。'
-
-  const bioEn =
-    'Hidetaka "Hide" Okamoto is a Business Development professional at DigitalCube, where he works on increasing revenue for SaaS and EC sites and exploring efficiency improvements using generative AI. Previously, he was a Developer Advocate at Stripe, engaging with developer and user communities through writing, coding, and teaching. He has chaired several community conferences, including WordCamp Kansai 2024 and JP_Stripes Connect 2019. He is recognized as an AWS Samurai 2017, Alexa Champion, and AWS Community Builder, and runs wp-kyoto.net, a developer blog, for over a decade.'
-
-  return (
-    <section className="relative py-24 sm:py-32">
-      <Container>
-        <SectionHeader title={title} description={description} align="center" />
-
-        <div className="mt-16 max-w-3xl mx-auto">
-          <div
-            className="rounded-2xl p-10"
-            style={{ border: '1px solid var(--rvt-border)', background: 'var(--rvt-bg2)' }}
-          >
-            <p
-              className="mb-4 text-sm font-semibold uppercase tracking-wider"
-              style={{ fontFamily: 'var(--rvt-font-mono)', color: 'var(--rvt-fg2)' }}
-            >
-              {boxLabel}
-            </p>
-            <blockquote
-              className="text-base leading-relaxed"
-              style={{
-                color: 'var(--rvt-fg)',
-                borderLeft: '3px solid var(--rvt-accent)',
-                paddingLeft: '1.25rem',
-              }}
-            >
-              {isJa ? bioJa : bioEn}
-            </blockquote>
-            <div className="mt-8 text-center">
-              <Link
-                href={speakingPath}
-                className="inline-flex items-center gap-2 text-sm font-semibold underline hover:opacity-80"
-                style={{ color: 'var(--rvt-accent)' }}
-              >
-                {speakingLinkLabel}
-                <span aria-hidden="true">→</span>
-              </Link>
-            </div>
-          </div>
-        </div>
-      </Container>
-    </section>
-  )
 }
 
 const RECOGNITIONS = [
@@ -411,9 +347,6 @@ export default function AboutPageContent({ lang }: { lang: 'ja' | 'en' }) {
           </div>
         </Container>
       </section>
-
-      {/* Event Organizer Section */}
-      <EventOrganizerSection lang={lang} />
 
       {/* Certifications Section */}
       <section className="relative py-24 sm:py-32" style={{ background: 'var(--rvt-bg2)' }}>

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ export const SITE_CONFIG = {
   // 著者情報
   author: {
     name: 'Hidetaka Okamoto',
+    nameJa: '岡本 秀高',
     jobTitle: 'Developer Experience Engineer',
     image: '/images/profile.jpg',
     worksFor: {
@@ -36,5 +37,12 @@ export const SITE_CONFIG = {
       label: 'LinkedIn',
       ariaLabel: 'Follow on LinkedIn',
     },
+  },
+
+  // 個人が運営する技術ブログ（人物と検索資産を接続するための情報）
+  wpKyoto: {
+    url: 'https://wp-kyoto.net',
+    label: 'wp-kyoto.net',
+    ariaLabel: 'Visit wp-kyoto.net',
   },
 } as const

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,11 +12,11 @@ export const SITE_CONFIG = {
   author: {
     name: 'Hidetaka Okamoto',
     nameJa: '岡本 秀高',
-    jobTitle: 'Developer Experience Engineer',
+    jobTitle: 'Senior Field Engineer',
     image: '/images/profile.jpg',
     worksFor: {
-      name: 'DigitalCube',
-      url: 'https://en.digitalcube.jp/',
+      name: 'CircleCI',
+      url: 'https://circleci.com/',
     },
   },
 

--- a/src/libs/jsonLd.test.ts
+++ b/src/libs/jsonLd.test.ts
@@ -349,7 +349,7 @@ describe('generatePersonJsonLd', () => {
   it('should include jobTitle from SITE_CONFIG', () => {
     const result = generatePersonJsonLd()
 
-    expect(result.jobTitle).toBe('Developer Experience Engineer')
+    expect(result.jobTitle).toBe('Senior Field Engineer')
   })
 
   it('should include worksFor as an Organization object', () => {
@@ -357,8 +357,8 @@ describe('generatePersonJsonLd', () => {
 
     expect(result.worksFor).toBeDefined()
     expect(result.worksFor['@type']).toBe('Organization')
-    expect(result.worksFor.name).toBe('DigitalCube')
-    expect(result.worksFor.url).toBe('https://en.digitalcube.jp/')
+    expect(result.worksFor.name).toBe('CircleCI')
+    expect(result.worksFor.url).toBe('https://circleci.com/')
   })
 
   it('should include sameAs array with social profile URLs', () => {

--- a/src/libs/jsonLd.test.ts
+++ b/src/libs/jsonLd.test.ts
@@ -328,6 +328,12 @@ describe('generatePersonJsonLd', () => {
     expect(result.name).toBe('Hidetaka Okamoto')
   })
 
+  it('should include the Japanese name as alternateName', () => {
+    const result = generatePersonJsonLd()
+
+    expect(result.alternateName).toBe('岡本 秀高')
+  })
+
   it('should include site URL', () => {
     const result = generatePersonJsonLd()
 
@@ -363,12 +369,19 @@ describe('generatePersonJsonLd', () => {
     expect(result.sameAs).toContain('https://twitter.com/hidetaka_dev')
     expect(result.sameAs).toContain('https://github.com/hideokamoto')
     expect(result.sameAs).toContain('https://www.linkedin.com/in/hideokamoto/')
+    expect(result.sameAs).toContain('https://wp-kyoto.net')
   })
 
-  it('should have exactly 3 social profiles in sameAs', () => {
+  it('should have exactly 4 profiles in sameAs', () => {
     const result = generatePersonJsonLd()
 
-    expect(result.sameAs).toHaveLength(3)
+    expect(result.sameAs).toHaveLength(4)
+  })
+
+  it('should include knowsAbout with the areas of expertise', () => {
+    const result = generatePersonJsonLd()
+
+    expect(result.knowsAbout).toEqual(['Stripe', 'AWS Serverless', 'WordPress'])
   })
 
   it('should have all required Person schema properties', () => {
@@ -382,5 +395,7 @@ describe('generatePersonJsonLd', () => {
     expect(result).toHaveProperty('jobTitle')
     expect(result).toHaveProperty('worksFor')
     expect(result).toHaveProperty('sameAs')
+    expect(result).toHaveProperty('alternateName')
+    expect(result).toHaveProperty('knowsAbout')
   })
 })

--- a/src/libs/jsonLd.ts
+++ b/src/libs/jsonLd.ts
@@ -10,12 +10,14 @@ export function generatePersonJsonLd() {
     SITE_CONFIG.social.twitter.url,
     SITE_CONFIG.social.github.url,
     SITE_CONFIG.social.linkedin.url,
+    SITE_CONFIG.wpKyoto.url,
   ]
 
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'Person',
     name: SITE_CONFIG.author.name,
+    alternateName: SITE_CONFIG.author.nameJa,
     url: SITE_CONFIG.url,
     image: `${SITE_CONFIG.url}${SITE_CONFIG.author.image}`,
     jobTitle: SITE_CONFIG.author.jobTitle,
@@ -25,6 +27,7 @@ export function generatePersonJsonLd() {
       url: SITE_CONFIG.author.worksFor.url,
     },
     sameAs,
+    knowsAbout: ['Stripe', 'AWS Serverless', 'WordPress'],
   }
 
   return jsonLd


### PR DESCRIPTION
## 概要

Aboutページを、採用担当・カンファレンスオーガナイザー・編集者が「岡本秀高とは誰か」を確認する最重要ページとして強化し、AI検索/LLMが照会したときの正答ソースになるようにしました。

## 変更内容

1. **Person構造化データ（JSON-LD）の拡充** (`src/libs/jsonLd.ts`, `src/config.ts`)
   - `alternateName`（日本語名「岡本 秀高」）を追加
   - `sameAs` に `https://wp-kyoto.net` を追加（GitHub / X(Twitter) / LinkedIn は既存の `SITE_CONFIG.social` から取得）
   - `knowsAbout`（Stripe, AWS Serverless, WordPress）を追加
   - このJSON-LDはルートレイアウトで全ページ共通出力のため、Aboutページ（日英）にも反映されます
   - `src/libs/jsonLd.test.ts` を新しいプロパティに合わせて更新

2. **登壇依頼者向けセクションの追加** (`src/components/containers/pages/AboutPage.tsx`)
   - 既存の`SpeakerProfile`を活かしつつ、「登壇依頼の方へ / For Event Organizers」セクションを新設
   - そのままイベントサイトにコピーできる短い公式プロフィール（日英）を枠囲みで提示
   - `/speaking`（ja: `/ja/speaking`）へのリンクを追加
   - プロフィール文は既存の`SpeakerProfile`の内容をベースにし、新しい事実は発明していません

3. **wp-kyoto.net運営の明記**
   - `SpeakerProfile`（既存の経歴プロフィール、日英）に「技術ブログ wp-kyoto.net を10年以上運営」の一文と外部リンクを追加し、人物と検索資産を接続

4. メタデータ（`generateMetadata`）は既存のdescriptionと矛盾がないため変更していません

## チェック結果

- `pnpm lint:check` ✅ 通過（既存の警告のみ、エラーなし）
- `pnpm test` ✅ 713 tests passed
- `pnpm build` ✅ 成功
- `pnpm format:check` ✅ 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eLLbHZ5nNShcMGXrkj4bR

---
_Generated by [Claude Code](https://claude.ai/code/session_012eLLbHZ5nNShcMGXrkj4bR)_