### PR TITLE
feat: /about に実績サマリー（活動の記録）セクションを追加

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,11 +1,18 @@
 import AboutPageContent from '@/components/containers/pages/AboutPage'
+import ProfileStatsSection from '@/components/ui/stats/ProfileStatsSection'
 import { buildAlternates } from '@/libs/metadata'
+import { loadProfileStats } from '@/libs/stats/loadProfileStats'
 
 export const metadata = {
   alternates: buildAlternates('/about'),
   title: 'About',
 }
 
-export default function AboutPage() {
-  return <AboutPageContent lang="en" />
+// ISR: 実績の数字は日単位でしか動かないため1日ごとに再検証
+export const revalidate = 86400
+
+export default async function AboutPage() {
+  const stats = await loadProfileStats()
+
+  return <AboutPageContent lang="en" statsSlot={<ProfileStatsSection stats={stats} lang="en" />} />
 }

--- a/src/app/ja/about/page.tsx
+++ b/src/app/ja/about/page.tsx
@@ -1,11 +1,18 @@
 import AboutPageContent from '@/components/containers/pages/AboutPage'
+import ProfileStatsSection from '@/components/ui/stats/ProfileStatsSection'
 import { buildAlternates } from '@/libs/metadata'
+import { loadProfileStats } from '@/libs/stats/loadProfileStats'
 
 export const metadata = {
   alternates: buildAlternates('/ja/about'),
   title: 'About',
 }
 
-export default function AboutPage() {
-  return <AboutPageContent lang="ja" />
+// ISR: 実績の数字は日単位でしか動かないため1日ごとに再検証
+export const revalidate = 86400
+
+export default async function AboutPage() {
+  const stats = await loadProfileStats()
+
+  return <AboutPageContent lang="ja" statsSlot={<ProfileStatsSection stats={stats} lang="ja" />} />
 }

--- a/src/components/containers/pages/AboutPage.tsx
+++ b/src/components/containers/pages/AboutPage.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import type { ReactNode } from 'react'
 import Profile from '@/components/content/Profile'
 import Container from '@/components/tailwindui/Container'
 import SocialLink, {
@@ -175,7 +176,35 @@ function RecognitionBadge({ title, issuer }: { title: string; issuer: string }) 
   )
 }
 
-export default function AboutPageContent({ lang }: { lang: 'ja' | 'en' }) {
+function TrackRecordSection({ isJa, children }: { isJa: boolean; children?: ReactNode }) {
+  // 実績データを渡されていないページ（静的レンダリング）ではセクションごと出さない
+  if (!children) return null
+
+  return (
+    <section className="relative py-24 sm:py-32" style={{ background: 'var(--rvt-bg3)' }}>
+      <Container>
+        <SectionHeader
+          title={isJa ? '活動の記録' : 'Track Record'}
+          description={
+            isJa
+              ? '執筆・OSS・登壇の積み上げを数字で'
+              : 'Writing, open source, and speaking in numbers'
+          }
+          align="center"
+        />
+        <div className="mt-20">{children}</div>
+      </Container>
+    </section>
+  )
+}
+
+type AboutPageContentProps = {
+  lang: 'ja' | 'en'
+  /** 実績サマリー（ProfileStatsSection）。データ取得はページ側で行う。 */
+  statsSlot?: ReactNode
+}
+
+export default function AboutPageContent({ lang, statsSlot }: AboutPageContentProps) {
   const isJa = lang.startsWith('ja')
 
   const pageTitle = isJa ? 'Hidetaka Okamotoについて' : 'About Hidetaka Okamoto'
@@ -309,6 +338,9 @@ export default function AboutPageContent({ lang }: { lang: 'ja' | 'en' }) {
           </div>
         </Container>
       </section>
+
+      {/* Track Record Section */}
+      <TrackRecordSection isJa={isJa}>{statsSlot}</TrackRecordSection>
 
       {/* Experience Section */}
       <section className="relative py-24 sm:py-32">

--- a/src/components/ui/stats/ProfileStatsSection.tsx
+++ b/src/components/ui/stats/ProfileStatsSection.tsx
@@ -1,0 +1,191 @@
+import type { OssStats, ProfileStats, WritingStats } from '@/libs/stats/loadProfileStats'
+import { WRITING_SOURCE_LABEL } from '@/libs/stats/loadProfileStats'
+import StatCardGrid, { type StatCardItem } from './StatCardGrid'
+import YearlyActivityTable from './YearlyActivityTable'
+
+type Props = {
+  stats: ProfileStats
+  lang: string
+}
+
+// 文言は言語ごとにまとめて持ち、組み立て側では分岐しない。
+type StatsCopy = {
+  articles: { label: string; value: (total: string) => string; hint: string }
+  yearsWriting: { label: string; value: (years: number) => string; hint: (from: number) => string }
+  packages: { label: string; hint: (npm: string, wporg: string) => string }
+  activeInstalls: { label: string; hint: string }
+  downloads: { label: string; hint: string }
+  speaking: { label: string; value: (count: string) => string; hint: string }
+  tableTitle: string
+  tableNote: string
+}
+
+const JA_COPY: StatsCopy = {
+  articles: {
+    label: '累計記事数',
+    value: (total) => `${total}本`,
+    hint: `${WRITING_SOURCE_LABEL}（日本語 + 英語）`,
+  },
+  yearsWriting: {
+    label: '発信歴',
+    value: (years) => `${years}年`,
+    hint: (from) => `${from}年から継続`,
+  },
+  packages: {
+    label: '公開パッケージ',
+    hint: (npm, wporg) => `npm ${npm} / WordPress.org ${wporg}`,
+  },
+  activeInstalls: {
+    label: '稼働サイト数',
+    hint: 'WordPress.org プラグインを利用中のサイト',
+  },
+  downloads: {
+    label: '累計ダウンロード',
+    hint: 'WordPress.org プラグイン',
+  },
+  speaking: {
+    label: '登壇レポート',
+    value: (count) => `${count}本`,
+    hint: 'イベント登壇の記録',
+  },
+  tableTitle: '年別の執筆本数',
+  tableNote: `${WRITING_SOURCE_LABEL} の公開日を基準に集計（日本語 + 英語）。本年は集計途中の数値です。`,
+}
+
+const EN_COPY: StatsCopy = {
+  articles: {
+    label: 'Articles published',
+    value: (total) => total,
+    hint: `${WRITING_SOURCE_LABEL} (Japanese + English)`,
+  },
+  yearsWriting: {
+    label: 'Years writing',
+    value: (years) => `${years}`,
+    hint: (from) => `Continuously since ${from}`,
+  },
+  packages: {
+    label: 'Published packages',
+    hint: (npm, wporg) => `${npm} on npm / ${wporg} on WordPress.org`,
+  },
+  activeInstalls: {
+    label: 'Active installations',
+    hint: 'Sites running my WordPress.org plugins',
+  },
+  downloads: {
+    label: 'Total downloads',
+    hint: 'WordPress.org plugins',
+  },
+  speaking: {
+    label: 'Speaking reports',
+    value: (count) => count,
+    hint: 'Write-ups from events I spoke at',
+  },
+  tableTitle: 'Articles per year',
+  tableNote: `Based on publication dates on ${WRITING_SOURCE_LABEL} (Japanese + English). The current year is still in progress.`,
+}
+
+type NumberFormatter = (value: number) => string
+
+const buildWritingCards = (
+  writing: WritingStats,
+  copy: StatsCopy,
+  num: NumberFormatter,
+): StatCardItem[] => {
+  const cards: StatCardItem[] = [
+    {
+      label: copy.articles.label,
+      value: copy.articles.value(num(writing.total)),
+      hint: copy.articles.hint,
+    },
+  ]
+
+  if (writing.firstYear !== null) {
+    cards.push({
+      label: copy.yearsWriting.label,
+      value: copy.yearsWriting.value(writing.yearsActive),
+      hint: copy.yearsWriting.hint(writing.firstYear),
+    })
+  }
+
+  return cards
+}
+
+const buildOssCards = (oss: OssStats, copy: StatsCopy, num: NumberFormatter): StatCardItem[] => {
+  const cards: StatCardItem[] = [
+    {
+      label: copy.packages.label,
+      value: num(oss.npmPackages + oss.wpPlugins),
+      hint: copy.packages.hint(num(oss.npmPackages), num(oss.wpPlugins)),
+    },
+  ]
+
+  if (oss.activeInstalls > 0) {
+    cards.push({
+      label: copy.activeInstalls.label,
+      value: num(oss.activeInstalls),
+      hint: copy.activeInstalls.hint,
+    })
+  }
+
+  if (oss.downloads > 0) {
+    cards.push({
+      label: copy.downloads.label,
+      value: num(oss.downloads),
+      hint: copy.downloads.hint,
+    })
+  }
+
+  return cards
+}
+
+/**
+ * /about の実績サマリー。
+ * 取得できなかった指標（null）はカードごと省き、0 を並べない。
+ */
+export default function ProfileStatsSection({ stats, lang }: Props) {
+  const isJa = lang === 'ja'
+  const copy = isJa ? JA_COPY : EN_COPY
+  const locale = isJa ? 'ja-JP' : 'en-US'
+  const num: NumberFormatter = (value) => value.toLocaleString(locale)
+
+  const { writing, speakingReports, oss } = stats
+
+  const items: StatCardItem[] = [
+    ...(writing ? buildWritingCards(writing, copy, num) : []),
+    ...(oss ? buildOssCards(oss, copy, num) : []),
+    ...(speakingReports
+      ? [
+          {
+            label: copy.speaking.label,
+            value: copy.speaking.value(num(speakingReports)),
+            hint: copy.speaking.hint,
+          },
+        ]
+      : []),
+  ]
+
+  if (items.length === 0) return null
+
+  const series = writing?.series ?? []
+
+  return (
+    <div className="space-y-12">
+      <StatCardGrid items={items} columns="2/3" />
+
+      {series.length > 0 && (
+        <div
+          className="rounded-2xl p-6 sm:p-8"
+          style={{ border: '1px solid var(--rvt-border)', background: 'var(--rvt-bg2)' }}
+        >
+          <h3
+            className="mb-6 text-sm font-semibold uppercase tracking-wider"
+            style={{ fontFamily: 'var(--rvt-font-mono)', color: 'var(--rvt-fg2)' }}
+          >
+            {copy.tableTitle}
+          </h3>
+          <YearlyActivityTable series={series} lang={lang} note={copy.tableNote} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/stats/ProfileStatsSection.tsx
+++ b/src/components/ui/stats/ProfileStatsSection.tsx
@@ -24,7 +24,7 @@ const JA_COPY: StatsCopy = {
   articles: {
     label: '累計記事数',
     value: (total) => `${total}本`,
-    hint: `${WRITING_SOURCE_LABEL}（日本語 + 英語）`,
+    hint: `${WRITING_SOURCE_LABEL}（投稿・雑記・Stripe・DevNotes / 日本語 + 英語）`,
   },
   yearsWriting: {
     label: '発信歴',
@@ -49,14 +49,14 @@ const JA_COPY: StatsCopy = {
     hint: 'イベント登壇の記録',
   },
   tableTitle: '年別の執筆本数',
-  tableNote: `${WRITING_SOURCE_LABEL} の公開日を基準に集計（日本語 + 英語）。本年は集計途中の数値です。`,
+  tableNote: `${WRITING_SOURCE_LABEL} の全記事（投稿・雑記・Stripe・DevNotes）の公開日を基準に集計。本年は集計途中の数値です。`,
 }
 
 const EN_COPY: StatsCopy = {
   articles: {
     label: 'Articles published',
     value: (total) => total,
-    hint: `${WRITING_SOURCE_LABEL} (Japanese + English)`,
+    hint: `${WRITING_SOURCE_LABEL} (blog, notes, Stripe, dev notes / Japanese + English)`,
   },
   yearsWriting: {
     label: 'Years writing',
@@ -81,7 +81,7 @@ const EN_COPY: StatsCopy = {
     hint: 'Write-ups from events I spoke at',
   },
   tableTitle: 'Articles per year',
-  tableNote: `Based on publication dates on ${WRITING_SOURCE_LABEL} (Japanese + English). The current year is still in progress.`,
+  tableNote: `Based on publication dates of every article on ${WRITING_SOURCE_LABEL} (blog, notes, Stripe, dev notes). The current year is still in progress.`,
 }
 
 type NumberFormatter = (value: number) => string

--- a/src/components/ui/stats/StatCardGrid.tsx
+++ b/src/components/ui/stats/StatCardGrid.tsx
@@ -1,0 +1,60 @@
+export type StatCardItem = {
+  /** 指標名 */
+  label: string
+  /** 表示する値（整形済みの文字列） */
+  value: string
+  /** 補足（出典や内訳） */
+  hint?: string
+}
+
+/** 列レイアウト。`'2/3'` は sm で2列・lg で3列（カード数が多いとき向け）。 */
+export type StatCardColumns = 2 | 3 | '2/3'
+
+type Props = {
+  items: StatCardItem[]
+  /** 列レイアウト。既定は 3。 */
+  columns?: StatCardColumns
+  className?: string
+}
+
+// Tailwind の JIT が拾えるよう、クラス名は完全な文字列で保持する。
+const COLUMN_CLASSES: Record<StatCardColumns, string> = {
+  2: 'sm:grid-cols-2',
+  3: 'sm:grid-cols-3',
+  '2/3': 'sm:grid-cols-2 lg:grid-cols-3',
+}
+
+/**
+ * 数値ハイライトのカードグリッド。
+ * 値の整形（単位・桁区切り・i18n）は呼び出し側の責務。
+ */
+export default function StatCardGrid({ items, columns = 3, className = '' }: Props) {
+  if (items.length === 0) return null
+
+  return (
+    <dl className={`grid grid-cols-1 gap-4 ${COLUMN_CLASSES[columns]} ${className}`.trim()}>
+      {items.map((item) => (
+        <div
+          key={item.label}
+          className="rounded-2xl p-6 text-center"
+          style={{ border: '1px solid var(--rvt-border)', background: 'var(--rvt-bg2)' }}
+        >
+          <dt className="text-sm font-medium" style={{ color: 'var(--rvt-fg2)' }}>
+            {item.label}
+          </dt>
+          <dd
+            className="mt-2 text-4xl font-extrabold tracking-tight"
+            style={{ color: 'var(--rvt-accent)' }}
+          >
+            {item.value}
+          </dd>
+          {item.hint && (
+            <p className="mt-2 text-xs leading-relaxed" style={{ color: 'var(--rvt-fg3)' }}>
+              {item.hint}
+            </p>
+          )}
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/src/components/ui/stats/StatHighlights.tsx
+++ b/src/components/ui/stats/StatHighlights.tsx
@@ -1,3 +1,5 @@
+import StatCardGrid, { type StatCardItem } from './StatCardGrid'
+
 type Props = {
   total: number
   currentWeeks: number
@@ -5,18 +7,12 @@ type Props = {
   lang: string
 }
 
-type Highlight = {
-  label: string
-  value: string
-  hint?: string
-}
-
 export default function StatHighlights({ total, currentWeeks, longestWeeks, lang }: Props) {
   const isJa = lang === 'ja'
 
   const weeksUnit = (n: number): string => (isJa ? `${n}週` : `${n} ${n === 1 ? 'week' : 'weeks'}`)
 
-  const highlights: Highlight[] = [
+  const highlights: StatCardItem[] = [
     {
       label: isJa ? '直近12ヶ月の投稿数' : 'Posts (last 12 months)',
       value: isJa ? `${total.toLocaleString()}本` : total.toLocaleString(),
@@ -31,25 +27,5 @@ export default function StatHighlights({ total, currentWeeks, longestWeeks, lang
     },
   ]
 
-  return (
-    <dl className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-      {highlights.map((item) => (
-        <div
-          key={item.label}
-          className="rounded-2xl p-6 text-center"
-          style={{ border: '1px solid var(--rvt-border)', background: 'var(--rvt-bg2)' }}
-        >
-          <dt className="text-sm font-medium" style={{ color: 'var(--rvt-fg2)' }}>
-            {item.label}
-          </dt>
-          <dd
-            className="mt-2 text-4xl font-extrabold tracking-tight"
-            style={{ color: 'var(--rvt-accent)' }}
-          >
-            {item.value}
-          </dd>
-        </div>
-      ))}
-    </dl>
-  )
+  return <StatCardGrid items={highlights} columns={3} />
 }

--- a/src/components/ui/stats/YearlyActivityTable.tsx
+++ b/src/components/ui/stats/YearlyActivityTable.tsx
@@ -1,0 +1,109 @@
+import { peakCount, type YearCount } from '@/libs/stats/yearly'
+
+type Props = {
+  /** 新しい年が先頭の年次推移 */
+  series: YearCount[]
+  lang: string
+  /** 出典などの補足 */
+  note?: string
+}
+
+/**
+ * 年別の執筆本数と累計を並べた表。
+ * 件数のバーは最大値を基準にした相対幅で、数値の読み取りを補助するだけの装飾。
+ */
+export default function YearlyActivityTable({ series, lang, note }: Props) {
+  if (series.length === 0) return null
+
+  const isJa = lang === 'ja'
+  const locale = isJa ? 'ja-JP' : 'en-US'
+  const peak = peakCount(series)
+
+  const headers = {
+    year: isJa ? '年' : 'Year',
+    count: isJa ? '記事数' : 'Posts',
+    cumulative: isJa ? '累計' : 'Cumulative',
+  }
+
+  return (
+    <div>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[28rem] border-collapse text-sm">
+          <caption className="sr-only">
+            {isJa ? '年別の執筆本数と累計' : 'Posts and cumulative total by year'}
+          </caption>
+          <thead>
+            <tr style={{ borderBottom: '1px solid var(--rvt-border)' }}>
+              <th
+                scope="col"
+                className="py-3 pr-4 text-left text-xs font-semibold uppercase tracking-wider"
+                style={{ fontFamily: 'var(--rvt-font-mono)', color: 'var(--rvt-fg2)' }}
+              >
+                {headers.year}
+              </th>
+              <th
+                scope="col"
+                className="py-3 pr-4 text-right text-xs font-semibold uppercase tracking-wider"
+                style={{ fontFamily: 'var(--rvt-font-mono)', color: 'var(--rvt-fg2)' }}
+              >
+                {headers.count}
+              </th>
+              <th scope="col" className="w-1/2 py-3 pr-4">
+                <span className="sr-only">{isJa ? '件数の比較' : 'Relative volume'}</span>
+              </th>
+              <th
+                scope="col"
+                className="py-3 text-right text-xs font-semibold uppercase tracking-wider"
+                style={{ fontFamily: 'var(--rvt-font-mono)', color: 'var(--rvt-fg2)' }}
+              >
+                {headers.cumulative}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {series.map((row) => (
+              <tr key={row.year} style={{ borderBottom: '1px solid var(--rvt-border)' }}>
+                <th
+                  scope="row"
+                  className="py-3 pr-4 text-left font-medium"
+                  style={{ color: 'var(--rvt-fg)' }}
+                >
+                  {row.year}
+                </th>
+                <td
+                  className="py-3 pr-4 text-right tabular-nums"
+                  style={{ color: 'var(--rvt-fg)' }}
+                >
+                  {row.count.toLocaleString(locale)}
+                </td>
+                <td className="py-3 pr-4">
+                  <div
+                    className="h-2 w-full overflow-hidden rounded-full"
+                    style={{ background: 'var(--rvt-bg3)' }}
+                    aria-hidden="true"
+                  >
+                    <div
+                      className="h-full rounded-full"
+                      style={{
+                        width: peak > 0 ? `${(row.count / peak) * 100}%` : '0%',
+                        background: 'var(--rvt-accent)',
+                      }}
+                    />
+                  </div>
+                </td>
+                <td className="py-3 text-right tabular-nums" style={{ color: 'var(--rvt-fg2)' }}>
+                  {row.cumulative.toLocaleString(locale)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {note && (
+        <p className="mt-4 text-xs leading-relaxed" style={{ color: 'var(--rvt-fg3)' }}>
+          {note}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/libs/stats/loadProfileStats.ts
+++ b/src/libs/stats/loadProfileStats.ts
@@ -1,0 +1,145 @@
+import { listMyNPMPackages } from '@/libs/dataSources/npmjs'
+import { wpClient } from '@/libs/dataSources/wpClient'
+import { listMyWordPressPlugins } from '@/libs/dataSources/wporg'
+import { logger } from '@/libs/logger'
+import { activeYearSpan, buildYearlySeries, firstYear, type YearCount } from './yearly'
+
+// プロフィール実績は日単位でしか動かないため、1日ごとの再検証で十分。
+const REVALIDATE_SECONDS = 86400
+
+// 年次推移の対象は wp-kyoto.net の記事のみ。Qiita/Zenn/dev.to は
+// 全期間の取得手段が無い（RSS が直近数十件に限られる）ため、
+// 「累計」を名乗る数字に混ぜない。
+export const WRITING_SOURCE_LABEL = 'wp-kyoto.net'
+
+type DatedEntity = {
+  date: string
+}
+
+export type WritingStats = {
+  /** 累計記事数（日本語 + 英語） */
+  total: number
+  /** 最初の記事の年 */
+  firstYear: number | null
+  /** 発信歴（年数、開始年と現在年を両端とも含む） */
+  yearsActive: number
+  /** 新しい年が先頭の年次推移 */
+  series: YearCount[]
+}
+
+export type OssStats = {
+  /** npm に公開しているパッケージ数 */
+  npmPackages: number
+  /** WordPress.org に公開しているプラグイン数 */
+  wpPlugins: number
+  /** WordPress.org プラグインの稼働サイト数合計 */
+  activeInstalls: number
+  /** WordPress.org プラグインの累計ダウンロード数合計 */
+  downloads: number
+}
+
+export type ProfileStats = {
+  writing: WritingStats | null
+  /** 登壇レポートの記事数 */
+  speakingReports: number | null
+  oss: OssStats | null
+}
+
+/**
+ * 指定した投稿タイプの全記事の公開日を取得する。
+ * `_fields=date` で日付だけに絞ることで、1,000件超でも転送量を抑える。
+ */
+const fetchPublishedDates = async (
+  restBase: string,
+  lang?: 'ja' | 'en',
+): Promise<string[] | null> => {
+  try {
+    const items = await wpClient.postType<DatedEntity>(restBase).listAll(
+      {
+        per_page: 100,
+        _fields: ['date'],
+        orderby: 'date',
+        order: 'desc',
+        ...(lang ? { 'filter[lang]': lang } : {}),
+      },
+      {
+        next: { revalidate: REVALIDATE_SECONDS },
+      },
+    )
+    return items.map((item) => item.date).filter((date): date is string => Boolean(date))
+  } catch (error) {
+    logger.error('Failed to load published dates for profile stats', { error, restBase, lang })
+    return null
+  }
+}
+
+const loadWritingStats = async (now: Date): Promise<WritingStats | null> => {
+  const [ja, en] = await Promise.all([
+    fetchPublishedDates('posts', 'ja'),
+    fetchPublishedDates('posts', 'en'),
+  ])
+
+  // 片方でも取得できていれば表示する。両方失敗したときだけ非表示にする。
+  if (ja === null && en === null) return null
+
+  const dates = [...(ja ?? []), ...(en ?? [])]
+  if (dates.length === 0) return null
+
+  return {
+    total: dates.length,
+    firstYear: firstYear(dates),
+    yearsActive: activeYearSpan(dates, now),
+    series: buildYearlySeries(dates, now),
+  }
+}
+
+const loadSpeakingReportCount = async (): Promise<number | null> => {
+  try {
+    const { total } = await wpClient.postType<DatedEntity>('events').list(
+      { per_page: 1, _fields: ['date'] },
+      {
+        next: { revalidate: REVALIDATE_SECONDS },
+      },
+    )
+    return total
+  } catch (error) {
+    logger.error('Failed to load speaking report count', { error })
+    return null
+  }
+}
+
+const loadOssStats = async (): Promise<OssStats | null> => {
+  const [npmPackages, wpPlugins] = await Promise.all([
+    listMyNPMPackages(),
+    listMyWordPressPlugins(),
+  ])
+
+  const activeInstalls = wpPlugins.reduce((sum, plugin) => sum + (plugin.active_installs ?? 0), 0)
+  const downloads = wpPlugins.reduce((sum, plugin) => sum + (plugin.downloaded ?? 0), 0)
+
+  // 両方とも空（＝取得失敗またはデータ無し）なら、0 を並べるより非表示にする
+  if (npmPackages.length === 0 && wpPlugins.length === 0) return null
+
+  return {
+    npmPackages: npmPackages.length,
+    wpPlugins: wpPlugins.length,
+    activeInstalls,
+    downloads,
+  }
+}
+
+/**
+ * /about で表示するプロフィール実績を集約して返す。
+ *
+ * 各指標は独立して失敗しうる（外部APIが落ちてもページは壊さない）ため、
+ * 取得できなかったものは null にして呼び出し側で非表示にする。
+ */
+export async function loadProfileStats(now: Date = new Date()): Promise<ProfileStats> {
+  const [writing, speakingReports, oss] = await Promise.all([
+    loadWritingStats(now),
+    loadSpeakingReportCount(),
+    loadOssStats(),
+  ])
+
+  return { writing, speakingReports, oss }
+}

--- a/src/libs/stats/loadProfileStats.ts
+++ b/src/libs/stats/loadProfileStats.ts
@@ -16,8 +16,33 @@ type DatedEntity = {
   date: string
 }
 
+/**
+ * 執筆記事としてカウントする投稿タイプ。
+ *
+ * wp-kyoto.net に登録されている投稿タイプの分類（`/wp-json/wp/v2/types`）:
+ * - 執筆記事  … posts（投稿）/ thoughs（雑記）/ stripe（Stripe）/ dev-notes（DevNotes）← ここで集計
+ * - 登壇      … events ← `loadSpeakingReportCount` で別軸として集計
+ * - 記事以外  … products（リリース告知）/ stripe-products（製品データ）/ llms-texts（機械向け）
+ * - 対象外    … pages / attachment / wp_block / wp_template(_part) / wp_navigation /
+ *                nav_menu_item / wp_font_family / wp_font_face
+ * - 取得不可  … developer-deep-dives（REST が 401 を返す非公開タイプ）
+ *
+ * `langs` は Polylang の言語別取得が必要かどうか。posts のみ言語ごとに
+ * 記事が分かれており、他は `filter[lang]` を付けても全件が返るため、
+ * 言語別に取得すると二重計上になる。
+ */
+const WRITING_COLLECTIONS: ReadonlyArray<{
+  restBase: string
+  langs: ReadonlyArray<'ja' | 'en' | null>
+}> = [
+  { restBase: 'posts', langs: ['ja', 'en'] },
+  { restBase: 'thoughs', langs: [null] },
+  { restBase: 'stripe', langs: [null] },
+  { restBase: 'dev-notes', langs: [null] },
+]
+
 export type WritingStats = {
-  /** 累計記事数（日本語 + 英語） */
+  /** 累計記事数（WRITING_COLLECTIONS の全投稿タイプ、日本語 + 英語） */
   total: number
   /** 最初の記事の年 */
   firstYear: number | null
@@ -51,7 +76,7 @@ export type ProfileStats = {
  */
 const fetchPublishedDates = async (
   restBase: string,
-  lang?: 'ja' | 'en',
+  lang: 'ja' | 'en' | null,
 ): Promise<string[] | null> => {
   try {
     const items = await wpClient.postType<DatedEntity>(restBase).listAll(
@@ -74,15 +99,15 @@ const fetchPublishedDates = async (
 }
 
 const loadWritingStats = async (now: Date): Promise<WritingStats | null> => {
-  const [ja, en] = await Promise.all([
-    fetchPublishedDates('posts', 'ja'),
-    fetchPublishedDates('posts', 'en'),
-  ])
+  const results = await Promise.all(
+    WRITING_COLLECTIONS.flatMap((collection) =>
+      collection.langs.map((lang) => fetchPublishedDates(collection.restBase, lang)),
+    ),
+  )
 
-  // 片方でも取得できていれば表示する。両方失敗したときだけ非表示にする。
-  if (ja === null && en === null) return null
-
-  const dates = [...(ja ?? []), ...(en ?? [])]
+  // 一部の投稿タイプが取れなくても、取れた分で表示する。
+  // 全滅したときだけ非表示にする。
+  const dates = results.filter((result): result is string[] => result !== null).flat()
   if (dates.length === 0) return null
 
   return {

--- a/src/libs/stats/yearly.test.ts
+++ b/src/libs/stats/yearly.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { activeYearSpan, buildYearlySeries, firstYear, peakCount } from './yearly'
+
+const NOW = new Date('2026-08-10T00:00:00Z')
+
+describe('firstYear', () => {
+  it('最も古い年を返す', () => {
+    expect(firstYear(['2020-05-01T00:00:00Z', '2013-09-18T00:05:14', '2018-01-01'])).toBe(2013)
+  })
+
+  it('有効な日付が無ければ null を返す', () => {
+    expect(firstYear([])).toBeNull()
+    expect(firstYear(['not-a-date', ''])).toBeNull()
+  })
+
+  it('不正な日付を無視する', () => {
+    expect(firstYear(['broken', '2019-03-01T00:00:00Z'])).toBe(2019)
+  })
+})
+
+describe('activeYearSpan', () => {
+  it('開始年と現在年の両端を含めて数える', () => {
+    expect(activeYearSpan(['2013-09-18T00:05:14'], NOW)).toBe(14)
+  })
+
+  it('同じ年に開始していれば 1 年', () => {
+    expect(activeYearSpan(['2026-01-05T00:00:00Z'], NOW)).toBe(1)
+  })
+
+  it('有効な日付が無ければ 0 を返す', () => {
+    expect(activeYearSpan([], NOW)).toBe(0)
+  })
+
+  it('未来の日付しか無くても 1 を下回らない', () => {
+    expect(activeYearSpan(['2030-01-01T00:00:00Z'], NOW)).toBe(1)
+  })
+})
+
+describe('buildYearlySeries', () => {
+  it('新しい年から順に、件数と累計を返す', () => {
+    const series = buildYearlySeries(
+      [
+        '2024-01-01T00:00:00Z',
+        '2024-06-01T00:00:00Z',
+        '2026-02-01T00:00:00Z',
+        '2025-07-01T00:00:00Z',
+      ],
+      NOW,
+    )
+
+    expect(series.map((row) => row.year)).toEqual([2026, 2025, 2024])
+    expect(series.map((row) => row.count)).toEqual([1, 1, 2])
+    // 累計は古い年から積み上げるので、新しい年ほど大きい
+    expect(series.map((row) => row.cumulative)).toEqual([4, 3, 2])
+  })
+
+  it('投稿の無い年も 0 で補完する', () => {
+    const series = buildYearlySeries(['2023-01-01T00:00:00Z', '2026-01-01T00:00:00Z'], NOW)
+
+    expect(series.map((row) => row.year)).toEqual([2026, 2025, 2024, 2023])
+    expect(series.map((row) => row.count)).toEqual([1, 0, 0, 1])
+    expect(series.map((row) => row.cumulative)).toEqual([2, 1, 1, 1])
+  })
+
+  it('最新の投稿が過去年でも現在年まで並べる', () => {
+    const series = buildYearlySeries(['2024-01-01T00:00:00Z'], NOW)
+    expect(series[0]?.year).toBe(2026)
+    expect(series[0]?.count).toBe(0)
+    expect(series[0]?.cumulative).toBe(1)
+  })
+
+  it('未来日付の投稿も系列に含める', () => {
+    const series = buildYearlySeries(['2026-01-01T00:00:00Z', '2027-05-01T00:00:00Z'], NOW)
+    expect(series[0]?.year).toBe(2027)
+    expect(series[0]?.count).toBe(1)
+  })
+
+  it('有効な日付が無ければ空配列を返す', () => {
+    expect(buildYearlySeries([], NOW)).toEqual([])
+    expect(buildYearlySeries(['broken'], NOW)).toEqual([])
+  })
+
+  it('タイムゾーンに依存せず UTC の年で集計する', () => {
+    // JST では 2025-01-01、UTC では 2024-12-31
+    const series = buildYearlySeries(['2024-12-31T23:00:00Z'], new Date('2024-12-31T23:30:00Z'))
+    expect(series).toEqual([{ year: 2024, count: 1, cumulative: 1 }])
+  })
+})
+
+describe('peakCount', () => {
+  it('系列中の最大件数を返す', () => {
+    expect(peakCount(buildYearlySeries(['2025-01-01', '2025-02-01', '2026-01-01'], NOW))).toBe(2)
+  })
+
+  it('空の系列では 0 を返す', () => {
+    expect(peakCount([])).toBe(0)
+  })
+})

--- a/src/libs/stats/yearly.ts
+++ b/src/libs/stats/yearly.ts
@@ -1,0 +1,70 @@
+// 年次アクティビティの集計ユーティリティ。
+// `aggregate.ts` が「直近Nヶ月の勢い」を扱うのに対し、こちらは「全期間の積み上げ」を扱う。
+// すべて純粋関数で、UTC 基準で計算するため実行環境のタイムゾーンに依存しない。
+
+export type YearCount = {
+  year: number
+  /** その年の件数 */
+  count: number
+  /** その年までの累計件数（古い年から積み上げた値） */
+  cumulative: number
+}
+
+const parseYear = (date: string): number | null => {
+  const d = new Date(date)
+  if (Number.isNaN(d.getTime())) return null
+  return d.getUTCFullYear()
+}
+
+/** 有効な日付だけを年に変換して返す。 */
+const toYears = (dates: readonly string[]): number[] =>
+  dates.map(parseYear).filter((year): year is number => year !== null)
+
+/** 最も古い年。有効な日付が無ければ null。 */
+export function firstYear(dates: readonly string[]): number | null {
+  const years = toYears(dates)
+  return years.length === 0 ? null : Math.min(...years)
+}
+
+/**
+ * 発信歴の年数（最初の年と現在年を両端とも含む）。
+ * 2013年に開始して現在が2026年なら 14 を返す。有効な日付が無ければ 0。
+ */
+export function activeYearSpan(dates: readonly string[], now: Date = new Date()): number {
+  const first = firstYear(dates)
+  if (first === null) return 0
+  return Math.max(1, now.getUTCFullYear() - first + 1)
+}
+
+/**
+ * 年別の件数と累計を、最初の投稿年から現在年まで（投稿の無い年も0で補完して）返す。
+ * 表示順は新しい年が先頭。
+ */
+export function buildYearlySeries(dates: readonly string[], now: Date = new Date()): YearCount[] {
+  const years = toYears(dates)
+  if (years.length === 0) return []
+
+  const counts = new Map<number, number>()
+  for (const year of years) {
+    counts.set(year, (counts.get(year) ?? 0) + 1)
+  }
+
+  const start = Math.min(...years)
+  // 未来日付の投稿があっても取りこぼさないよう、現在年と最大年の大きい方まで並べる
+  const end = Math.max(now.getUTCFullYear(), ...years)
+
+  const ascending: YearCount[] = []
+  let cumulative = 0
+  for (let year = start; year <= end; year++) {
+    const count = counts.get(year) ?? 0
+    cumulative += count
+    ascending.push({ year, count, cumulative })
+  }
+
+  return ascending.reverse()
+}
+
+/** 系列中の最大件数。棒グラフの正規化に使う（0件しか無い場合は 0）。 */
+export function peakCount(series: readonly YearCount[]): number {
+  return series.reduce((max, row) => (row.count > max ? row.count : max), 0)
+}


### PR DESCRIPTION
執筆・OSS・登壇の積み上げを数字で示すセクションを /about（日英）の
プロフィール直後に追加。数字はすべて既存APIから自動取得する。

- 累計記事数・発信歴: wp-kyoto.net の全記事の公開日から集計
- 公開パッケージ数 / 稼働サイト数 / 累計DL: npm registry・WordPress.org
- 登壇レポート数: events カスタム投稿タイプの総件数
- 年別の執筆本数と累計を表で表示（件数バー付き、投稿の無い年も0で補完）

指標ごとに独立して失敗を許容し、取得できなかったものはカードごと省く。
0 を並べて実績を過小に見せないため。年次推移は全期間の取得手段がある
wp-kyoto.net のみを対象とし、出典を注記に明示している。

再検証は1日ごと（ISR）。純粋な集計ロジックは src/libs/stats/yearly.ts に
分離し、ユニットテストを追加。StatHighlights は新設の StatCardGrid を
使う形にリファクタ（公開APIは変更なし）。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RvLPp3PR1G86epGqBovhqQ