### PR TITLE
fix: session-start hookをpnpmに揃える

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,10 +9,11 @@ echo "🚀 Starting Claude Code session..."
 # Check if running in Claude Code remote environment
 if [ -n "$CLAUDE_CODE_REMOTE" ]; then
   echo "📦 Installing dependencies..."
-  npm install
+  corepack enable
+  pnpm install --frozen-lockfile
 
   echo "🔨 Building project..."
-  npm run build
+  pnpm run build
 
   echo "✅ Session setup complete!"
 else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -101,8 +99,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -137,8 +133,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -166,8 +160,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "node": ">=22.12.0"
   },
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- `.claude/hooks/session-start.sh` が `pnpm-lock.yaml` を使うプロジェクトなのに `npm install` / `npm run build` を実行しており、CIやローカルのpnpmとは別系統で依存関係を解決していた（例: `vitest ^4.1.7` 指定に対し実際は4.1.10が入るなど）
- npmとpnpmが混在した状態は `package-lock.json` の生成や、ビルド成果物のバージョンずれにもつながっていたため、`pnpm install --frozen-lockfile` と `pnpm run build` に統一
- `package.json` に `packageManager: "pnpm@10.33.0"` を追加し、corepack経由でpnpmのバージョンも固定

## Test plan
- [x] `bash .claude/hooks/session-start.sh`（`CLAUDE_CODE_REMOTE=1`）を実行し、`corepack enable && pnpm install --frozen-lockfile && pnpm run build` が最後まで成功することを確認
- [x] `pnpm lint:check` — pass
- [x] `pnpm test` — 713 tests pass
- [x] `pnpm build` — pass（上記hook実行に含む）
- [x] インストール後の `vitest`/`next` のバージョンが `pnpm-lock.yaml` の指定と一致することを確認（vitest 4.1.8 / next 16.2.9）
- [x] `package-lock.json` が生成されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01E9maejaPZSngsiMAQUgXV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9maejaPZSngsiMAQUgXV2)_