### PR TITLE
feat: TOPページと記事詳細にフォロー/購読導線を追加

### DIFF
--- a/src/app/ja/page.tsx
+++ b/src/app/ja/page.tsx
@@ -3,6 +3,7 @@ import FeaturedContent from '@/components/containers/FeaturedContent'
 import Hero from '@/components/Hero/Hero'
 import Capabilities from '@/components/home/Capabilities'
 import StackShowcase from '@/components/home/StackShowcase'
+import FollowCTA from '@/components/ui/FollowCTA'
 import { buildAlternates } from '@/libs/metadata'
 
 export const metadata: Metadata = {
@@ -18,6 +19,7 @@ export default async function HomePage() {
       <Capabilities lang={lang} />
       <StackShowcase lang={lang} />
       <FeaturedContent lang={lang} />
+      <FollowCTA lang={lang} variant="section" />
     </>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import FeaturedContent from '@/components/containers/FeaturedContent'
 import Hero from '@/components/Hero/Hero'
 import Capabilities from '@/components/home/Capabilities'
 import StackShowcase from '@/components/home/StackShowcase'
+import FollowCTA from '@/components/ui/FollowCTA'
 import { buildAlternates } from '@/libs/metadata'
 
 export const metadata: Metadata = {
@@ -18,6 +19,7 @@ export default async function HomePage() {
       <Capabilities lang={lang} />
       <StackShowcase lang={lang} />
       <FeaturedContent lang={lang} />
+      <FollowCTA lang={lang} variant="section" />
     </>
   )
 }

--- a/src/components/containers/pages/BlogDetailPage.tsx
+++ b/src/components/containers/pages/BlogDetailPage.tsx
@@ -7,6 +7,7 @@ import ArticleCTA from '@/components/ui/ArticleCTA'
 import ArticleMeta from '@/components/ui/ArticleMeta'
 import BlogDetailSidebar from '@/components/ui/BlogDetailSidebar'
 import CategoryTagList from '@/components/ui/CategoryTagList'
+import FollowCTA from '@/components/ui/FollowCTA'
 import PageShell from '@/components/ui/PageShell'
 import ProfileCard from '@/components/ui/ProfileCard'
 import RelatedArticles from '@/components/ui/RelatedArticles'
@@ -175,6 +176,9 @@ export default function BlogDetailPage({
 
           {/* 関連記事 */}
           <RelatedArticles articles={relatedArticles} lang={lang} />
+
+          {/* フォロー導線（読者捕捉CTA） */}
+          <FollowCTA lang={lang} variant="card" />
 
           {/* 前後の記事へのナビゲーション（モバイルのみ表示） */}
           {(previousThought || nextThought) && (

--- a/src/components/containers/pages/DevNoteDetailPage.tsx
+++ b/src/components/containers/pages/DevNoteDetailPage.tsx
@@ -6,6 +6,7 @@ import ArticleCTA from '@/components/ui/ArticleCTA'
 import ArticleMeta from '@/components/ui/ArticleMeta'
 import CategoryTagList from '@/components/ui/CategoryTagList'
 import DevNoteDetailSidebar from '@/components/ui/DevNoteDetailSidebar'
+import FollowCTA from '@/components/ui/FollowCTA'
 import PageShell from '@/components/ui/PageShell'
 import ProfileCard from '@/components/ui/ProfileCard'
 import RelatedArticles from '@/components/ui/RelatedArticles'
@@ -149,6 +150,9 @@ export default function DevNoteDetailPage({
 
           {/* 関連記事 */}
           <RelatedArticles articles={relatedArticles} lang={lang} />
+
+          {/* フォロー導線（読者捕捉CTA） */}
+          <FollowCTA lang={lang} variant="card" />
 
           {/* 前後の記事へのナビゲーション（モバイルのみ表示） */}
           {(previousNote || nextNote) && (

--- a/src/components/ui/FollowCTA.tsx
+++ b/src/components/ui/FollowCTA.tsx
@@ -1,0 +1,154 @@
+import type { ReactNode } from 'react'
+import GitHubIcon from '@/components/tailwindui/SocialIcons/GitHub'
+import TwitterIcon from '@/components/tailwindui/SocialIcons/Twitter'
+import { SITE_CONFIG } from '@/config'
+import { getActionButtonStyles } from '@/libs/componentStyles.utils'
+
+type FollowCTAVariant = 'section' | 'card'
+
+type FollowCTAProps = {
+  /** 表示言語 */
+  lang: string
+  /** X (Twitter) のフォローURL。未指定時はSITE_CONFIGの値を使用 */
+  twitterUrl?: string
+  /** GitHubのフォローURL。未指定時はSITE_CONFIGの値を使用 */
+  githubUrl?: string
+  /**
+   * 表示スタイル
+   * - 'section': TOPページ向け。上部に区切り線を持つ独立したセクションとして表示
+   * - 'card': 記事詳細ページ向け。本文中に差し込むカード表示
+   */
+  variant?: FollowCTAVariant
+  /** 追加のCSSクラス */
+  className?: string
+}
+
+function FollowButton({
+  href,
+  icon,
+  label,
+  variant,
+}: {
+  href: string
+  icon: ReactNode
+  label: string
+  variant: 'primary' | 'secondary'
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={label}
+      className={getActionButtonStyles(variant)}
+    >
+      {icon}
+      <span>{label}</span>
+    </a>
+  )
+}
+
+type FollowCTACardProps = {
+  lang: string
+  twitterUrl: string
+  githubUrl: string
+  className?: string
+}
+
+function FollowCTACard({ lang, twitterUrl, githubUrl, className = '' }: FollowCTACardProps) {
+  const isJapanese = lang.startsWith('ja')
+
+  const heading = isJapanese ? '更新を見逃さないために' : 'Never miss an update'
+  const description = isJapanese
+    ? 'この記事が気に入ったら、X (Twitter) やGitHubをフォローして次回の更新をチェックしてください。'
+    : 'If you enjoyed this article, follow on X (Twitter) or GitHub to catch the next update.'
+  const twitterLabel = isJapanese ? 'Xでフォロー' : 'Follow on X'
+  const githubLabel = isJapanese ? 'GitHubでフォロー' : 'Follow on GitHub'
+
+  return (
+    <section
+      className={`rounded-lg border p-6 shadow-sm transition-shadow hover:shadow-md sm:p-8 lg:p-10 ${className}`}
+      style={{ background: 'var(--rvt-bg2)', borderColor: 'var(--rvt-border)' }}
+      aria-label={isJapanese ? '更新の通知を受け取るセクション' : 'Follow for updates'}
+    >
+      <h2
+        className="mb-3 text-xl font-bold leading-tight sm:mb-4 sm:text-2xl md:text-3xl"
+        style={{ fontFamily: 'var(--rvt-font-display)', color: 'var(--rvt-fg)' }}
+      >
+        {heading}
+      </h2>
+      <p
+        className="mb-5 text-sm leading-relaxed sm:mb-6 sm:text-base md:text-lg"
+        style={{ color: 'var(--rvt-fg2)' }}
+      >
+        {description}
+      </p>
+      <nav
+        className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:gap-4"
+        aria-label={isJapanese ? 'フォロー導線' : 'Follow links'}
+      >
+        <FollowButton
+          href={twitterUrl}
+          icon={<TwitterIcon className="h-4 w-4 flex-none fill-current" />}
+          label={twitterLabel}
+          variant="primary"
+        />
+        <FollowButton
+          href={githubUrl}
+          icon={<GitHubIcon className="h-4 w-4 flex-none fill-current" />}
+          label={githubLabel}
+          variant="secondary"
+        />
+      </nav>
+    </section>
+  )
+}
+
+/**
+ * FollowCTA コンポーネント
+ *
+ * 読者にX (Twitter) / GitHubのフォローを促すコールトゥアクション。
+ * TOPページの独立セクション（`variant="section"`）と、記事詳細ページ本文内の
+ * カード表示（`variant="card"`、デフォルト）の両方で利用できる。
+ *
+ * 純粋なUIコンポーネントとしてpropsのみに依存する。SITE_CONFIGはビルド時に
+ * 固定されるサイト設定であり、副作用（データ取得など）を持たない。
+ */
+export default function FollowCTA({
+  lang,
+  twitterUrl = SITE_CONFIG.social.twitter.url,
+  githubUrl = SITE_CONFIG.social.github.url,
+  variant = 'card',
+  className = '',
+}: FollowCTAProps) {
+  if (variant === 'card') {
+    return (
+      <FollowCTACard
+        lang={lang}
+        twitterUrl={twitterUrl}
+        githubUrl={githubUrl}
+        className={`my-8 sm:my-10 md:my-12 ${className}`}
+      />
+    )
+  }
+
+  const isJapanese = lang.startsWith('ja')
+  const eyebrowLabel = isJapanese ? '更新をチェック' : 'STAY UPDATED'
+
+  return (
+    <section
+      style={{ position: 'relative', zIndex: 1, borderTop: '1px solid var(--rvt-border)' }}
+      className={`py-24 sm:py-32 ${className}`}
+    >
+      <div className="mx-auto max-w-7xl px-4 sm:px-8 lg:px-12">
+        <p
+          className="mb-5 text-[11px] uppercase tracking-[0.15em]"
+          style={{ fontFamily: 'var(--rvt-font-mono)', color: 'var(--rvt-accent)' }}
+        >
+          {eyebrowLabel}
+        </p>
+        <FollowCTACard lang={lang} twitterUrl={twitterUrl} githubUrl={githubUrl} />
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## 背景

このサイトは流入の83%がDirect+SNSであり、記事がバイラルしても読者を継続的に捕捉する導線がなく、翌月には離脱してしまうという課題があります。TOPページと記事詳細ページに「フォロー/購読」導線を追加し、読者をX (Twitter) / GitHubのフォローへ誘導することで、単発の流入をリピーターへ転換します。

## 変更内容

- 新規UIコンポーネント `src/components/ui/FollowCTA.tsx` を追加
  - 純粋なpropsベースのコンポーネント（三層構造のUI層）
  - `lang` propで日英切替、`variant="section"`（TOPページ用の独立セクション）/ `variant="card"`（記事本文内カード）を切替可能
  - X (Twitter) / GitHubのフォローリンクを表示。URLは `SITE_CONFIG.social` から解決
  - 折衷 (Setchū) デザイントークン（`--rvt-*` / remapped Tailwindクラス）のみを使用し、既存の `ArticleCTA` / `ProfileCard` と同じ見た目のパターンを踏襲
  - ダークモード・レスポンシブ対応済み
- `src/app/page.tsx` / `src/app/ja/page.tsx`: `FeaturedContent` の直後に `FollowCTA variant="section"` を追加
- `src/components/containers/pages/BlogDetailPage.tsx`: 関連記事の直後に `FollowCTA variant="card"` を追加（英語・日本語ブログ記事詳細の両方に反映）
- `src/components/containers/pages/DevNoteDetailPage.tsx`: 同様にDev Notes記事詳細にも追加

### RSSフィードについて

`src/app/` 配下にRSS/feedルートが存在しないため、今回はRSSへの導線は追加していません（X / GitHubフォローのみ）。将来的にRSSルートを新設する場合は `FollowCTA` に導線を追加できます。

## チェック結果

- ✅ `pnpm lint:check` — pass（既存の警告のみ、新規エラーなし）
- ✅ `pnpm test` — 711 tests passed
- ✅ `pnpm build` — 成功（Qiita APIの403エラーは既存の外部API起因でフォールバックデータ使用、今回の変更とは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eLLbHZ5nNShcMGXrkj4bR

---
_Generated by [Claude Code](https://claude.ai/code/session_012eLLbHZ5nNShcMGXrkj4bR)_